### PR TITLE
Fix screenshot saving to wrong directory

### DIFF
--- a/screenshot.cpp
+++ b/screenshot.cpp
@@ -33,6 +33,8 @@ bool8 S9xDoScreenshot (int width, int height)
 	current_time = localtime(&current_timet);
 
 	auto screenshot_dir = S9xGetDirectory(SCREENSHOT_DIR);
+	if (screenshot_dir.empty() || screenshot_dir.back() != SLASH_CHAR)
+		screenshot_dir += SLASH_STR;
 	std::stringstream ss;
 	ss << screenshot_dir
 	   << S9xBasenameNoExt(Memory.ROMFilename) << "-"


### PR DESCRIPTION
S9xGetDirectory() returns a path without a trailing separator, but the screenshot code concatenated the ROM name directly to it. This caused the last directory component to merge with the filename (e.g. "ScreenshotsSuper Mario World" instead of "Screenshots\Super Mario World").

Add a trailing slash check before building the screenshot filename.