### PR TITLE
Refactor RetroAchievements for cross-platform support (Win32 + Qt/Linux)

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -93,8 +93,8 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         set(CMAKE_PREFIX_PATH ${qt6-mingw-clang-bin_SOURCE_DIR})
     endif()
 endif()
-find_package(Qt6 REQUIRED COMPONENTS Widgets Gui)
-list(APPEND LIBS Qt6::Widgets Qt6::Gui)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Gui Network)
+list(APPEND LIBS Qt6::Widgets Qt6::Gui Qt6::Network)
 list(APPEND INCLUDES ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
 
 find_package(PkgConfig REQUIRED)
@@ -228,6 +228,44 @@ list(APPEND QT_GUI_SOURCES
     ../filter/snes_ntsc.h
     ../filter/snes_ntsc_impl.h
     ../filter/snes_ntsc.c)
+
+# RetroAchievements support
+list(APPEND DEFINES RETROACHIEVEMENTS_SUPPORT RC_DISABLE_LUA RC_CLIENT_SUPPORTS_HASH)
+list(APPEND INCLUDES ../external/rcheevos/include)
+list(APPEND QT_GUI_SOURCES
+    src/RAIntegrationQt.cpp
+    ../retroachievements.cpp
+    ../external/rcheevos/src/rc_client.c
+    ../external/rcheevos/src/rc_compat.c
+    ../external/rcheevos/src/rc_util.c
+    ../external/rcheevos/src/rc_version.c
+    ../external/rcheevos/src/rcheevos/alloc.c
+    ../external/rcheevos/src/rcheevos/condition.c
+    ../external/rcheevos/src/rcheevos/condset.c
+    ../external/rcheevos/src/rcheevos/consoleinfo.c
+    ../external/rcheevos/src/rcheevos/format.c
+    ../external/rcheevos/src/rcheevos/lboard.c
+    ../external/rcheevos/src/rcheevos/memref.c
+    ../external/rcheevos/src/rcheevos/operand.c
+    ../external/rcheevos/src/rcheevos/rc_validate.c
+    ../external/rcheevos/src/rcheevos/richpresence.c
+    ../external/rcheevos/src/rcheevos/runtime.c
+    ../external/rcheevos/src/rcheevos/runtime_progress.c
+    ../external/rcheevos/src/rcheevos/trigger.c
+    ../external/rcheevos/src/rcheevos/value.c
+    ../external/rcheevos/src/rapi/rc_api_common.c
+    ../external/rcheevos/src/rapi/rc_api_editor.c
+    ../external/rcheevos/src/rapi/rc_api_info.c
+    ../external/rcheevos/src/rapi/rc_api_runtime.c
+    ../external/rcheevos/src/rapi/rc_api_user.c
+    ../external/rcheevos/src/rhash/hash.c
+    ../external/rcheevos/src/rhash/hash_disc.c
+    ../external/rcheevos/src/rhash/hash_encrypted.c
+    ../external/rcheevos/src/rhash/hash_rom.c
+    ../external/rcheevos/src/rhash/hash_zip.c
+    ../external/rcheevos/src/rhash/aes.c
+    ../external/rcheevos/src/rhash/cdreader.c
+    ../external/rcheevos/src/rhash/md5.c)
 
 set(QT_UI_FILES
     src/GeneralPanel.ui

--- a/qt/src/EmuApplication.cpp
+++ b/qt/src/EmuApplication.cpp
@@ -14,6 +14,11 @@
 #include <QStyleHints>
 #include <thread>
 
+#ifdef RETROACHIEVEMENTS_SUPPORT
+#include "RAIntegrationQt.hpp"
+#include "retroachievements.h"
+#endif
+
 #undef SOUND_BUFFER_WINDOW
 
 EmuApplication::EmuApplication()
@@ -23,6 +28,9 @@ EmuApplication::EmuApplication()
 
 EmuApplication::~EmuApplication()
 {
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    RA_Shutdown();
+#endif
     core->deinit();
 }
 
@@ -245,9 +253,15 @@ bool EmuApplication::openFile(const std::string &filename)
     window->gameChanging();
     updateSettings();
     suspendThread();
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    RA_OnCloseROM();
+#endif
     auto result = core->openFile(filename);
     unsuspendThread();
-
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    if (result)
+        RA_OnLoadROM();
+#endif
     return result;
 }
 
@@ -260,6 +274,9 @@ void EmuApplication::mainLoop()
     }
 
     core->mainLoop();
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    RA_DoFrame();
+#endif
 }
 
 void EmuApplication::reportBinding(EmuBinding b, bool active)
@@ -395,6 +412,11 @@ void EmuApplication::handleBinding(const std::string &name, bool pressed)
     {
         if (name == "Rewind")
         {
+#ifdef RETROACHIEVEMENTS_SUPPORT
+            if (RA_IsHardcoreModeActive())
+                core->rewinding = false;
+            else
+#endif
             core->rewinding = pressed;
         }
         else if (pressed) // Only activate with core active and on button down
@@ -576,6 +598,10 @@ void EmuApplication::startInputTimer()
 void EmuApplication::loadState(int slot)
 {
     emu_thread->runOnThread([&, slot] {
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        if (!RA_WarnDisableHardcore("Loading save states"))
+            return;
+#endif
         core->loadState(slot);
     });
 }
@@ -583,7 +609,14 @@ void EmuApplication::loadState(int slot)
 void EmuApplication::loadState(const std::string& filename)
 {
     emu_thread->runOnThread([&, filename] {
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        if (!RA_WarnDisableHardcore("Loading save states"))
+            return;
+#endif
         core->loadState(filename);
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnLoadState(filename.c_str());
+#endif
     });
 }
 
@@ -598,6 +631,9 @@ void EmuApplication::saveState(const std::string& filename)
 {
     emu_thread->runOnThread([&, filename] {
         core->saveState(filename);
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnSaveState(filename.c_str());
+#endif
     });
 }
 
@@ -605,6 +641,9 @@ void EmuApplication::reset()
 {
     emu_thread->runOnThread([&] {
         core->softReset();
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnReset();
+#endif
     });
 }
 
@@ -612,6 +651,9 @@ void EmuApplication::powerCycle()
 {
     emu_thread->runOnThread([&] {
         core->reset();
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnReset();
+#endif
     });
 }
 

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -546,6 +546,13 @@ void EmuConfig::config(const std::string &filename, bool write)
 
     Int("SRAMSaveInterval", sram_save_interval);
     EndSection();
+
+    BeginSection("RetroAchievements");
+    Bool("Enabled", ra_enabled);
+    Bool("HardcoreMode", ra_hardcore_mode);
+    String("Username", ra_username);
+    String("ApiToken", ra_api_token);
+    EndSection();
 }
 
 void EmuConfig::setVRRConfig(bool enable)

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -155,6 +155,12 @@ struct EmuConfig
 
     int sram_save_interval;
 
+    // RetroAchievements
+    bool ra_enabled = false;
+    bool ra_hardcore_mode = false;
+    std::string ra_username;
+    std::string ra_api_token;
+
     enum PortConfiguration
     {
         eOneController = 0,

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -11,6 +11,10 @@
 
 #include "CheatsDialog.hpp"
 #include "EmuApplication.hpp"
+#ifdef RETROACHIEVEMENTS_SUPPORT
+#include "RAIntegrationQt.hpp"
+#include "retroachievements.h"
+#endif
 #include "EmuBinding.hpp"
 #include "EmuCanvasOpenGL.hpp"
 #include "EmuCanvasQt.hpp"
@@ -352,6 +356,62 @@ void EmuMainWindow::createWidgets()
     options_menu->addAction(shader_settings_item);
 
     menuBar()->addMenu(options_menu);
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    auto ra_menu = new QMenu(tr("&RetroAchievements"));
+
+    ra_enabled_action = ra_menu->addAction(tr("&Enabled"));
+    ra_enabled_action->setCheckable(true);
+    ra_enabled_action->setChecked(app->config->ra_enabled);
+    connect(ra_enabled_action, &QAction::triggered, [&](bool checked) {
+        app->config->ra_enabled = checked;
+        RA_SetEnabled(checked);
+        if (checked)
+        {
+            RA_Qt_RegisterCallbacks(app);
+            RA_Init();
+            RA_AttemptLogin(app->config->ra_username.c_str(), app->config->ra_api_token.c_str());
+            if (app->isCoreActive())
+                RA_OnLoadROM();
+        }
+        else
+        {
+            RA_Shutdown();
+        }
+    });
+
+    ra_login_action = ra_menu->addAction(tr("&Login..."));
+    connect(ra_login_action, &QAction::triggered, [&] {
+        RA_Qt_RegisterCallbacks(app);
+        RA_Init();
+        if (RA_IsLoggedIn())
+        {
+            RA_Logout();
+            ra_login_action->setText(tr("&Login..."));
+        }
+        else
+        {
+            RA_ShowLoginDialog();
+        }
+    });
+
+    ra_hardcore_action = ra_menu->addAction(tr("&Hardcore Mode"));
+    ra_hardcore_action->setCheckable(true);
+    ra_hardcore_action->setChecked(app->config->ra_hardcore_mode);
+    connect(ra_hardcore_action, &QAction::triggered, [&](bool checked) {
+        app->config->ra_hardcore_mode = checked;
+        RA_SetHardcoreEnabled(checked);
+    });
+
+    ra_menu->addSeparator();
+
+    ra_achievements_action = ra_menu->addAction(tr("&Achievement List..."));
+    connect(ra_achievements_action, &QAction::triggered, [&] {
+        RA_ShowAchievementList();
+    });
+
+    menuBar()->addMenu(ra_menu);
+#endif
 
     setCoreActionsEnabled(false);
 

--- a/qt/src/EmuMainWindow.hpp
+++ b/qt/src/EmuMainWindow.hpp
@@ -63,6 +63,13 @@ class EmuMainWindow : public QMainWindow
     QAction *shader_settings_item;
     std::vector<QAction *> core_actions;
     std::vector<QAction *> recent_menu_items;
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    QAction *ra_enabled_action = nullptr;
+    QAction *ra_login_action = nullptr;
+    QAction *ra_hardcore_action = nullptr;
+    QAction *ra_achievements_action = nullptr;
+#endif
 };
 
 #endif

--- a/qt/src/RAIntegrationQt.cpp
+++ b/qt/src/RAIntegrationQt.cpp
@@ -1,0 +1,304 @@
+#ifdef RETROACHIEVEMENTS_SUPPORT
+
+#include "RAIntegrationQt.hpp"
+#include "EmuApplication.hpp"
+#include "EmuMainWindow.hpp"
+#include "EmuConfig.hpp"
+#include "retroachievements.h"
+
+#include "rc_client.h"
+#include "rc_api_request.h"
+
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QUrl>
+#include <QMessageBox>
+#include <QDialog>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QLabel>
+#include <QTreeWidget>
+#include <QHeaderView>
+#include <QApplication>
+#include <QThread>
+#include <thread>
+#include <cstdio>
+
+// ---------------------------------------------------------------------------
+// Statics
+// ---------------------------------------------------------------------------
+static EmuApplication *g_app = nullptr;
+static QNetworkAccessManager *g_nam = nullptr;
+
+// ---------------------------------------------------------------------------
+// Qt HTTP Implementation
+// ---------------------------------------------------------------------------
+struct QtHttpContext
+{
+    rc_client_server_callback_t callback;
+    void *callback_data;
+};
+
+static void ra_qt_server_call(const rc_api_request_t *request,
+                               rc_client_server_callback_t callback,
+                               void *callback_data, rc_client_t *client)
+{
+    std::string url_str = request->url ? request->url : "";
+    std::string post_data = request->post_data ? request->post_data : "";
+    std::string content_type = request->content_type ? request->content_type : "";
+
+    auto *ctx = new QtHttpContext{callback, callback_data};
+
+    // Marshal to main thread where QNetworkAccessManager lives
+    QMetaObject::invokeMethod(g_nam, [=]() {
+        QNetworkRequest qreq(QUrl(QString::fromStdString(url_str)));
+
+        QNetworkReply *reply = nullptr;
+        if (post_data.empty())
+        {
+            reply = g_nam->get(qreq);
+        }
+        else
+        {
+            QString ct = content_type.empty()
+                             ? "application/x-www-form-urlencoded"
+                             : QString::fromStdString(content_type);
+            qreq.setHeader(QNetworkRequest::ContentTypeHeader, ct);
+            reply = g_nam->post(qreq, QByteArray::fromStdString(post_data));
+        }
+
+        QObject::connect(reply, &QNetworkReply::finished, [reply, ctx]() {
+            rc_api_server_response_t response = {};
+            QByteArray body = reply->readAll();
+            response.body = body.constData();
+            response.body_length = body.size();
+            response.http_status_code = reply->attribute(
+                QNetworkRequest::HttpStatusCodeAttribute).toInt();
+
+            if (reply->error() != QNetworkReply::NoError && response.http_status_code == 0)
+                response.http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR;
+
+            ctx->callback(&response, ctx->callback_data);
+
+            reply->deleteLater();
+            delete ctx;
+        });
+    }, Qt::QueuedConnection);
+}
+
+// ---------------------------------------------------------------------------
+// Qt Login Dialog
+// ---------------------------------------------------------------------------
+static void ra_qt_show_login()
+{
+    if (!g_app || !g_app->window)
+        return;
+
+    QDialog dlg(g_app->window.get());
+    dlg.setWindowTitle("RetroAchievements Login");
+    dlg.setMinimumWidth(300);
+
+    auto *layout = new QVBoxLayout(&dlg);
+    auto *form = new QFormLayout();
+
+    auto *username = new QLineEdit();
+    username->setText(QString::fromStdString(g_app->config->ra_username));
+    form->addRow("Username:", username);
+
+    auto *password = new QLineEdit();
+    password->setEchoMode(QLineEdit::Password);
+    form->addRow("Password:", password);
+
+    layout->addLayout(form);
+
+    auto *note = new QLabel("Your password is only used to get an API token.\nIt is never stored.");
+    note->setStyleSheet("color: gray;");
+    layout->addWidget(note);
+
+    auto *buttons = new QHBoxLayout();
+    auto *okBtn = new QPushButton("Login");
+    auto *cancelBtn = new QPushButton("Cancel");
+    buttons->addStretch();
+    buttons->addWidget(okBtn);
+    buttons->addWidget(cancelBtn);
+    layout->addLayout(buttons);
+
+    QObject::connect(okBtn, &QPushButton::clicked, &dlg, &QDialog::accept);
+    QObject::connect(cancelBtn, &QPushButton::clicked, &dlg, &QDialog::reject);
+
+    if (username->text().isEmpty())
+        username->setFocus();
+    else
+        password->setFocus();
+
+    if (dlg.exec() == QDialog::Accepted)
+    {
+        auto u = username->text().toStdString();
+        auto p = password->text().toStdString();
+        if (!u.empty() && !p.empty())
+            RA_LoginWithPassword(u.c_str(), p.c_str());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Qt Achievement List Dialog
+// ---------------------------------------------------------------------------
+static void ra_qt_show_achievements()
+{
+    if (!g_app || !g_app->window)
+        return;
+
+    rc_client_t *client = RA_GetClient();
+    if (!client)
+        return;
+
+    QDialog dlg(g_app->window.get());
+    dlg.setWindowTitle("RetroAchievements");
+    dlg.resize(550, 400);
+
+    auto *layout = new QVBoxLayout(&dlg);
+
+    const rc_client_game_t *game = rc_client_get_game_info(client);
+    auto *titleLabel = new QLabel(game ? game->title : "No game loaded");
+    auto font = titleLabel->font();
+    font.setBold(true);
+    titleLabel->setFont(font);
+    layout->addWidget(titleLabel);
+
+    auto *tree = new QTreeWidget();
+    tree->setHeaderLabels({"Title", "Points", "Status", "Description"});
+    tree->setRootIsDecorated(false);
+    tree->setAlternatingRowColors(true);
+    tree->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    tree->header()->setStretchLastSection(true);
+
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(client,
+        RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+
+    if (list)
+    {
+        for (uint32_t b = 0; b < list->num_buckets; b++)
+        {
+            const rc_client_achievement_bucket_t *bucket = &list->buckets[b];
+            for (uint32_t a = 0; a < bucket->num_achievements; a++)
+            {
+                const rc_client_achievement_t *ach = bucket->achievements[a];
+
+                const char *status;
+                if (ach->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE)
+                    status = "Unlocked (HC)";
+                else if (ach->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE)
+                    status = "Unlocked";
+                else if (ach->state == RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE)
+                    status = "Locked";
+                else
+                    status = "Inactive";
+
+                auto *item = new QTreeWidgetItem({
+                    ach->title,
+                    QString::number(ach->points),
+                    status,
+                    ach->description
+                });
+                tree->addTopLevelItem(item);
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+
+    layout->addWidget(tree);
+
+    auto *closeBtn = new QPushButton("Close");
+    auto *btnLayout = new QHBoxLayout();
+    btnLayout->addStretch();
+    btnLayout->addWidget(closeBtn);
+    btnLayout->addStretch();
+    layout->addLayout(btnLayout);
+
+    QObject::connect(closeBtn, &QPushButton::clicked, &dlg, &QDialog::accept);
+
+    dlg.exec();
+}
+
+// ---------------------------------------------------------------------------
+// Qt Confirm Disable Hardcore
+// ---------------------------------------------------------------------------
+static bool ra_qt_confirm_disable_hardcore(const char *activity)
+{
+    // May be called from emu thread — marshal to main thread
+    bool result = false;
+    if (QThread::currentThread() == QApplication::instance()->thread())
+    {
+        QWidget *parent = g_app ? g_app->window.get() : nullptr;
+        auto ret = QMessageBox::warning(parent, "RetroAchievements - Hardcore Mode",
+            QString("%1 is not allowed in Hardcore mode.\n\n"
+                    "Disable Hardcore mode to proceed?\n"
+                    "(Achievement progress for the current session will be lost)")
+                .arg(activity),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        result = (ret == QMessageBox::Yes);
+    }
+    else
+    {
+        QMetaObject::invokeMethod(QApplication::instance(), [&]() {
+            QWidget *parent = g_app ? g_app->window.get() : nullptr;
+            auto ret = QMessageBox::warning(parent, "RetroAchievements - Hardcore Mode",
+                QString("%1 is not allowed in Hardcore mode.\n\n"
+                        "Disable Hardcore mode to proceed?\n"
+                        "(Achievement progress for the current session will be lost)")
+                    .arg(activity),
+                QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+            result = (ret == QMessageBox::Yes);
+        }, Qt::BlockingQueuedConnection);
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Qt Logging
+// ---------------------------------------------------------------------------
+static void ra_qt_log(const char *message)
+{
+    fprintf(stderr, "%s\n", message);
+}
+
+// ---------------------------------------------------------------------------
+// Qt Credentials Changed
+// ---------------------------------------------------------------------------
+static void ra_qt_credentials_changed(const char *username, const char *token)
+{
+    if (!g_app)
+        return;
+
+    g_app->config->ra_username = username ? username : "";
+    g_app->config->ra_api_token = token ? token : "";
+    g_app->config->ra_enabled = (username && username[0] && token && token[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Public: Register Qt callbacks
+// ---------------------------------------------------------------------------
+void RA_Qt_RegisterCallbacks(EmuApplication *app)
+{
+    g_app = app;
+
+    // Create QNetworkAccessManager on the main thread
+    if (!g_nam)
+        g_nam = new QNetworkAccessManager();
+
+    RAPlatformCallbacks cb = {};
+    cb.server_call = ra_qt_server_call;
+    cb.show_login_dialog = ra_qt_show_login;
+    cb.show_achievement_list = ra_qt_show_achievements;
+    cb.confirm_disable_hardcore = ra_qt_confirm_disable_hardcore;
+    cb.log_message = ra_qt_log;
+    cb.on_credentials_changed = ra_qt_credentials_changed;
+    RA_RegisterPlatformCallbacks(cb);
+}
+
+#endif // RETROACHIEVEMENTS_SUPPORT

--- a/qt/src/RAIntegrationQt.hpp
+++ b/qt/src/RAIntegrationQt.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+
+class EmuApplication;
+
+void RA_Qt_RegisterCallbacks(EmuApplication *app);
+
+#endif

--- a/qt/src/main.cpp
+++ b/qt/src/main.cpp
@@ -3,6 +3,11 @@
 #include "EmuMainWindow.hpp"
 #include "SDLInputManager.hpp"
 
+#ifdef RETROACHIEVEMENTS_SUPPORT
+#include "RAIntegrationQt.hpp"
+#include "retroachievements.h"
+#endif
+
 #include <clocale>
 #include <qnamespace.h>
 #include <QStyle>
@@ -85,6 +90,22 @@ int main(int argc, char *argv[])
 
     emu.updateBindings();
     emu.startInputTimer();
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    if (!emu.config->ra_enabled &&
+        !emu.config->ra_api_token.empty() && !emu.config->ra_username.empty())
+        emu.config->ra_enabled = true;
+
+    if (emu.config->ra_enabled)
+    {
+        RA_Qt_RegisterCallbacks(&emu);
+        RA_Init();
+        RA_SetEnabled(true);
+        RA_SetHardcoreEnabled(emu.config->ra_hardcore_mode);
+        RA_AttemptLogin(emu.config->ra_username.c_str(), emu.config->ra_api_token.c_str());
+    }
+#endif
+
     emu.qtapp->exec();
 
     emu.stopThread();

--- a/retroachievements.cpp
+++ b/retroachievements.cpp
@@ -1,0 +1,562 @@
+#include "retroachievements.h"
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+
+#include <string>
+#include <vector>
+#include <deque>
+#include <mutex>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+
+#include "rc_client.h"
+#include "rc_consoles.h"
+#include "rc_hash.h"
+
+#include "imgui.h"
+
+#include "snes9x.h"
+#include "memmap.h"
+#include "cpuexec.h"
+
+// ---------------------------------------------------------------------------
+// Platform callbacks (set by platform before RA_Init)
+// ---------------------------------------------------------------------------
+static RAPlatformCallbacks g_callbacks = {};
+
+void RA_RegisterPlatformCallbacks(const RAPlatformCallbacks &callbacks)
+{
+    g_callbacks = callbacks;
+}
+
+// ---------------------------------------------------------------------------
+// Globals
+// ---------------------------------------------------------------------------
+static rc_client_t *g_rcClient = nullptr;
+static bool g_initialized = false;
+static bool g_raEnabled = false;
+
+// ---------------------------------------------------------------------------
+// Notification queue (thread-safe)
+// ---------------------------------------------------------------------------
+struct RANotification
+{
+    std::string title;
+    std::string subtitle;
+    float duration;
+    float elapsed;
+};
+
+static std::deque<RANotification> g_notifications;
+static std::mutex g_notifMutex;
+static std::chrono::steady_clock::time_point g_lastTime;
+
+static void RA_QueueNotification(const char *title, const char *subtitle, float duration)
+{
+    std::lock_guard<std::mutex> lock(g_notifMutex);
+    RANotification n;
+    n.title = title ? title : "";
+    n.subtitle = subtitle ? subtitle : "";
+    n.duration = duration;
+    n.elapsed = 0.0f;
+    g_notifications.push_back(std::move(n));
+}
+
+// ---------------------------------------------------------------------------
+// Callback: Memory Read
+// ---------------------------------------------------------------------------
+static uint32_t RC_CCONV ra_read_memory(uint32_t address, uint8_t *buffer, uint32_t num_bytes, rc_client_t *client)
+{
+    const uint8_t *src = nullptr;
+    uint32_t available = 0;
+
+    if (address < 0x20000)
+    {
+        src = Memory.RAM + address;
+        available = 0x20000 - address;
+    }
+    else if (address < 0x0A0000)
+    {
+        uint32_t offset = address - 0x020000;
+        src = Memory.SRAM + offset;
+        available = 0x80000 - offset;
+    }
+    else if (address < 0x0A0800)
+    {
+        uint32_t offset = address - 0x0A0000;
+        src = Memory.FillRAM + 0x3000 + offset;
+        available = 0x800 - offset;
+    }
+    else
+    {
+        return 0;
+    }
+
+    uint32_t to_copy = (num_bytes < available) ? num_bytes : available;
+    memcpy(buffer, src, to_copy);
+    return to_copy;
+}
+
+// ---------------------------------------------------------------------------
+// Callback: Logging
+// ---------------------------------------------------------------------------
+static void RC_CCONV ra_log_message(const char *message, const rc_client_t *client)
+{
+    if (g_callbacks.log_message)
+    {
+        char buf[2048];
+        snprintf(buf, sizeof(buf), "[RetroAchievements] %s", message);
+        g_callbacks.log_message(buf);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Callback: Event Handler
+// ---------------------------------------------------------------------------
+static void RC_CCONV ra_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    switch (event->type)
+    {
+    case RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED:
+        if (event->achievement)
+        {
+            char msg[256];
+            snprintf(msg, sizeof(msg), "%s (%u pts)",
+                     event->achievement->title, event->achievement->points);
+            RA_QueueNotification("Achievement Unlocked!", msg, 5.0f);
+        }
+        break;
+
+    case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW:
+        if (event->achievement)
+            RA_QueueNotification("Challenge Active", event->achievement->title, 3.0f);
+        break;
+
+    case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW:
+    case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE:
+        if (event->achievement && event->achievement->measured_progress[0])
+            RA_QueueNotification(event->achievement->title,
+                                 event->achievement->measured_progress, 2.0f);
+        break;
+
+    case RC_CLIENT_EVENT_LEADERBOARD_STARTED:
+        if (event->leaderboard)
+            RA_QueueNotification("Leaderboard Started", event->leaderboard->title, 3.0f);
+        break;
+
+    case RC_CLIENT_EVENT_LEADERBOARD_FAILED:
+        if (event->leaderboard)
+            RA_QueueNotification("Leaderboard Failed", event->leaderboard->title, 3.0f);
+        break;
+
+    case RC_CLIENT_EVENT_LEADERBOARD_SUBMITTED:
+        if (event->leaderboard)
+            RA_QueueNotification("Leaderboard Submitted", event->leaderboard->title, 3.0f);
+        break;
+
+    case RC_CLIENT_EVENT_GAME_COMPLETED:
+        RA_QueueNotification("Congratulations!", "All achievements earned!", 8.0f);
+        break;
+
+    case RC_CLIENT_EVENT_RESET:
+        S9xReset();
+        break;
+
+    case RC_CLIENT_EVENT_SERVER_ERROR:
+        if (event->server_error)
+            RA_QueueNotification("RA Server Error", event->server_error->error_message, 5.0f);
+        break;
+
+    case RC_CLIENT_EVENT_DISCONNECTED:
+        RA_QueueNotification("RetroAchievements", "Disconnected - unlocks pending", 5.0f);
+        break;
+
+    case RC_CLIENT_EVENT_RECONNECTED:
+        RA_QueueNotification("RetroAchievements", "Reconnected", 3.0f);
+        break;
+
+    default:
+        break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Login callback
+// ---------------------------------------------------------------------------
+static void RC_CCONV ra_login_callback(int result, const char *error_message,
+                                        rc_client_t *client, void *userdata)
+{
+    if (result == RC_OK)
+    {
+        const rc_client_user_t *user = rc_client_get_user_info(client);
+        if (user)
+        {
+            if (g_callbacks.on_credentials_changed)
+                g_callbacks.on_credentials_changed(user->username, user->token);
+
+            g_raEnabled = true;
+
+            char msg[256];
+            snprintf(msg, sizeof(msg), "Welcome, %s!", user->display_name);
+            RA_QueueNotification("Login Successful", msg, 3.0f);
+
+            if (!Settings.StopEmulation)
+                RA_OnLoadROM();
+        }
+    }
+    else
+    {
+        RA_QueueNotification("Unable to Login", "Check your credentials and try again.", 5.0f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Game loaded callback
+// ---------------------------------------------------------------------------
+static void RC_CCONV ra_game_loaded_callback(int result, const char *error_message,
+                                              rc_client_t *client, void *userdata)
+{
+    if (result == RC_OK)
+    {
+        const rc_client_game_t *game = rc_client_get_game_info(client);
+        if (game)
+        {
+            char msg[256];
+            snprintf(msg, sizeof(msg), "%s", game->title);
+            RA_QueueNotification("Game Loaded", msg, 3.0f);
+        }
+    }
+    else if (result == RC_NO_GAME_LOADED)
+    {
+        RA_QueueNotification("RetroAchievements", "Game not recognized", 3.0f);
+    }
+    else
+    {
+        RA_QueueNotification("RA Error", error_message ? error_message : "Failed to load game", 5.0f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Callback: HTTP server call (delegates to platform)
+// ---------------------------------------------------------------------------
+static void RC_CCONV ra_server_call_dispatch(const rc_api_request_t *request,
+                                              rc_client_server_callback_t callback,
+                                              void *callback_data, rc_client_t *client)
+{
+    if (g_callbacks.server_call)
+        g_callbacks.server_call(request, callback, callback_data, client);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: Lifecycle
+// ---------------------------------------------------------------------------
+void RA_Init()
+{
+    if (g_initialized)
+        return;
+
+    g_lastTime = std::chrono::steady_clock::now();
+
+    g_rcClient = rc_client_create(ra_read_memory, ra_server_call_dispatch);
+    if (!g_rcClient)
+        return;
+
+    rc_client_enable_logging(g_rcClient, RC_CLIENT_LOG_LEVEL_VERBOSE, ra_log_message);
+    rc_client_set_event_handler(g_rcClient, ra_event_handler);
+
+    g_initialized = true;
+}
+
+void RA_Shutdown()
+{
+    if (!g_initialized)
+        return;
+
+    if (g_rcClient)
+    {
+        rc_client_destroy(g_rcClient);
+        g_rcClient = nullptr;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_notifMutex);
+        g_notifications.clear();
+    }
+
+    g_initialized = false;
+    g_raEnabled = false;
+}
+
+void RA_DoFrame()
+{
+    if (!g_rcClient || !g_raEnabled)
+        return;
+
+    rc_client_do_frame(g_rcClient);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: Game lifecycle
+// ---------------------------------------------------------------------------
+void RA_OnLoadROM()
+{
+    if (!g_rcClient || !g_raEnabled)
+        return;
+
+    rc_client_begin_identify_and_load_game(g_rcClient,
+                                           RC_CONSOLE_SUPER_NINTENDO,
+                                           NULL,
+                                           Memory.ROM,
+                                           Memory.CalculatedSize,
+                                           ra_game_loaded_callback,
+                                           nullptr);
+}
+
+void RA_OnReset()
+{
+    if (!g_rcClient || !g_raEnabled)
+        return;
+
+    rc_client_reset(g_rcClient);
+}
+
+void RA_OnCloseROM()
+{
+    if (!g_rcClient || !g_raEnabled)
+        return;
+
+    rc_client_unload_game(g_rcClient);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: Save state integration
+// ---------------------------------------------------------------------------
+void RA_OnSaveState(const char *filename)
+{
+    if (!g_rcClient || !g_raEnabled)
+        return;
+
+    size_t size = rc_client_progress_size(g_rcClient);
+    if (size == 0)
+        return;
+
+    std::vector<uint8_t> buffer(size);
+    if (rc_client_serialize_progress_sized(g_rcClient, buffer.data(), size) == RC_OK)
+    {
+        std::string ra_filename = std::string(filename) + ".rcheevos";
+        FILE *f = fopen(ra_filename.c_str(), "wb");
+        if (f)
+        {
+            fwrite(buffer.data(), 1, size, f);
+            fclose(f);
+        }
+    }
+}
+
+void RA_OnLoadState(const char *filename)
+{
+    if (!g_rcClient || !g_raEnabled)
+        return;
+
+    std::string ra_filename = std::string(filename) + ".rcheevos";
+    FILE *f = fopen(ra_filename.c_str(), "rb");
+    if (f)
+    {
+        fseek(f, 0, SEEK_END);
+        size_t size = (size_t)ftell(f);
+        fseek(f, 0, SEEK_SET);
+        std::vector<uint8_t> buffer(size);
+        fread(buffer.data(), 1, size, f);
+        fclose(f);
+        rc_client_deserialize_progress_sized(g_rcClient, buffer.data(), size);
+    }
+    else
+    {
+        rc_client_deserialize_progress(g_rcClient, nullptr);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API: Hardcore mode
+// ---------------------------------------------------------------------------
+bool RA_IsHardcoreModeActive()
+{
+    if (!g_rcClient || !g_raEnabled)
+        return false;
+
+    return rc_client_get_hardcore_enabled(g_rcClient) != 0;
+}
+
+bool RA_WarnDisableHardcore(const char *activity)
+{
+    if (!RA_IsHardcoreModeActive())
+        return true;
+
+    if (g_callbacks.confirm_disable_hardcore)
+    {
+        if (g_callbacks.confirm_disable_hardcore(activity))
+        {
+            rc_client_set_hardcore_enabled(g_rcClient, 0);
+            return true;
+        }
+        return false;
+    }
+
+    return true;
+}
+
+void RA_SetEnabled(bool enabled)
+{
+    g_raEnabled = enabled;
+}
+
+void RA_SetHardcoreEnabled(bool enabled)
+{
+    if (g_rcClient)
+        rc_client_set_hardcore_enabled(g_rcClient, enabled ? 1 : 0);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: Login
+// ---------------------------------------------------------------------------
+void RA_AttemptLogin(const char *username, const char *token)
+{
+    if (!g_rcClient)
+        return;
+
+    if (username && username[0] && token && token[0])
+    {
+        rc_client_begin_login_with_token(g_rcClient,
+                                         username, token,
+                                         ra_login_callback, nullptr);
+    }
+}
+
+void RA_LoginWithPassword(const char *username, const char *password)
+{
+    if (!g_rcClient)
+        return;
+
+    if (username && username[0] && password && password[0])
+    {
+        rc_client_begin_login_with_password(g_rcClient, username, password,
+                                             ra_login_callback, nullptr);
+    }
+}
+
+void RA_ShowLoginDialog()
+{
+    if (g_callbacks.show_login_dialog)
+        g_callbacks.show_login_dialog();
+}
+
+bool RA_IsLoggedIn()
+{
+    if (!g_rcClient)
+        return false;
+
+    return rc_client_get_user_info(g_rcClient) != nullptr;
+}
+
+void RA_Logout()
+{
+    if (!g_rcClient)
+        return;
+
+    rc_client_logout(g_rcClient);
+
+    if (g_callbacks.on_credentials_changed)
+        g_callbacks.on_credentials_changed("", "");
+
+    RA_QueueNotification("RetroAchievements", "Logged out", 3.0f);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: UI
+// ---------------------------------------------------------------------------
+void RA_ShowAchievementList()
+{
+    if (g_callbacks.show_achievement_list)
+        g_callbacks.show_achievement_list();
+}
+
+rc_client_t *RA_GetClient()
+{
+    return g_rcClient;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: ImGui Overlay
+// ---------------------------------------------------------------------------
+void RA_RenderOverlay(int width, int height)
+{
+    if (!g_initialized)
+        return;
+
+    auto now = std::chrono::steady_clock::now();
+    float dt = std::chrono::duration<float>(now - g_lastTime).count();
+    g_lastTime = now;
+
+    if (dt > 0.5f)
+        dt = 0.5f;
+
+    std::lock_guard<std::mutex> lock(g_notifMutex);
+
+    auto *drawList = ImGui::GetForegroundDrawList();
+    float y = 10.0f;
+    const float padding = 8.0f;
+    const float maxWidth = 400.0f;
+    const ImU32 bgColor = IM_COL32(0x10, 0x10, 0x40, 0xE0);
+    const ImU32 titleColor = IM_COL32(0xFF, 0xD7, 0x00, 0xFF);
+    const ImU32 textColor = IM_COL32(0xFF, 0xFF, 0xFF, 0xFF);
+
+    auto it = g_notifications.begin();
+    while (it != g_notifications.end())
+    {
+        it->elapsed += dt;
+        if (it->elapsed >= it->duration)
+        {
+            it = g_notifications.erase(it);
+            continue;
+        }
+
+        float alpha = 1.0f;
+        if (it->elapsed < 0.3f)
+            alpha = it->elapsed / 0.3f;
+        else if (it->elapsed > it->duration - 0.5f)
+            alpha = (it->duration - it->elapsed) / 0.5f;
+
+        ImU32 bg = (bgColor & 0x00FFFFFF) | ((uint32_t)(((bgColor >> 24) & 0xFF) * alpha) << 24);
+        ImU32 tc = (titleColor & 0x00FFFFFF) | ((uint32_t)(((titleColor >> 24) & 0xFF) * alpha) << 24);
+        ImU32 txt = (textColor & 0x00FFFFFF) | ((uint32_t)(((textColor >> 24) & 0xFF) * alpha) << 24);
+
+        ImVec2 titleSize = ImGui::CalcTextSize(it->title.c_str(), nullptr, false, maxWidth);
+        ImVec2 subtitleSize = {0, 0};
+        if (!it->subtitle.empty())
+            subtitleSize = ImGui::CalcTextSize(it->subtitle.c_str(), nullptr, false, maxWidth);
+
+        float boxW = (titleSize.x > subtitleSize.x ? titleSize.x : subtitleSize.x) + padding * 2;
+        float boxH = titleSize.y + subtitleSize.y + padding * 2;
+        if (!it->subtitle.empty())
+            boxH += 4.0f;
+
+        float x = ((float)width - boxW) * 0.5f;
+
+        drawList->AddRectFilled(ImVec2(x, y), ImVec2(x + boxW, y + boxH), bg, 6.0f);
+        drawList->AddText(nullptr, 0.0f, ImVec2(x + padding, y + padding), tc,
+                          it->title.c_str(), nullptr, maxWidth);
+
+        if (!it->subtitle.empty())
+        {
+            drawList->AddText(nullptr, 0.0f,
+                              ImVec2(x + padding, y + padding + titleSize.y + 4.0f), txt,
+                              it->subtitle.c_str(), nullptr, maxWidth);
+        }
+
+        y += boxH + 6.0f;
+        ++it;
+    }
+}
+
+#endif // RETROACHIEVEMENTS_SUPPORT

--- a/retroachievements.h
+++ b/retroachievements.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+
+#include <cstdint>
+
+#include "rc_client.h"
+
+// ---------------------------------------------------------------------------
+// Platform callbacks — must be registered before calling RA_Init()
+// ---------------------------------------------------------------------------
+struct RAPlatformCallbacks
+{
+    // HTTP: must perform async request and invoke callback with response (even on error)
+    rc_client_server_call_t server_call;
+
+    // UI: show login dialog (platform-specific)
+    void (*show_login_dialog)();
+
+    // UI: show achievement list dialog (platform-specific)
+    void (*show_achievement_list)();
+
+    // UI: blocking yes/no confirmation for disabling hardcore mode
+    // Returns true if user confirmed (disable hardcore), false to cancel
+    bool (*confirm_disable_hardcore)(const char *activity);
+
+    // Logging
+    void (*log_message)(const char *message);
+
+    // Config persistence: called when credentials change (login success / logout)
+    void (*on_credentials_changed)(const char *username, const char *token);
+};
+
+void RA_RegisterPlatformCallbacks(const RAPlatformCallbacks &callbacks);
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+void RA_Init();
+void RA_Shutdown();
+void RA_DoFrame();
+
+// ---------------------------------------------------------------------------
+// Game lifecycle
+// ---------------------------------------------------------------------------
+void RA_OnLoadROM();
+void RA_OnReset();
+void RA_OnCloseROM();
+
+// ---------------------------------------------------------------------------
+// Save state integration
+// ---------------------------------------------------------------------------
+void RA_OnSaveState(const char *filename);
+void RA_OnLoadState(const char *filename);
+
+// ---------------------------------------------------------------------------
+// Hardcore mode
+// ---------------------------------------------------------------------------
+bool RA_IsHardcoreModeActive();
+bool RA_WarnDisableHardcore(const char *activity);
+void RA_SetEnabled(bool enabled);
+void RA_SetHardcoreEnabled(bool enabled);
+
+// ---------------------------------------------------------------------------
+// Login
+// ---------------------------------------------------------------------------
+void RA_AttemptLogin(const char *username, const char *token);
+void RA_LoginWithPassword(const char *username, const char *password);
+void RA_ShowLoginDialog();
+void RA_Logout();
+bool RA_IsLoggedIn();
+
+// ---------------------------------------------------------------------------
+// UI
+// ---------------------------------------------------------------------------
+void RA_ShowAchievementList();
+
+// ---------------------------------------------------------------------------
+// ImGui overlay
+// ---------------------------------------------------------------------------
+void RA_RenderOverlay(int width, int height);
+
+// ---------------------------------------------------------------------------
+// Access to rc_client for platform dialogs
+// ---------------------------------------------------------------------------
+rc_client_t *RA_GetClient();
+
+#endif // RETROACHIEVEMENTS_SUPPORT

--- a/win32/retroachievements.h
+++ b/win32/retroachievements.h
@@ -1,37 +1,9 @@
 #pragma once
 
+#include "../retroachievements.h"
+
 #ifdef RETROACHIEVEMENTS_SUPPORT
 
-#include <cstdint>
-
-// Lifecycle
-void RA_Init(void *hWnd);
-void RA_Shutdown();
-void RA_DoFrame();
-
-// Game lifecycle
-void RA_OnLoadROM();
-void RA_OnReset();
-void RA_OnCloseROM();
-
-// Save state integration
-void RA_OnSaveState(const char *filename);
-void RA_OnLoadState(const char *filename);
-
-// Hardcore mode
-bool RA_IsHardcoreModeActive();
-bool RA_WarnDisableHardcore(const char *activity);
-
-// Login
-void RA_AttemptLogin();
-void RA_ShowLoginDialog(void *hWnd);
-void RA_Logout();
-bool RA_IsLoggedIn();
-
-// UI
-void RA_ShowAchievementList(void *hWnd);
-
-// ImGui overlay
-void RA_RenderOverlay(int width, int height);
+void RA_Win32_RegisterCallbacks();
 
 #endif // RETROACHIEVEMENTS_SUPPORT

--- a/win32/retroachievements_win32.cpp
+++ b/win32/retroachievements_win32.cpp
@@ -1,0 +1,385 @@
+#include "retroachievements.h"
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+
+#include <windows.h>
+#include <commctrl.h>
+#include <wininet.h>
+#include <process.h>
+#include <string>
+#include <cstdio>
+
+#include "rc_client.h"
+
+#include "wsnes9x.h"
+
+#pragma comment(lib, "wininet.lib")
+
+extern HINSTANCE g_hInst;
+
+// ---------------------------------------------------------------------------
+// WinINet HTTP Server Call (async on background thread)
+// ---------------------------------------------------------------------------
+struct RAHttpRequest
+{
+    std::string url;
+    std::string post_data;
+    std::string content_type;
+    rc_client_server_callback_t callback;
+    void *callback_data;
+};
+
+static unsigned __stdcall ra_http_thread(void *param)
+{
+    RAHttpRequest *req = static_cast<RAHttpRequest *>(param);
+
+    rc_api_server_response_t response = {};
+    std::string response_body;
+
+    HINTERNET hInet = InternetOpenA("snes9x", INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0);
+    if (!hInet)
+    {
+        response.http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR;
+        req->callback(&response, req->callback_data);
+        delete req;
+        return 0;
+    }
+
+    if (req->post_data.empty())
+    {
+        HINTERNET hUrl = InternetOpenUrlA(hInet, req->url.c_str(), NULL, 0,
+                                          INTERNET_FLAG_RELOAD | INTERNET_FLAG_NO_CACHE_WRITE, 0);
+        if (hUrl)
+        {
+            char buf[8192];
+            DWORD bytesRead;
+            while (InternetReadFile(hUrl, buf, sizeof(buf), &bytesRead) && bytesRead > 0)
+                response_body.append(buf, bytesRead);
+
+            DWORD statusCode = 0;
+            DWORD statusSize = sizeof(statusCode);
+            HttpQueryInfoA(hUrl, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER,
+                           &statusCode, &statusSize, NULL);
+            response.http_status_code = (int)statusCode;
+            InternetCloseHandle(hUrl);
+        }
+        else
+        {
+            response.http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR;
+        }
+    }
+    else
+    {
+        URL_COMPONENTSA urlParts = {};
+        char hostBuf[256], pathBuf[1024];
+        urlParts.dwStructSize = sizeof(urlParts);
+        urlParts.lpszHostName = hostBuf;
+        urlParts.dwHostNameLength = sizeof(hostBuf);
+        urlParts.lpszUrlPath = pathBuf;
+        urlParts.dwUrlPathLength = sizeof(pathBuf);
+
+        if (InternetCrackUrlA(req->url.c_str(), 0, 0, &urlParts))
+        {
+            HINTERNET hConnect = InternetConnectA(hInet, hostBuf, urlParts.nPort,
+                                                   NULL, NULL, INTERNET_SERVICE_HTTP, 0, 0);
+            if (hConnect)
+            {
+                DWORD flags = INTERNET_FLAG_RELOAD | INTERNET_FLAG_NO_CACHE_WRITE;
+                if (urlParts.nScheme == INTERNET_SCHEME_HTTPS)
+                    flags |= INTERNET_FLAG_SECURE;
+
+                HINTERNET hRequest = HttpOpenRequestA(hConnect, "POST", pathBuf,
+                                                       NULL, NULL, NULL, flags, 0);
+                if (hRequest)
+                {
+                    const char *ct = req->content_type.empty()
+                                         ? "application/x-www-form-urlencoded"
+                                         : req->content_type.c_str();
+                    std::string headers = "Content-Type: ";
+                    headers += ct;
+
+                    BOOL sent = HttpSendRequestA(hRequest, headers.c_str(), (DWORD)headers.size(),
+                                                  (LPVOID)req->post_data.c_str(),
+                                                  (DWORD)req->post_data.size());
+                    if (sent)
+                    {
+                        char buf[8192];
+                        DWORD bytesRead;
+                        while (InternetReadFile(hRequest, buf, sizeof(buf), &bytesRead) && bytesRead > 0)
+                            response_body.append(buf, bytesRead);
+
+                        DWORD statusCode = 0;
+                        DWORD statusSize = sizeof(statusCode);
+                        HttpQueryInfoA(hRequest, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER,
+                                       &statusCode, &statusSize, NULL);
+                        response.http_status_code = (int)statusCode;
+                    }
+                    else
+                    {
+                        response.http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR;
+                    }
+                    InternetCloseHandle(hRequest);
+                }
+                InternetCloseHandle(hConnect);
+            }
+        }
+        else
+        {
+            response.http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR;
+        }
+    }
+
+    InternetCloseHandle(hInet);
+
+    response.body = response_body.c_str();
+    response.body_length = response_body.size();
+
+    req->callback(&response, req->callback_data);
+    delete req;
+    return 0;
+}
+
+static void RC_CCONV ra_win32_server_call(const rc_api_request_t *request,
+                                           rc_client_server_callback_t callback,
+                                           void *callback_data, rc_client_t *client)
+{
+    RAHttpRequest *req = new RAHttpRequest();
+    req->url = request->url ? request->url : "";
+    req->post_data = request->post_data ? request->post_data : "";
+    req->content_type = request->content_type ? request->content_type : "";
+    req->callback = callback;
+    req->callback_data = callback_data;
+
+    unsigned tid;
+    HANDLE hThread = (HANDLE)_beginthreadex(NULL, 0, ra_http_thread, req, 0, &tid);
+    if (hThread)
+        CloseHandle(hThread);
+    else
+    {
+        rc_api_server_response_t response = {};
+        response.http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR;
+        callback(&response, callback_data);
+        delete req;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Win32 Achievement List Dialog
+// ---------------------------------------------------------------------------
+static void RA_PopulateAchievementList(HWND hList)
+{
+    ListView_DeleteAllItems(hList);
+
+    rc_client_t *client = RA_GetClient();
+    if (!client)
+        return;
+
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(client,
+        RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+
+    if (!list)
+        return;
+
+    int index = 0;
+    for (uint32_t b = 0; b < list->num_buckets; b++)
+    {
+        const rc_client_achievement_bucket_t *bucket = &list->buckets[b];
+        for (uint32_t a = 0; a < bucket->num_achievements; a++)
+        {
+            const rc_client_achievement_t *ach = bucket->achievements[a];
+
+            LVITEMA lvi = {};
+            lvi.mask = LVIF_TEXT;
+            lvi.iItem = index;
+
+            lvi.iSubItem = 0;
+            lvi.pszText = const_cast<char *>(ach->title);
+            SendMessageA(hList, LVM_INSERTITEMA, 0, (LPARAM)&lvi);
+
+            char pts[16];
+            snprintf(pts, sizeof(pts), "%u", ach->points);
+            lvi.iSubItem = 1;
+            lvi.pszText = pts;
+            SendMessageA(hList, LVM_SETITEMA, 0, (LPARAM)&lvi);
+
+            const char *status;
+            if (ach->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE)
+                status = "Unlocked (HC)";
+            else if (ach->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE)
+                status = "Unlocked";
+            else if (ach->state == RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE)
+                status = "Locked";
+            else
+                status = "Inactive";
+            lvi.iSubItem = 2;
+            lvi.pszText = const_cast<char *>(status);
+            SendMessageA(hList, LVM_SETITEMA, 0, (LPARAM)&lvi);
+
+            lvi.iSubItem = 3;
+            lvi.pszText = const_cast<char *>(ach->description);
+            SendMessageA(hList, LVM_SETITEMA, 0, (LPARAM)&lvi);
+
+            index++;
+        }
+    }
+
+    rc_client_destroy_achievement_list(list);
+}
+
+static INT_PTR CALLBACK DlgRAAchievementsProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_INITDIALOG:
+    {
+        HWND hList = GetDlgItem(hDlg, IDC_RA_ACHLIST);
+        ListView_SetExtendedListViewStyle(hList, LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES);
+
+        LVCOLUMNA col = {};
+        col.mask = LVCF_TEXT | LVCF_WIDTH;
+
+        col.pszText = (char *)"Title";
+        col.cx = 150;
+        SendMessageA(hList, LVM_INSERTCOLUMNA, 0, (LPARAM)&col);
+
+        col.pszText = (char *)"Points";
+        col.cx = 45;
+        SendMessageA(hList, LVM_INSERTCOLUMNA, 1, (LPARAM)&col);
+
+        col.pszText = (char *)"Status";
+        col.cx = 85;
+        SendMessageA(hList, LVM_INSERTCOLUMNA, 2, (LPARAM)&col);
+
+        col.pszText = (char *)"Description";
+        col.cx = 280;
+        SendMessageA(hList, LVM_INSERTCOLUMNA, 3, (LPARAM)&col);
+
+        rc_client_t *client = RA_GetClient();
+        const rc_client_game_t *game = client ? rc_client_get_game_info(client) : nullptr;
+        if (game)
+            SetDlgItemTextA(hDlg, IDC_RA_GAME_TITLE, game->title);
+        else
+            SetDlgItemTextA(hDlg, IDC_RA_GAME_TITLE, "No game loaded");
+
+        RA_PopulateAchievementList(hList);
+        return TRUE;
+    }
+
+    case WM_SIZE:
+    {
+        RECT rc;
+        GetClientRect(hDlg, &rc);
+        HWND hList = GetDlgItem(hDlg, IDC_RA_ACHLIST);
+        MoveWindow(hList, 6, 20, rc.right - 12, rc.bottom - 46, TRUE);
+        HWND hBtn = GetDlgItem(hDlg, IDCANCEL);
+        MoveWindow(hBtn, (rc.right - 50) / 2, rc.bottom - 20, 50, 14, TRUE);
+        return TRUE;
+    }
+
+    case WM_COMMAND:
+        if (LOWORD(wParam) == IDCANCEL)
+        {
+            EndDialog(hDlg, IDCANCEL);
+            return TRUE;
+        }
+        break;
+    }
+    return FALSE;
+}
+
+// ---------------------------------------------------------------------------
+// Win32 Login Dialog
+// ---------------------------------------------------------------------------
+static INT_PTR CALLBACK DlgRALoginProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_INITDIALOG:
+        SetDlgItemTextA(hDlg, IDC_RA_USERNAME, GUI.RAUsername);
+        SetFocus(GetDlgItem(hDlg, GUI.RAUsername[0] ? IDC_RA_PASSWORD : IDC_RA_USERNAME));
+        return FALSE;
+
+    case WM_COMMAND:
+        switch (LOWORD(wParam))
+        {
+        case IDOK:
+        {
+            char username[256] = {}, password[256] = {};
+            GetDlgItemTextA(hDlg, IDC_RA_USERNAME, username, sizeof(username));
+            GetDlgItemTextA(hDlg, IDC_RA_PASSWORD, password, sizeof(password));
+
+            if (username[0] && password[0])
+                RA_LoginWithPassword(username, password);
+
+            EndDialog(hDlg, IDOK);
+            return TRUE;
+        }
+        case IDCANCEL:
+            EndDialog(hDlg, IDCANCEL);
+            return TRUE;
+        }
+        break;
+    }
+    return FALSE;
+}
+
+// ---------------------------------------------------------------------------
+// Win32 Callback Implementations
+// ---------------------------------------------------------------------------
+static void ra_win32_show_login()
+{
+    DialogBoxA(g_hInst, MAKEINTRESOURCEA(IDD_RA_LOGIN), GUI.hWnd, DlgRALoginProc);
+}
+
+static void ra_win32_show_achievements()
+{
+    DialogBoxA(g_hInst, MAKEINTRESOURCEA(IDD_RA_ACHIEVEMENTS), GUI.hWnd, DlgRAAchievementsProc);
+}
+
+static bool ra_win32_confirm_disable_hardcore(const char *activity)
+{
+    char msg[512];
+    snprintf(msg, sizeof(msg),
+             "%s is not allowed in Hardcore mode.\n\n"
+             "Disable Hardcore mode to proceed?\n"
+             "(Achievement progress for the current session will be lost)",
+             activity);
+
+    int res = MessageBoxA(GUI.hWnd, msg, "RetroAchievements - Hardcore Mode",
+                          MB_YESNO | MB_ICONWARNING);
+    return (res == IDYES);
+}
+
+static void ra_win32_log(const char *message)
+{
+    OutputDebugStringA(message);
+    OutputDebugStringA("\n");
+}
+
+static void ra_win32_credentials_changed(const char *username, const char *token)
+{
+    strncpy(GUI.RAUsername, username ? username : "", sizeof(GUI.RAUsername) - 1);
+    GUI.RAUsername[sizeof(GUI.RAUsername) - 1] = '\0';
+    strncpy(GUI.RAApiToken, token ? token : "", sizeof(GUI.RAApiToken) - 1);
+    GUI.RAApiToken[sizeof(GUI.RAApiToken) - 1] = '\0';
+
+    GUI.RAEnabled = (username && username[0] && token && token[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Public: Register Win32 callbacks
+// ---------------------------------------------------------------------------
+void RA_Win32_RegisterCallbacks()
+{
+    RAPlatformCallbacks cb = {};
+    cb.server_call = ra_win32_server_call;
+    cb.show_login_dialog = ra_win32_show_login;
+    cb.show_achievement_list = ra_win32_show_achievements;
+    cb.confirm_disable_hardcore = ra_win32_confirm_disable_hardcore;
+    cb.log_message = ra_win32_log;
+    cb.on_credentials_changed = ra_win32_credentials_changed;
+    RA_RegisterPlatformCallbacks(cb);
+}
+
+#endif // RETROACHIEVEMENTS_SUPPORT

--- a/win32/snes9xw.vcxproj
+++ b/win32/snes9xw.vcxproj
@@ -492,6 +492,7 @@
     <ClInclude Include="wlanguage.h" />
     <ClInclude Include="wsnes9x.h" />
     <ClInclude Include="retroachievements.h" />
+    <ClInclude Include="..\retroachievements.h" />
     <ClInclude Include="_tfwopen.h" />
   </ItemGroup>
   <ItemGroup>
@@ -693,7 +694,8 @@
     <ClCompile Include="kaillera_client.cpp" />
     <ClCompile Include="kaillera_server.cpp" />
     <ClCompile Include="render.cpp" />
-    <ClCompile Include="retroachievements.cpp" />
+    <ClCompile Include="retroachievements_win32.cpp" />
+    <ClCompile Include="..\retroachievements.cpp" />
     <ClCompile Include="wconfig.cpp" />
     <ClCompile Include="win32.cpp" />
     <ClCompile Include="win32_display.cpp" />

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -2412,10 +2412,12 @@ LRESULT CALLBACK WinProc(
 #ifdef RETROACHIEVEMENTS_SUPPORT
 		case ID_RA_ENABLED:
 			GUI.RAEnabled = !GUI.RAEnabled;
+			RA_SetEnabled(GUI.RAEnabled);
 			if (GUI.RAEnabled)
 			{
-				RA_Init(GUI.hWnd);
-				RA_AttemptLogin();
+				RA_Win32_RegisterCallbacks();
+				RA_Init();
+				RA_AttemptLogin(GUI.RAUsername, GUI.RAApiToken);
 				if (!Settings.StopEmulation)
 					RA_OnLoadROM();
 			}
@@ -2425,27 +2427,21 @@ LRESULT CALLBACK WinProc(
 			}
 			break;
 		case ID_RA_LOGIN:
-			RA_Init(GUI.hWnd);
+			RA_Win32_RegisterCallbacks();
+			RA_Init();
 			if (RA_IsLoggedIn())
 				RA_Logout();
 			else
-				RA_ShowLoginDialog(GUI.hWnd);
+				RA_ShowLoginDialog();
 			break;
 		case ID_RA_HARDCORE_MODE:
-			if (GUI.RAHardcoreMode)
-			{
-				// Disabling hardcore
-				GUI.RAHardcoreMode = false;
-			}
-			else
-			{
-				// Enabling hardcore requires a reset
-				GUI.RAHardcoreMode = true;
-			}
+			GUI.RAHardcoreMode = !GUI.RAHardcoreMode;
+			RA_SetHardcoreEnabled(GUI.RAHardcoreMode);
 			break;
 		case ID_RA_ACHIEVEMENTS_LIST:
-			RA_Init(GUI.hWnd);
-			RA_ShowAchievementList(GUI.hWnd);
+			RA_Win32_RegisterCallbacks();
+			RA_Init();
+			RA_ShowAchievementList();
 			break;
 #endif
 		case ID_FRAME_ADVANCE:
@@ -3628,8 +3624,11 @@ int WINAPI WinMain(
 
 	if (GUI.RAEnabled)
 	{
-		RA_Init(GUI.hWnd);
-		RA_AttemptLogin();
+		RA_Win32_RegisterCallbacks();
+		RA_Init();
+		RA_SetEnabled(true);
+		RA_SetHardcoreEnabled(GUI.RAHardcoreMode);
+		RA_AttemptLogin(GUI.RAUsername, GUI.RAApiToken);
 	}
 #endif
 


### PR DESCRIPTION
Extract shared RA logic into root-level files and add Qt/Linux support:

Shared core (new files in root):
- retroachievements.h: Cross-platform public API with RAPlatformCallbacks struct for dependency injection of HTTP, UI, and logging
- retroachievements.cpp: All platform-agnostic logic using std::mutex and std::chrono (memory callback, event handler, notification queue, overlay, rc_client lifecycle, save state serialization)

Win32 platform (refactored):
- win32/retroachievements_win32.cpp: Extracted WinINet HTTP, Win32 dialogs, and callback registration
- win32/retroachievements.h: Thin forwarding header

Qt/Linux platform (new):
- qt/src/RAIntegrationQt.cpp: Full Qt implementation with QNetworkAccessManager HTTP, login dialog, achievement list dialog (QTreeWidget), QMessageBox for hardcore warnings, qDebug logging
- EmuApplication.cpp: RA lifecycle hooks (frame, load/close ROM, reset, save/load state, rewind block, shutdown)
- EmuMainWindow.cpp: RetroAchievements menu with Enabled, Login/Logout, Hardcore Mode, Achievement List
- EmuConfig: RA settings persistence (enabled, hardcore, username, token)
- main.cpp: Auto-enable and auto-login on startup when token saved
- CMakeLists.txt: Added Qt6::Network, rcheevos sources, RA defines