### PR TITLE
sgb: per-pixel PPU + per-dot interleaving + Mesen2 4-bank ICD2 protocol

### DIFF
--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -36,7 +36,7 @@ void S9xMainLoop (void)
 			S9xMovieUpdate();
 		}
 
-		IPPU.RenderThisFrame      = TRUE;
+		IPPU.RenderThisFrame      = !Settings.InRunAhead;
 		PPU.ScreenHeight          = SNES_HEIGHT;
 		IPPU.RenderedScreenWidth  = SNES_WIDTH;
 		IPPU.RenderedScreenHeight = SNES_HEIGHT;
@@ -59,10 +59,17 @@ void S9xMainLoop (void)
 		// picks up sound-config changes (output device / rate switch).
 		S9xSGBSetAudioRate(Settings.SoundPlaybackRate);
 
-		S9xStartScreenRefresh();
+		// Hidden runahead frames advance GB state but skip blit/present:
+		// double-presenting per displayed frame can clobber video on
+		// some host backends.
+		if (!Settings.InRunAhead)
+			S9xStartScreenRefresh();
 		S9xSGBRunFrame();
-		S9xSGBBlitScreen(GFX.Screen, GFX.RealPPL);
-		S9xEndScreenRefresh();
+		if (!Settings.InRunAhead)
+		{
+			S9xSGBBlitScreen(GFX.Screen, GFX.RealPPL);
+			S9xEndScreenRefresh();
+		}
 
 		// Drive the host audio callback to drain GB samples into the
 		// sound device. In standard SNES mode the SPC scanline path

--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -250,17 +250,17 @@ void S9xMainLoop (void)
 		Registers.PCw++;
 		(*Opcodes[Op].S9xOpcode)();
 
+		// Per-opcode SGB sync. ICD2-access + scanline syncs alone deliver
+		// variable chunk sizes (a few cycles to ~1300), making GB CPU
+		// HALT-vs-code mix vary per frame, drifting BIOS bank-rotation
+		// timing and producing visible border-tile corruption at default
+		// settings (CPUOverclock=0). Per-opcode sync delivers tiny uniform
+		// deltas (1-3 SNES cycles), keeping per-frame timing stable.
+		if (Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased())
+			S9xSGBSyncToSnesCycle(CPU.Cycles);
+
 		if (Settings.SA1)
 			S9xSA1MainLoop();
-
-		// SNES→GB sync now happens at scanline boundaries only (see
-		// HC_HCOUNTER_MAX_EVENT below) plus on every ICD2 register
-		// access in getset.h. The previous per-opcode sync here cost
-		// millions of function calls/sec in BIOS-released mode and
-		// dropped wall-fps from 60 to ~25. Scanline-grained sync is
-		// fine for game-running mode — the BIOS handshake's tight
-		// $7800-slice timing happens before release, where ICD2-access
-		// syncs already serialize state correctly.
 	}
 
 	// P2 — in BIOS mode the GB core is held in reset until the BIOS

--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -250,17 +250,17 @@ void S9xMainLoop (void)
 		Registers.PCw++;
 		(*Opcodes[Op].S9xOpcode)();
 
-		// Per-opcode SGB sync. ICD2-access + scanline syncs alone deliver
-		// variable chunk sizes (a few cycles to ~1300), making GB CPU
-		// HALT-vs-code mix vary per frame, drifting BIOS bank-rotation
-		// timing and producing visible border-tile corruption at default
-		// settings (CPUOverclock=0). Per-opcode sync delivers tiny uniform
-		// deltas (1-3 SNES cycles), keeping per-frame timing stable.
-		if (Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased())
-			S9xSGBSyncToSnesCycle(CPU.Cycles);
-
 		if (Settings.SA1)
 			S9xSA1MainLoop();
+
+		// SNES→GB sync now happens at scanline boundaries only (see
+		// HC_HCOUNTER_MAX_EVENT below) plus on every ICD2 register
+		// access in getset.h. The previous per-opcode sync here cost
+		// millions of function calls/sec in BIOS-released mode and
+		// dropped wall-fps from 60 to ~25. Scanline-grained sync is
+		// fine for game-running mode — the BIOS handshake's tight
+		// $7800-slice timing happens before release, where ICD2-access
+		// syncs already serialize state correctly.
 	}
 
 	// P2 — in BIOS mode the GB core is held in reset until the BIOS

--- a/sgb/gb_cpu.h
+++ b/sgb/gb_cpu.h
@@ -64,6 +64,12 @@ void     IrqServicedReset();
 // Fired in user code (hot path), so keep hooks cheap.
 using TraceHook = void (*)(uint16_t pc, uint8_t opcode, const CpuState &state);
 
+// Upper bound on T-cycles a single Cpu::Step() can consume. The longest
+// observed paths are CALL cc,nn taken (24 T-cycles) and IRQ dispatch
+// (20 T-cycles). Used by the per-dot CPU/PPU interleaving gate in
+// RunCycles so the GB CPU never overshoots PPU on a sub-opcode boundary.
+static constexpr int kMaxOpcodeTCycles = 24;
+
 class Cpu
 {
 public:

--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -4,7 +4,7 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
-// Game Boy PPU — scanline-level implementation.
+// Game Boy PPU — per-pixel implementation (one render call per dot).
 //
 // Timing (T-cycles, per Pan Docs):
 //   line = 456 dots, split as
@@ -13,16 +13,19 @@
 //     mode 0 (HBlank)         : 204 dots
 //   144 visible lines + 10 VBlank lines = 154 total. Frame = 70224 dots.
 //
-// The renderer runs at mode-3 entry and deposits the entire scanline
-// atomically. This matches what most scanline emulators do — it passes
-// dmg-acid2 and the vast majority of commercial games, but won't
-// reproduce mid-scanline register-write effects used by a handful of
-// demos. Pixel-FIFO accuracy is P10 territory if ever needed.
+// PpuStep iterates one GB t-cycle at a time. During mode 3 the renderer
+// emits ONE pixel per dot (RenderPixel), re-sampling LCDC/SCX/SCY/BGP/
+// OBP0/OBP1/WX/WY at each pixel — this catches mid-LY register writes
+// that some games use for parallax (Animaniacs cloud strip), palette
+// effects, and window-position changes. It's not the full Mesen2 fetcher
+// state machine (no per-tile fetch delay, no sprite/window/SCX-fine
+// mode 3 length penalty), but it's enough to fix the visible artifacts.
+// Promote to fetcher-driven mode 3 length (Mesen-style RunDrawCycle) if
+// games need cycle-exact mode-3 timing.
 //
-// OBJ-over-BG priority: the BG's raw pre-palette color (scanline_bg_raw)
-// is tracked alongside the palette-mapped framebuffer so the sprite
-// renderer can respect the "BG wins when BG color != 0" flag after the
-// fact.
+// OBJ-over-BG priority: the per-pixel BG raw value (scanline_bg_raw) is
+// tracked alongside the palette-mapped framebuffer so SampleSpritePixel
+// can respect the "BG wins when BG color != 0" flag.
 //
 // STAT IRQ uses edge detection: the four sources (LYC match / mode 2 /
 // mode 1 / mode 0) are ORed into a single "stat line"; we raise
@@ -75,142 +78,135 @@ void RecomputeStatLine(Ppu &p, Memory &mem)
 	p.stat_line_high = line_high;
 }
 
-void RenderBG(Ppu &p, uint8_t *line_out)
+// Sample one BG pixel at (x, ly) using the CURRENT register values.
+// Inlined so the per-dot path doesn't pay function-call overhead per pixel.
+inline uint8_t SampleBgPixel(const Ppu &p, int x)
 {
-	const uint16_t map_base  = (p.lcdc & 0x08) ? 0x1C00 : 0x1800;  // VRAM-relative
+	const uint16_t map_base  = (p.lcdc & 0x08) ? 0x1C00 : 0x1800;
 	const bool     tiles_un  = (p.lcdc & 0x10) != 0;
 	const uint8_t  bg_y      = static_cast<uint8_t>(p.ly + p.scy);
 	const uint32_t tile_row  = bg_y >> 3;
 	const uint32_t fine_y    = bg_y & 7;
+	const uint8_t  bg_x      = static_cast<uint8_t>(x + p.scx);
+	const uint32_t tile_col  = bg_x >> 3;
+	const uint32_t fine_x    = bg_x & 7;
 
-	for (int x = 0; x < GB_SCREEN_WIDTH; ++x)
-	{
-		const uint8_t  bg_x     = static_cast<uint8_t>(x + p.scx);
-		const uint32_t tile_col = bg_x >> 3;
-		const uint32_t fine_x   = bg_x & 7;
+	const uint8_t tile_num = p.vram[map_base + (tile_row * 32) + tile_col];
 
-		const uint8_t tile_num = p.vram[map_base + (tile_row * 32) + tile_col];
+	uint16_t tile_addr;
+	if (tiles_un)
+		tile_addr = static_cast<uint16_t>(tile_num * 16);
+	else
+		tile_addr = static_cast<uint16_t>(0x1000 + static_cast<int8_t>(tile_num) * 16);
+	tile_addr = static_cast<uint16_t>(tile_addr + fine_y * 2);
 
-		uint16_t tile_addr;
-		if (tiles_un)
-		{
-			// Unsigned mode — 0x8000 base.
-			tile_addr = static_cast<uint16_t>(tile_num * 16);
-		}
-		else
-		{
-			// Signed mode — 0x9000 base (= VRAM offset 0x1000).
-			tile_addr = static_cast<uint16_t>(0x1000 + static_cast<int8_t>(tile_num) * 16);
-		}
-		tile_addr = static_cast<uint16_t>(tile_addr + fine_y * 2);
-
-		const uint8_t lo = p.vram[tile_addr];
-		const uint8_t hi = p.vram[tile_addr + 1];
-		const uint8_t bit = static_cast<uint8_t>(7 - fine_x);
-		const uint8_t color_idx = static_cast<uint8_t>(
-			(((hi >> bit) & 1) << 1) | ((lo >> bit) & 1));
-
-		p.scanline_bg_raw[x] = color_idx;
-		p.scanline_raw[x]    = color_idx;   // raw for SGB $7800 capture
-		line_out[x]          = ApplyPalette(p.bgp, color_idx);
-	}
+	const uint8_t lo  = p.vram[tile_addr];
+	const uint8_t hi  = p.vram[tile_addr + 1];
+	const uint8_t bit = static_cast<uint8_t>(7 - fine_x);
+	return static_cast<uint8_t>((((hi >> bit) & 1) << 1) | ((lo >> bit) & 1));
 }
 
-void RenderWindow(Ppu &p, uint8_t *line_out)
+// Sample one window pixel using CURRENT registers. Caller has already
+// confirmed the pixel falls inside the window (x >= WX-7 and ly >= WY).
+inline uint8_t SampleWindowPixel(const Ppu &p, int x)
 {
-	// WX is offset by 7; WX=7 puts window at screen column 0.
-	// Values 0..6 and 166+ are unreliable on real HW; we render what we can.
-	const int wx = static_cast<int>(p.wx) - 7;
-	if (wx >= GB_SCREEN_WIDTH) return;
-
 	const uint16_t map_base = (p.lcdc & 0x40) ? 0x1C00 : 0x1800;
 	const bool     tiles_un = (p.lcdc & 0x10) != 0;
 	const uint32_t win_y    = static_cast<uint32_t>(p.window_line);
 	const uint32_t tile_row = win_y >> 3;
 	const uint32_t fine_y   = win_y & 7;
+	const int      wx       = static_cast<int>(p.wx) - 7;
+	const int      win_col  = x - wx;
+	const uint32_t tile_col = static_cast<uint32_t>(win_col) >> 3;
+	const uint32_t fine_x   = static_cast<uint32_t>(win_col) & 7;
 
-	const int start_x = (wx < 0) ? 0 : wx;
+	const uint8_t tile_num = p.vram[map_base + (tile_row * 32) + tile_col];
 
-	for (int x = start_x; x < GB_SCREEN_WIDTH; ++x)
-	{
-		const int      win_col  = x - wx;
-		const uint32_t tile_col = static_cast<uint32_t>(win_col) >> 3;
-		const uint32_t fine_x   = static_cast<uint32_t>(win_col) & 7;
+	uint16_t tile_addr;
+	if (tiles_un)
+		tile_addr = static_cast<uint16_t>(tile_num * 16);
+	else
+		tile_addr = static_cast<uint16_t>(0x1000 + static_cast<int8_t>(tile_num) * 16);
+	tile_addr = static_cast<uint16_t>(tile_addr + fine_y * 2);
 
-		const uint8_t tile_num = p.vram[map_base + (tile_row * 32) + tile_col];
-
-		uint16_t tile_addr;
-		if (tiles_un) tile_addr = static_cast<uint16_t>(tile_num * 16);
-		else          tile_addr = static_cast<uint16_t>(0x1000 + static_cast<int8_t>(tile_num) * 16);
-		tile_addr = static_cast<uint16_t>(tile_addr + fine_y * 2);
-
-		const uint8_t lo  = p.vram[tile_addr];
-		const uint8_t hi  = p.vram[tile_addr + 1];
-		const uint8_t bit = static_cast<uint8_t>(7 - fine_x);
-		const uint8_t color_idx = static_cast<uint8_t>(
-			(((hi >> bit) & 1) << 1) | ((lo >> bit) & 1));
-
-		p.scanline_bg_raw[x] = color_idx;
-		p.scanline_raw[x]    = color_idx;   // raw for SGB $7800 capture
-		line_out[x]          = ApplyPalette(p.bgp, color_idx);
-	}
+	const uint8_t lo  = p.vram[tile_addr];
+	const uint8_t hi  = p.vram[tile_addr + 1];
+	const uint8_t bit = static_cast<uint8_t>(7 - fine_x);
+	return static_cast<uint8_t>((((hi >> bit) & 1) << 1) | ((lo >> bit) & 1));
 }
 
-void RenderSprites(Ppu &p, uint8_t *line_out)
+// Pull a per-LY sprite list at mode 2 → mode 3. Up to 10 sprites in OAM
+// scan order (matches DMG hardware), pre-sorted by DMG draw priority
+// (lowest X first, ties by OAM index). Render-time uses this list to
+// answer "is there a sprite covering pixel x?" with a linear scan.
+void EvalSprites(Ppu &p)
 {
-	const bool    large     = (p.lcdc & 0x04) != 0;
-	const int     sprite_h  = large ? 16 : 8;
+	const bool large    = (p.lcdc & 0x04) != 0;
+	const int  sprite_h = large ? 16 : 8;
 
-	// OAM scan — up to 10 sprites overlapping this scanline.
-	struct Hit { int x; uint8_t oam_idx; };
-	Hit hits[10];
-	int hit_count = 0;
-
-	for (int i = 0; i < 40 && hit_count < 10; ++i)
+	p.sprite_count = 0;
+	for (int i = 0; i < 40 && p.sprite_count < 10; ++i)
 	{
-		const uint8_t oy = p.oam[i * 4 + 0];
-		const uint8_t ox = p.oam[i * 4 + 1];
-		const int top    = static_cast<int>(oy) - 16;
-		const int ly     = static_cast<int>(p.ly);
+		const uint8_t oy  = p.oam[i * 4 + 0];
+		const int     top = static_cast<int>(oy) - 16;
+		const int     ly  = static_cast<int>(p.ly);
 		if (ly < top || ly >= top + sprite_h) continue;
-		// OX of 0 or >= 168 still counts toward the 10-per-line cap but
-		// draws off-screen. We skip the pixel loop later.
-		hits[hit_count++] = { static_cast<int>(ox), static_cast<uint8_t>(i) };
+		const uint8_t ox = p.oam[i * 4 + 1];
+		Ppu::SpriteHit &h = p.sprites[p.sprite_count++];
+		h.x       = static_cast<int16_t>(static_cast<int>(ox) - 8);
+		h.oam_idx = static_cast<uint8_t>(i);
 	}
 
-	// DMG priority: lower X wins; tie breaks on lower OAM index. We draw
-	// in REVERSE priority order so higher-priority sprites overwrite.
-	// Simple insertion sort to keep this stable.
-	for (int i = 1; i < hit_count; ++i)
+	// DMG priority: lower X wins, ties by lower OAM index. Sort ascending
+	// (insertion sort, stable) so render-time picks the FIRST sprite that
+	// produces a non-zero pixel.
+	for (uint8_t i = 1; i < p.sprite_count; ++i)
 	{
-		Hit cur = hits[i];
-		int j = i;
+		Ppu::SpriteHit cur = p.sprites[i];
+		uint8_t j = i;
 		while (j > 0)
 		{
-			const Hit &prev = hits[j - 1];
+			const Ppu::SpriteHit &prev = p.sprites[j - 1];
 			const bool prev_higher_pri = (prev.x < cur.x) ||
 			                             (prev.x == cur.x && prev.oam_idx < cur.oam_idx);
 			if (prev_higher_pri) break;
-			hits[j] = hits[j - 1];
+			p.sprites[j] = p.sprites[j - 1];
 			--j;
 		}
-		hits[j] = cur;
+		p.sprites[j] = cur;
 	}
+}
 
-	// Render from lowest priority → highest, overwriting as we go.
-	for (int idx = hit_count - 1; idx >= 0; --idx)
+// Sample one sprite-covering-pixel value using CURRENT registers. Returns
+// {covered, sprite_color_2bit, sprite_palette_8bit, bg_priority} via out
+// args. covered=false means no sprite covers this pixel or all covering
+// sprites are color-0 (transparent).
+struct SpritePixel { bool covered; uint8_t color; uint8_t palette; bool bg_over; };
+
+SpritePixel SampleSpritePixel(const Ppu &p, int x)
+{
+	SpritePixel out{ false, 0, 0, false };
+	if (!(p.lcdc & 0x02)) return out;
+
+	const bool large    = (p.lcdc & 0x04) != 0;
+	const int  sprite_h = large ? 16 : 8;
+
+	// First sprite in priority order whose pixel at x is non-transparent wins.
+	for (uint8_t i = 0; i < p.sprite_count; ++i)
 	{
-		const uint8_t oi    = hits[idx].oam_idx;
+		const int sx = p.sprites[i].x;
+		if (x < sx || x >= sx + 8) continue;
+
+		const uint8_t oi    = p.sprites[i].oam_idx;
 		const uint8_t oy    = p.oam[oi * 4 + 0];
-		const uint8_t ox    = p.oam[oi * 4 + 1];
 		uint8_t       tile  = p.oam[oi * 4 + 2];
 		const uint8_t flags = p.oam[oi * 4 + 3];
 
 		int sprite_top = static_cast<int>(oy) - 16;
 		int tile_row   = static_cast<int>(p.ly) - sprite_top;
-		if (flags & 0x40) tile_row = sprite_h - 1 - tile_row;   // Y flip
+		if (flags & 0x40) tile_row = sprite_h - 1 - tile_row;
 
-		if (large) tile = static_cast<uint8_t>(tile & 0xFE);    // 8x16 mode: bit 0 of tile ignored
+		if (large) tile = static_cast<uint8_t>(tile & 0xFE);
 		const uint8_t sub_tile = static_cast<uint8_t>(tile + (tile_row / 8));
 		const int     fine_y   = tile_row & 7;
 
@@ -218,66 +214,91 @@ void RenderSprites(Ppu &p, uint8_t *line_out)
 		const uint8_t  lo        = p.vram[tile_addr];
 		const uint8_t  hi        = p.vram[tile_addr + 1];
 
-		const uint8_t palette   = (flags & 0x10) ? p.obp1 : p.obp0;
-		const bool    bg_over   = (flags & 0x80) != 0;
-		const int     screen_x  = static_cast<int>(ox) - 8;
+		const int     px        = x - sx;
+		const int     bit       = (flags & 0x20) ? px : (7 - px);
+		const uint8_t color_idx = static_cast<uint8_t>(
+			(((hi >> bit) & 1) << 1) | ((lo >> bit) & 1));
+		if (color_idx == 0) continue;   // transparent — try next sprite
 
-		for (int px = 0; px < 8; ++px)
+		out.covered  = true;
+		out.color    = color_idx;
+		out.palette  = (flags & 0x10) ? p.obp1 : p.obp0;
+		out.bg_over  = (flags & 0x80) != 0;
+		return out;
+	}
+	return out;
+}
+
+// Render exactly one pixel at p.draw_x for the current LY. Re-samples
+// every relevant register so mid-LY changes (SCX/SCY/BGP/LCDC/WX/etc.)
+// take effect at the right pixel, matching real hardware's per-dot
+// fetch behavior.
+void RenderPixel(Ppu &p)
+{
+	const int x = static_cast<int>(p.draw_x);
+	if (x < 0 || x >= GB_SCREEN_WIDTH) return;
+	if (p.ly >= GB_SCREEN_HEIGHT)      return;
+
+	uint8_t *const line = &p.framebuffer[p.ly * GB_SCREEN_WIDTH];
+
+	// BG / window resolve.
+	uint8_t bg_color = 0;   // raw 2-bit pre-palette
+	if (p.lcdc & 0x01)
+	{
+		const int wx = static_cast<int>(p.wx) - 7;
+		const bool win_active_here =
+			(p.lcdc & 0x20) != 0 &&
+			static_cast<int>(p.ly) >= static_cast<int>(p.wy) &&
+			x >= wx;
+
+		if (win_active_here)
 		{
-			const int x = screen_x + px;
-			if (x < 0 || x >= GB_SCREEN_WIDTH) continue;
-
-			const int     bit       = (flags & 0x20) ? px : (7 - px);   // X flip
-			const uint8_t color_idx = static_cast<uint8_t>(
-				(((hi >> bit) & 1) << 1) | ((lo >> bit) & 1));
-			if (color_idx == 0) continue;  // sprite color 0 = transparent
-
-			if (bg_over && p.scanline_bg_raw[x] != 0) continue;
-
-			p.scanline_raw[x] = color_idx;   // raw sprite pixel for SGB capture
-			line_out[x]       = ApplyPalette(palette, color_idx);
+			bg_color = SampleWindowPixel(p, x);
+			// Latch the "window did draw" state for window_line bookkeeping
+			// at end of LY.
+			if (!p.window_active)
+			{
+				p.window_active  = true;
+				p.window_start_x = static_cast<int16_t>(x);
+			}
 		}
+		else
+		{
+			bg_color = SampleBgPixel(p, x);
+		}
+	}
+
+	p.scanline_bg_raw[x] = bg_color;
+	p.scanline_raw[x]    = bg_color;
+	line[x]              = ApplyPalette(p.bgp, bg_color);
+
+	// Sprite resolve — overwrite if visible.
+	const SpritePixel sp = SampleSpritePixel(p, x);
+	if (sp.covered && (!sp.bg_over || bg_color == 0))
+	{
+		p.scanline_raw[x] = sp.color;
+		line[x]           = ApplyPalette(sp.palette, sp.color);
 	}
 }
 
-void RenderScanline(Ppu &p)
+// Called once at the mode 3 → HBlank transition (after all 160 pixels
+// have been emitted by RenderPixel). Snapshots the raw indices for the
+// SGB BIOS-less border-capture path and hands the post-palette LCD line
+// to the SGB ICD2 char-transfer ring. window_line advances only when the
+// window actually drew at least one pixel this LY (matches Pan Docs:
+// Window Internal Line Counter).
+void FinalizeScanline(Ppu &p)
 {
-	const uint32_t y = p.ly;
-	if (y >= GB_SCREEN_HEIGHT) return;
+	if (p.ly >= GB_SCREEN_HEIGHT) return;
 
-	uint8_t *const line = &p.framebuffer[y * GB_SCREEN_WIDTH];
+	uint8_t *const line = &p.framebuffer[p.ly * GB_SCREEN_WIDTH];
 
-	if (p.lcdc & 0x01)
-	{
-		RenderBG(p, line);
-
-		if ((p.lcdc & 0x20) && y >= p.wy)
-		{
-			RenderWindow(p, line);
-			++p.window_line;
-		}
-	}
-	else
-	{
-		// BG/window master off — fill with color 0 (post-palette).
-		std::memset(line,                 ApplyPalette(p.bgp, 0), GB_SCREEN_WIDTH);
-		std::memset(p.scanline_bg_raw, 0, GB_SCREEN_WIDTH);
-		std::memset(p.scanline_raw,    0, GB_SCREEN_WIDTH);
-	}
-
-	if (p.lcdc & 0x02) RenderSprites(p, line);
-
-	// Snapshot pre-palette raw indices for the SGB BIOS-less border
-	// capture path. End-of-frame, the capture decodes a 128x128 area
-	// from raw_framebuffer back into 4 KB of CHR_TRN/PCT_TRN bytes.
-	std::memcpy(&p.raw_framebuffer[y * GB_SCREEN_WIDTH],
+	std::memcpy(&p.raw_framebuffer[p.ly * GB_SCREEN_WIDTH],
 	            p.scanline_raw, GB_SCREEN_WIDTH);
-
-	// SGB BIOS-mode hook: capture post-BGP/OBP shade values (what the
-	// real GB's LCD would show). SameBoy's ICD pixel callback delivers
-	// the same — post-palette value 0-3 — and bsnes stores those
-	// directly as the "color" it shifts into $7800 bit-planes.
 	S9xSGBCaptureScanline(line);
+
+	if (p.window_active)
+		++p.window_line;
 }
 
 } // anonymous
@@ -300,10 +321,126 @@ void PpuReset(Ppu &p)
 	p.window_line   = 0;
 	p.stat_line_high = false;
 	p.frame_ready   = false;
+	p.t_cycles      = 0;
+	p.draw_x        = 0;
+	p.sprite_count  = 0;
+	p.window_active = false;
+	p.window_start_x = 0;
+}
+
+// One GB t-cycle's worth of PPU work. Drives mode 2 sprite eval (latched
+// at the mode 2→3 boundary), mode 3 per-pixel render (one pixel per dot,
+// re-sampling registers fresh — fixes mid-LY scroll/palette/LCDC tricks),
+// and mode 0/1 timing.
+inline void ExecPpuDot(Ppu &p, Memory &mem)
+{
+	p.mode_clock += 1;
+	bool transitioned = false;
+
+	switch (p.mode)
+	{
+	case PpuMode::OamScan:
+		if (p.mode_clock >= MODE2_DOTS)
+		{
+			p.mode_clock -= MODE2_DOTS;
+			p.mode        = PpuMode::Transfer;
+			// Latch the per-LY sprite list at mode 2→3 boundary, matching
+			// real-hw OAM-scan completion. Per-pixel sprite resolve in
+			// SampleSpritePixel uses this list.
+			EvalSprites(p);
+			p.draw_x        = 0;
+			p.window_active = false;
+			transitioned    = true;
+		}
+		break;
+
+	case PpuMode::Transfer:
+	{
+		// Render one pixel per dot. After 160 emitted, idle until the
+		// mode 3 budget elapses (constant 172 dots — fetcher penalties
+		// for sprites/window/SCX-fine are NOT modeled yet, follow-up).
+		if (p.draw_x < GB_SCREEN_WIDTH)
+		{
+			if (p.lcdc & 0x01)
+			{
+				RenderPixel(p);
+			}
+			else
+			{
+				// LCDC.0 cleared on DMG = BG/window OFF, force pixel 0.
+				// Sprites still composite on top.
+				const int x = static_cast<int>(p.draw_x);
+				p.scanline_bg_raw[x] = 0;
+				p.scanline_raw[x]    = 0;
+				p.framebuffer[p.ly * GB_SCREEN_WIDTH + x] =
+					ApplyPalette(p.bgp, 0);
+				const SpritePixel sp = SampleSpritePixel(p, x);
+				if (sp.covered)
+				{
+					p.scanline_raw[x] = sp.color;
+					p.framebuffer[p.ly * GB_SCREEN_WIDTH + x] =
+						ApplyPalette(sp.palette, sp.color);
+				}
+			}
+			++p.draw_x;
+		}
+		if (p.mode_clock >= MODE3_DOTS)
+		{
+			p.mode_clock -= MODE3_DOTS;
+			p.mode        = PpuMode::HBlank;
+			FinalizeScanline(p);
+			transitioned = true;
+		}
+		break;
+	}
+
+	case PpuMode::HBlank:
+		if (p.mode_clock >= MODE0_DOTS)
+		{
+			p.mode_clock -= MODE0_DOTS;
+			++p.ly;
+			S9xSGBOnPpuHBlank();
+			if (p.ly == VISIBLE_LINES)
+			{
+				p.mode          = PpuMode::VBlank;
+				p.frame_ready   = true;
+				p.window_line   = 0;
+				p.window_active = false;
+				mem.if_         = static_cast<uint8_t>(mem.if_ | IRQ_VBLANK);
+				S9xSGBOnPpuVBlank();
+			}
+			else
+			{
+				p.mode = PpuMode::OamScan;
+			}
+			transitioned = true;
+		}
+		break;
+
+	case PpuMode::VBlank:
+		if (p.mode_clock >= LINE_DOTS)
+		{
+			p.mode_clock -= LINE_DOTS;
+			++p.ly;
+			if (p.ly >= TOTAL_LINES)
+			{
+				p.ly   = 0;
+				p.mode = PpuMode::OamScan;
+			}
+			transitioned = true;
+		}
+		break;
+	}
+
+	if (transitioned)
+		RecomputeStatLine(p, mem);
 }
 
 void PpuStep(Ppu &p, Memory &mem, int32_t tcycles)
 {
+	if (tcycles <= 0) return;
+	p.t_cycles += tcycles;
+
 	// LCD master disable (LCDC bit 7). Real HW parks the PPU in mode 0
 	// with LY=0 until the bit toggles back on. We keep the framebuffer
 	// contents so the display keeps showing the last valid frame.
@@ -323,81 +460,15 @@ void PpuStep(Ppu &p, Memory &mem, int32_t tcycles)
 		p.mode_clock     = 0;
 		p.window_line    = 0;
 		p.stat_line_high = false;
-		// Zero the STAT mode + coincidence bits (low 3); keep the IRQ
-		// enable bits (4..6) because the game's register writes still
-		// work. Intentionally NOT raising IRQ_LCDSTAT.
+		p.draw_x         = 0;
+		p.window_active  = false;
 		p.stat = static_cast<uint8_t>(p.stat & 0xF8);
 		(void)mem;
 		return;
 	}
 
-	p.mode_clock += tcycles;
-
-	bool mode_changed = false;
-
-	switch (p.mode)
-	{
-	case PpuMode::OamScan:
-		if (p.mode_clock >= MODE2_DOTS)
-		{
-			p.mode_clock -= MODE2_DOTS;
-			p.mode        = PpuMode::Transfer;
-			// Render at mode-3 entry (simplification — see top-of-file note).
-			RenderScanline(p);
-			mode_changed = true;
-		}
-		break;
-
-	case PpuMode::Transfer:
-		if (p.mode_clock >= MODE3_DOTS)
-		{
-			p.mode_clock -= MODE3_DOTS;
-			p.mode        = PpuMode::HBlank;
-			mode_changed  = true;
-		}
-		break;
-
-	case PpuMode::HBlank:
-		if (p.mode_clock >= MODE0_DOTS)
-		{
-			p.mode_clock -= MODE0_DOTS;
-			++p.ly;
-			// bsnes ICD::ppuHreset equivalent — advance $6000 row/bank
-			// from GB PPU. Frozen while GB halted (callback only fires
-			// when GB actually ticks).
-			S9xSGBOnPpuHBlank();
-			if (p.ly == VISIBLE_LINES)
-			{
-				p.mode          = PpuMode::VBlank;
-				p.frame_ready   = true;
-				p.window_line   = 0;
-				mem.if_         = static_cast<uint8_t>(mem.if_ | IRQ_VBLANK);
-				S9xSGBOnPpuVBlank();  // bsnes ICD::ppuVreset
-			}
-			else
-			{
-				p.mode = PpuMode::OamScan;
-			}
-			mode_changed = true;
-		}
-		break;
-
-	case PpuMode::VBlank:
-		if (p.mode_clock >= LINE_DOTS)
-		{
-			p.mode_clock -= LINE_DOTS;
-			++p.ly;
-			if (p.ly >= TOTAL_LINES)
-			{
-				p.ly   = 0;
-				p.mode = PpuMode::OamScan;
-			}
-			mode_changed = true;
-		}
-		break;
-	}
-
-	if (mode_changed) RecomputeStatLine(p, mem);
+	while (tcycles-- > 0)
+		ExecPpuDot(p, mem);
 }
 
 uint8_t PpuReadReg(const Ppu &p, uint16_t addr)

--- a/sgb/gb_ppu.h
+++ b/sgb/gb_ppu.h
@@ -42,6 +42,33 @@ struct Ppu
 	PpuMode  mode = PpuMode::OamScan;
 	int32_t  mode_clock = 0;
 
+	// Per-pixel rendering state (mode-3 active draw).
+	// draw_x advances 0..160 across mode 3, one pixel per GB t-cycle dot.
+	// Each pixel re-samples SCX/SCY/BGP/OBP0/OBP1/LCDC/WX/WY so games that
+	// change those registers mid-scanline (Animaniacs cloud strip, Balloon
+	// Kid title parallax, others) render with the right per-pixel state
+	// instead of a single sample latched at mode-3 entry.
+	int16_t  draw_x = 0;
+
+	// Sprite list for the current LY, latched at mode 2 → mode 3 transition.
+	// Up to 10 sprites overlap a scanline; we pre-sort by render priority
+	// (lowest X first, ties by OAM index) so per-pixel coverage checks can
+	// be a linear scan against sprite_x[i] / sprite_x_end[i].
+	struct SpriteHit {
+		int16_t  x;        // OAM X-8 (screen-space leftmost pixel)
+		uint8_t  oam_idx;  // 0..39
+	};
+	SpriteHit sprites[10];
+	uint8_t   sprite_count    = 0;
+	bool      window_active   = false;   // window engaged on this LY
+	int16_t   window_start_x  = 0;       // x at which window engaged
+
+	// Monotonic GB t-cycle counter — advanced by PpuStep. Used by
+	// AdvanceMasterCycles (sgb.cpp) to drive PPU exactly to the SNES
+	// master-cycle target on each sync, decoupled from CPU instruction
+	// boundaries. Required for cycle-exact $6000 reads.
+	int64_t  t_cycles = 0;
+
 	// Internal window line counter — increments only on lines where the
 	// window was actually drawn, independent of LY (Pan Docs: Window
 	// Internal Line Counter).

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -182,6 +182,21 @@ struct Emulator::Impl
 		// counts since $60xx and $78xx share low nibbles).
 		uint32_t r_6000, r_6002, r_6003, r_600F, r_7000, r_7800;
 		uint32_t w_6000, w_6001, w_6003, w_7000, w_6004;
+
+		// Slice-rotation jitter defenses. The SGB BIOS is supposed to write
+		// $6001 exactly 18 times per frame (one per 8-row slice). At default
+		// SNES cycle settings our timing occasionally drifts by ±1 → BIOS
+		// writes 17 or 19 → slice rotation goes off → next frame's tile
+		// uploads land at the wrong vertical position (visible jitter).
+		// Mitigations: (a) clamp the rotation at 18 writes per frame; (b)
+		// phantom rotations at VBlank fill in any missing advances; (c)
+		// freeze_capture skips next frame's CaptureScanline so $7800 reads
+		// stream identical bytes — visually steady for one frame instead
+		// of jumping. Reset to 0 / false in OnPpuVBlank.
+		uint8_t  frame_6001_count;
+		uint8_t  frame_6001_bytes[24];
+		bool     freeze_capture;
+
 		uint16_t last_read_addr;
 		uint16_t last_write_addr;
 		uint8_t  last_write_val;
@@ -1150,13 +1165,18 @@ void Emulator::SetICD2(uint8_t value, uint16_t addr)
 		case 0x6001:
 			icd.lcd_row_select = value;
 			icd.read_position  = 0;
-			// Advance the slice-read counter. The BIOS issues $6001
-			// writes in order: slice 0, 1, …, 17, then wraps. We use
-			// THIS counter (not the bank field) to index the full_frame
-			// buffer, so each $7800 stream serves the correct slice
-			// regardless of bank-wrap.
-			icd.read_slice = static_cast<uint8_t>((icd.read_slice + 1) % 18);
-			icd.slice_index = static_cast<uint8_t>((icd.slice_index + 1) % 18);
+			// Slice-rotation clamp: only advance read_slice on the first
+			// 18 writes per frame. A 19th+ write parks at the last good
+			// position so over-count frames don't double-stream a slice
+			// and shift the slice→data mapping into the next frame.
+			if (icd.frame_6001_count < 18)
+			{
+				icd.read_slice  = static_cast<uint8_t>((icd.read_slice  + 1) % 18);
+				icd.slice_index = static_cast<uint8_t>((icd.slice_index + 1) % 18);
+			}
+			if (icd.frame_6001_count < 24)
+				icd.frame_6001_bytes[icd.frame_6001_count] = value;
+			++icd.frame_6001_count;
 			icd.row_writes++;
 			return;
 		case 0x6003:
@@ -1266,23 +1286,48 @@ void Emulator::OnPpuHBlank()
 void Emulator::OnPpuVBlank()
 {
 	if (!impl_) return;
-	// Reset row and bank at VBlank — see earlier comment for why both.
 	impl_->icd2.sgb_row  = 0;
 	impl_->icd2.sgb_bank = 0;
 
+	// Phantom rotations: if the BIOS under-counted (wrote $6001 fewer
+	// than 18 times), advance read_slice for the missing slices so the
+	// running total reaches 18 before the realign. Together with the
+	// over-count clamp in the $6001 write path this caps the per-frame
+	// rotation at exactly 18 regardless of how the BIOS actually wrote.
+	const uint8_t advances = (impl_->icd2.frame_6001_count < 18)
+	                         ? impl_->icd2.frame_6001_count
+	                         : static_cast<uint8_t>(18);
+	const uint8_t missing  = static_cast<uint8_t>(18 - advances);
+	for (uint8_t i = 0; i < missing; ++i)
+	{
+		impl_->icd2.read_slice  = static_cast<uint8_t>(
+			(impl_->icd2.read_slice  + 1) % 18);
+		impl_->icd2.slice_index = static_cast<uint8_t>(
+			(impl_->icd2.slice_index + 1) % 18);
+	}
+
 	// Force-realign read_slice to 16 per frame so the first $6001 write
 	// of the next frame always advances to slice 17 (the wrap-read).
-	// Without this, drift accumulates if any frame has !=18 $6001 writes
-	// (e.g., during handshake transitions or BIOS internal scheduling
-	// variation), producing the slow vertical scroll-up of the entire
-	// composited image.
 	impl_->icd2.read_slice = 16;
+
+	// Visual-freeze on off-count frames. CaptureScanline next frame is
+	// a no-op so full_frame retains last frame's data and BIOS $7800
+	// reads stream identical bytes — GB game area visually freezes for
+	// one frame instead of jumping. Self-clears at the next VBlank.
+	impl_->icd2.freeze_capture   = (impl_->icd2.frame_6001_count != 18);
+	impl_->icd2.frame_6001_count = 0;
 }
 
 void Emulator::CaptureScanline(const uint8_t *pixels)
 {
 	if (!impl_ || !pixels) return;
 	Emulator::Impl::Icd2 &icd = impl_->icd2;
+	// Visual-freeze for off-count frames: while freeze_capture is set,
+	// leave full_frame at the previous good frame's data so $7800 reads
+	// stream identical bytes and SNES VRAM uploads match the previous
+	// frame — visible jitter collapses to a one-frame freeze. Cleared
+	// at the next OnPpuVBlank.
+	if (icd.freeze_capture) return;
 	const uint8_t bank  = static_cast<uint8_t>(icd.sgb_bank & 0x03);
 	const uint8_t row   = static_cast<uint8_t>(icd.sgb_row  & 0x07);
 	const uint8_t slice = static_cast<uint8_t>((icd.sgb_row / 8) % 18);

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -183,19 +183,12 @@ struct Emulator::Impl
 		uint32_t r_6000, r_6002, r_6003, r_600F, r_7000, r_7800;
 		uint32_t w_6000, w_6001, w_6003, w_7000, w_6004;
 
-		// Slice-rotation jitter defenses. The SGB BIOS is supposed to write
-		// $6001 exactly 18 times per frame (one per 8-row slice). At default
-		// SNES cycle settings our timing occasionally drifts by ±1 → BIOS
-		// writes 17 or 19 → slice rotation goes off → next frame's tile
-		// uploads land at the wrong vertical position (visible jitter).
-		// Mitigations: (a) clamp the rotation at 18 writes per frame; (b)
-		// phantom rotations at VBlank fill in any missing advances; (c)
-		// freeze_capture skips next frame's CaptureScanline so $7800 reads
-		// stream identical bytes — visually steady for one frame instead
-		// of jumping. Reset to 0 / false in OnPpuVBlank.
+		// Per-frame $6001 write counter / byte log. Diagnostic only under
+		// the 4-bank protocol — slice-index defenses don't apply here
+		// (sgb_bank is GB-driven; W6001 wobble doesn't shift the protocol's
+		// data layout the way it did under 18-slice). Reset in OnPpuVBlank.
 		uint8_t  frame_6001_count;
 		uint8_t  frame_6001_bytes[24];
-		bool     freeze_capture;
 
 		uint16_t last_read_addr;
 		uint16_t last_write_addr;
@@ -1246,11 +1239,6 @@ void Emulator::OnPpuVBlank()
 	// finished; persisting _bank is what makes that signal work
 	// across frames.
 	impl_->icd2.sgb_row = 0;
-
-	// Visual-freeze on off-count frames carried forward from slice
-	// defenses. With 4-bank, freeze still skips lcd_ring writes so
-	// $7800 streams identical bytes from last frame.
-	impl_->icd2.freeze_capture   = (impl_->icd2.frame_6001_count != 18);
 	impl_->icd2.frame_6001_count = 0;
 }
 
@@ -1258,7 +1246,6 @@ void Emulator::CaptureScanline(const uint8_t *pixels)
 {
 	if (!impl_ || !pixels) return;
 	Emulator::Impl::Icd2 &icd = impl_->icd2;
-	if (icd.freeze_capture) return;
 	const uint8_t bank = static_cast<uint8_t>(icd.sgb_bank & 0x03);
 	const uint8_t row  = static_cast<uint8_t>(icd.sgb_row  & 0x07);
 	std::memcpy(&icd.lcd_ring[bank][row * 160], pixels, 160);

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -299,16 +299,6 @@ struct Emulator::Impl
 	                                // keep re-queuing handshake packets (which would
 	                                // block game-generated SGB commands).
 
-	// Cycle-debt accumulator for RunCycles. The per-opcode SyncToSnesCycle
-	// path in BIOS mode hands tiny tcycle requests (1-3 GB cycles) to
-	// RunCycles, but cpu.Step() always advances >=4 T-cycles (NOP min).
-	// Without a debt accumulator, every small request triggered a full
-	// step, over-running by ~2.5x → APU produced samples at ~98 kHz vs
-	// the host's 48 kHz drain, ring overflow, audible crackle. Now we
-	// only step when debt covers a full instruction; under-runs carry
-	// forward as positive debt; over-runs carry as negative debt.
-	int32_t  cycle_debt            = 0;
-
 	// Deferred CHR_TRN / PCT_TRN capture. Real SGB hardware reconstructs
 	// border tile/map data from the GB's LCD over multiple frames after
 	// the *_TRN packet — not from VRAM at packet completion. A direct
@@ -389,11 +379,6 @@ void Emulator::ColdReset()
 void Emulator::Reset()
 {
 	impl_->cpu.Reset();
-	// Drop any in-flight cycle debt — Reset semantically restarts the GB
-	// at t=0 so a stale negative/positive debt from before the reset has
-	// no meaning and would either freeze the GB (huge negative) or run
-	// it ahead by tens of cycles (positive) on the very first SyncToSnes.
-	impl_->cycle_debt = 0;
 	MemReset(impl_->mem);
 	PpuReset(impl_->ppu);
 	ApuReset(impl_->apu);
@@ -931,39 +916,42 @@ static void DecodeBorderCapture(const uint8_t *raw_fb, uint8_t *out_4kb)
 void Emulator::RunCycles(int32_t tcycles)
 {
 	if (!impl_->has_rom) return;
+	if (tcycles <= 0) return;
 
-	// Partial-frame advance. Used when a host driving its own clock wants
-	// to interleave GB execution with other work at finer granularity
-	// than one frame. cycle_debt absorbs the gap between requested cycles
-	// and the GB CPU's minimum step size — see Impl::cycle_debt comment.
-	impl_->cycle_debt += tcycles;
-	while (impl_->cycle_debt >= 4)
+	// Per-dot CPU/PPU interleaving. Advance PPU one t-cycle at a time;
+	// after each dot, run CPU as far as it can go without overshooting
+	// PPU. STAT IRQs raised by PPU mode transitions (HBlank entry, mode
+	// 2, LYC match) are serviced by CPU before PPU advances further, so
+	// games that update SCX/BGP/WX from the HBlank IRQ between scan-
+	// lines (Wario Land 2 cloud parallax, Balloon Fight title) have
+	// their new register value in place by the time PPU starts the next
+	// mode 3. cycle_debt is no longer needed — the per-dot model only
+	// steps CPU when it has kMaxOpcodeTCycles of headroom.
+	const int64_t target_t = impl_->ppu.t_cycles + tcycles;
+	while (impl_->ppu.t_cycles < target_t)
 	{
-		const bool was_boot = impl_->mem.boot_rom_enabled;
-		const int64_t pre_t = impl_->cpu.State().t_cycles;
-		impl_->cpu.Step(impl_->mem);
-		int32_t consumed = static_cast<int32_t>(
-			impl_->cpu.State().t_cycles - pre_t);
-		if (consumed <= 0) consumed = 4;
+		PpuStep(impl_->ppu, impl_->mem, 1);
 
-		// One-shot snapshot of GB CPU registers at the moment the
-		// boot ROM unmaps itself. That's the exact "post-boot,
-		// pre-cart" handoff state DK / Pokemon / etc. inspect to
-		// detect SGB1 vs SGB2 vs DMG. Persists across the rest of
-		// the run so the OSD always shows the handoff value, not
-		// whatever the running game has since clobbered.
-		if (was_boot && !impl_->mem.boot_rom_enabled &&
-		    !impl_->boot_handoff_captured)
+		while (impl_->cpu.State().t_cycles + kMaxOpcodeTCycles <=
+		       impl_->ppu.t_cycles)
 		{
-			impl_->boot_handoff_captured = true;
-			impl_->boot_handoff_regs     = impl_->cpu.State().r;
+			const bool was_boot = impl_->mem.boot_rom_enabled;
+			const int64_t pre_t = impl_->cpu.State().t_cycles;
+			impl_->cpu.Step(impl_->mem);
+			int32_t consumed = static_cast<int32_t>(
+				impl_->cpu.State().t_cycles - pre_t);
+			if (consumed <= 0) consumed = 4;
+
+			if (was_boot && !impl_->mem.boot_rom_enabled &&
+			    !impl_->boot_handoff_captured)
+			{
+				impl_->boot_handoff_captured = true;
+				impl_->boot_handoff_regs     = impl_->cpu.State().r;
+			}
+
+			TimerStep(impl_->timer, impl_->mem, consumed);
+			ApuStep  (impl_->apu,                consumed);
 		}
-
-		PpuStep  (impl_->ppu,   impl_->mem, consumed);
-		TimerStep(impl_->timer, impl_->mem, consumed);
-		ApuStep  (impl_->apu,                consumed);
-
-		impl_->cycle_debt -= consumed;
 	}
 
 	if (impl_->border_capture.stage != Impl::BorderCapture::Idle &&
@@ -1768,10 +1756,6 @@ bool Emulator::StateLoad(const uint8_t *buffer, size_t size)
 	impl_->apu.sample_head      = 0;
 	impl_->apu.sample_tail      = 0;
 	impl_->apu.sample_timer     = impl_->apu.cycles_per_sample;
-
-	// cycle_debt is transient — reset on load so a stale debt from
-	// before the snapshot doesn't burst-step the GB.
-	impl_->cycle_debt           = 0;
 
 	// Rebuild full_frame_planar from full_frame. The planar mirror is a
 	// derived view; if a snapshot from before this field existed gets

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -700,6 +700,18 @@ void Emulator::RunFrame()
 	const int32_t  budget    = static_cast<int32_t>(per_frame);
 
 	RunCycles(budget);
+
+	// Always end at VBlank entry so BlitScreen reads a complete framebuffer.
+	// Fixed budget alone drifts the render position out of VBlank every few
+	// calls (SGB1 overshoots ~2.77 lines/call; SGB2/DMG undershoot ~0.95
+	// lines/call), tearing the displayed image and depositing mid-frame
+	// palette/attr packets onto a half-rendered buffer.
+	int32_t safety = 70224;
+	while (!impl_->ppu.frame_ready && safety > 0)
+	{
+		RunCycles(456);
+		safety -= 456;
+	}
 }
 
 // ===================================================================
@@ -968,7 +980,9 @@ void Emulator::RunCycles(int32_t tcycles)
 		                 impl_->border_capture.pkt, 16,
 		                 decoded, impl_->ppu.framebuffer);
 		impl_->border_capture.stage = Impl::BorderCapture::Idle;
-		impl_->ppu.frame_ready      = false;
+		// Don't clear frame_ready here — RunFrame's run-to-vblank loop
+		// reads it to know the frame completed. The tail can't re-fire
+		// because stage is now Idle.
 	}
 }
 
@@ -1748,13 +1762,14 @@ bool Emulator::StateLoad(const uint8_t *buffer, size_t size)
 	impl_->mem.joypad = &impl_->joypad;
 	impl_->mem.cart   = &impl_->cart;
 
-	// Reset transient audio output state — the ring buffer content is
-	// not serialized because it's sub-frame scratch.
+	// Reset only the sub-sample integration accumulator. The ring buffer
+	// is not serialized but also not wiped — it stays at its current
+	// in-memory positions so already-queued samples keep playing across
+	// the load. Wiping it on every load broke runahead audio (the hidden
+	// frame's samples were discarded each iteration).
 	impl_->apu.sample_accum_l   = 0;
 	impl_->apu.sample_accum_r   = 0;
 	impl_->apu.sample_accum_cnt = 0;
-	impl_->apu.sample_head      = 0;
-	impl_->apu.sample_tail      = 0;
 	impl_->apu.sample_timer     = impl_->apu.cycles_per_sample;
 
 	// Rebuild full_frame_planar from full_frame. The planar mirror is a
@@ -1928,28 +1943,11 @@ void S9xSGBOverlayBiosBorder(uint16_t *dest, uint32_t pitch_pixels)
 
 int32_t S9xSGBGetSampleCount(void)
 {
-	int32_t count = SGB::Instance().GetAudioSamplesAvailable();
-	// Cap depends on which audio drive cadence is active:
-	//   BIOS-less SGB — ProcessSound is called once per SNES frame
-	//   from cpuexec's SuperGameBoy branch. avail per call should be
-	//   ~one full frame's worth of samples; otherwise ProcessSound
-	//   under-drains and audio queue underruns into gibberish.
-	//   Cap = output_rate × 2 / 60 = 1600 at 48 kHz (one NTSC frame).
-	//
-	//   BIOS mode — SPC scanline driver fires ProcessSound ~33/frame.
-	//   avail per call is per-call drain, much smaller. Cap tuned
-	//   empirically (~381 at 48 kHz) to land emulation at 60 fps wall
-	//   without over-throttling. See commit log for the binary search.
-	const int32_t out_rate = SGB::Instance().GetAudioSampleRate();
-	int32_t       cap;
-	if (Settings.SGB_BIOSModeActive)
-		cap = (out_rate * 2) / 252;  // ~381 at 48k
-	else
-		cap = (out_rate * 2) / 60;   // 1600 at 48k (BIOS-less)
-	if (cap < 64)   cap = 64;
-	if (cap > 6000) cap = 6000;
-	if (count > cap) count = cap;
-	return count;
+	// Hand the host whatever the GB APU has produced. S9xMixSamples is
+	// already bounded by the host's per-call sample_count request, so no
+	// internal cap is needed; capping here just starves hosts whose audio
+	// buffer cadence differs from ours.
+	return SGB::Instance().GetAudioSamplesAvailable();
 }
 
 int32_t S9xSGBDrainSamples(int16_t *dest, int32_t count_int16s)

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -242,13 +242,6 @@ struct Emulator::Impl
 		uint8_t  synth_remaining;    // packets yet to hand out (6 → 0)
 		uint8_t  drain_ptr;          // bytes read of current packet (0..15)
 
-		// P2d — framebuffer char-transfer for $7800. The SGB BIOS reads
-		// 320 bytes per bank (8 rows × 20 tiles × 2 bit-planes) to
-		// reconstruct a 160×8 slice of the GB screen. 144 scanlines /
-		// 8 = 18 full slices per frame, so we advance an 18-slot slice
-		// index on each $6001 write.
-		uint8_t  slice_index;        // 0..17 — which 8-row band of the GB frame
-
 		// $6000 row/bank counters (Mesen2-style). Advanced by GB PPU
 		// scanline events: sgb_row++ on each HBlank end (mode 0 → OAM
 		// scan for line 1..143), sgb_bank advances every 8 rows, and
@@ -257,46 +250,11 @@ struct Emulator::Impl
 		uint8_t  sgb_bank;
 
 		// Per-pixel capture ring — 4 banks × 8 rows × 160 pixels (palette
-		// indices 0..3). The GB PPU's renderer calls S9xSGBCaptureScanline
-		// after drawing each visible line, which writes into bank[sgb_bank]
-		// at row (sgb_row & 7). Matches bsnes/Mesen2 layout but only used
-		// as a transitional buffer; $7800 reads from full_frame instead
-		// (see below).
+		// indices 0..3). Mesen2 SuperGameboy::WriteLcdColor writes into
+		// _lcdBuffer[_bank][(_row & 7) * 160 + pixel] from the GB PPU
+		// renderer; $7800 reads decode planar bytes inline from this
+		// buffer (live, no snapshot).
 		uint8_t  lcd_ring[4][8 * 160];
-
-		// Full 18-slice frame buffer. Each scanline N is captured into
-		// full_frame[N/8][N%8] without bank-wrap overwrite, so all 18
-		// slices (rows 0-7, 8-15, ..., 136-143) are simultaneously
-		// addressable.
-		uint8_t  full_frame[18][8 * 160];
-
-		// BIOS's $6001-write sequence counter. The BIOS writes $6001
-		// once per slice in order (slice 0, 1, ..., 17, then wraps).
-		// We track this independently of the bank value the BIOS
-		// writes, so $7800 reads map to the actual slice the BIOS is
-		// requesting — fixing the bank-wrap ambiguity (BIOS reads bank
-		// 3 at frame-end-wrap expecting slice 17, not slice 15 which
-		// happens to be in bank 3 at that moment).
-		uint8_t  read_slice;          // 0..17, current slice being read
-
-		// Snapshot of the selected bank at the moment $6001 was written.
-		// $7800 reads from this snapshot (not the live lcd_ring), so the
-		// BIOS gets a stable view of the bank even if the GB overwrites
-		// it while the BIOS is mid-DMA. Without this, a bank whose rows
-		// are concurrently being re-drawn (slice 4 overwrites slice 0's
-		// bank 0, for instance) reads as a mix of two slices and produces
-		// horizontally-banded tile corruption in CHR_TRN output.
-		uint8_t  r7800_snapshot[8 * 160];
-
-		// Pre-computed bit-planar layout of full_frame, in the exact
-		// byte order $7800 reads expect (8 rows × 20 tiles × 2 planes
-		// = 320 bytes per slice). Produced incrementally by Capture-
-		// Scanline so that GetICD2's $7800 path is a single byte load
-		// instead of an 8-iteration bit-extraction loop. The SGB BIOS
-		// in-game menu reads this window at 5760 bytes/frame to embed
-		// the GB screen inside the menu — that's 345k extractions/sec
-		// in the old code.
-		uint8_t  full_frame_planar[18][320];
 	} icd2;
 
 	// Cache of the first 6 packets bit-banged by the GB boot ROM. The
@@ -407,17 +365,10 @@ void Emulator::Reset()
 	impl_->boot_handoff_regs     = {};
 	IrqServicedReset();
 	std::memset(&impl_->icd2, 0, sizeof impl_->icd2);
-	// $7800 capture ring starts as $FF (matches bsnes `output[2048]=0xFF`).
-	std::memset(impl_->icd2.lcd_ring, 0xFF, sizeof impl_->icd2.lcd_ring);
-	// $7800 snapshot buffer also $FF so early reads (before any $6001
-	// write) return open-bus-like all-ones rather than stale pixels.
-	std::memset(impl_->icd2.r7800_snapshot, 0xFF, sizeof impl_->icd2.r7800_snapshot);
+	// 4-bank LCD ring starts at $00 (matches Mesen2 SuperGameboy::Reset).
 	// $7000-$700F latch buffer starts as $FF so reads before the first
 	// $6002 pop return all-ones (matches bsnes r7000 power-on state).
 	std::memset(impl_->icd2.r7000_buf, 0xFF, sizeof impl_->icd2.r7000_buf);
-	// Init read_slice to 17 so the first $6001 write advances it to
-	// 0 (slice 0 — what the BIOS expects on its first drain).
-	impl_->icd2.read_slice = 17;
 	// Joypad registers idle = $FF (active-low, no buttons held).
 	// bsnes r6004-r6007 = 0xff. Initializing to 0 makes the GB see all
 	// buttons held and the SGB BIOS's probe sequences fail. Critical.
@@ -1080,21 +1031,26 @@ uint8_t Emulator::GetICD2(uint16_t addr)
 		if (pos >= 320)
 			return 0xFF;
 
-		// Pre-computed in CaptureScanline — see Impl::Icd2::full_frame_planar.
-		const uint8_t slice = icd.read_slice % 18;
-		return icd.full_frame_planar[slice][pos];
+		const uint8_t bank  = static_cast<uint8_t>(icd.lcd_row_select & 0x03);
+		const uint8_t row   = static_cast<uint8_t>((pos >> 1) & 0x07);
+		const uint8_t col   = static_cast<uint8_t>(pos >> 4);
+		const uint8_t shift = static_cast<uint8_t>(pos & 0x01);
+		const uint8_t *src  = &icd.lcd_ring[bank][row * 160 + col * 8];
+		uint8_t data = 0;
+		for (int i = 0; i < 8; ++i)
+			data |= static_cast<uint8_t>(((src[i] >> shift) & 0x01) << (7 - i));
+		return data;
 	}
 
 	switch (a)
 	{
 		case 0x6000:
-			// bsnes `io.cpp`: `vcounter & ~7 | writeBank` — the low bits
-			// are the latched $6001 bank value (the BIOS's *request*),
-			// NOT our scanline-derived sgb_bank. Before the BIOS writes
-			// $6001 (early handshake) these bits must read zero, matching
-			// real hardware / bsnes. Upper bits are GB LY masked — includes
-			// VBlank lines 144..153, so during VBlank $6000 = 0x90 | bank.
-			return static_cast<uint8_t>((impl_->ppu.ly & 0xF8) | (icd.lcd_row_select & 0x03));
+			// Mesen2 SuperGameboy.cpp: `(_row & ~0x07) | _bank` — high bits
+			// are the GB-driven row counter, low bits are the GB-driven
+			// bank counter (cycles 0→1→2→3→0 every 8 GB scanlines). The
+			// BIOS uses the bank rotation to detect when a fresh bank is
+			// ready to drain.
+			return static_cast<uint8_t>((icd.sgb_row & 0xF8) | (icd.sgb_bank & 0x03));
 		case 0x6002:
 		{
 			// Lazy-stage the next synth packet if queue's empty (no-op
@@ -1163,17 +1119,8 @@ void Emulator::SetICD2(uint8_t value, uint16_t addr)
 	switch (a)
 	{
 		case 0x6001:
-			icd.lcd_row_select = value;
+			icd.lcd_row_select = static_cast<uint8_t>(value & 0x03);
 			icd.read_position  = 0;
-			// Slice-rotation clamp: only advance read_slice on the first
-			// 18 writes per frame. A 19th+ write parks at the last good
-			// position so over-count frames don't double-stream a slice
-			// and shift the slice→data mapping into the next frame.
-			if (icd.frame_6001_count < 18)
-			{
-				icd.read_slice  = static_cast<uint8_t>((icd.read_slice  + 1) % 18);
-				icd.slice_index = static_cast<uint8_t>((icd.slice_index + 1) % 18);
-			}
 			if (icd.frame_6001_count < 24)
 				icd.frame_6001_bytes[icd.frame_6001_count] = value;
 			++icd.frame_6001_count;
@@ -1278,42 +1225,31 @@ void Emulator::OnPpuHBlank()
 	if (!impl_) return;
 	Emulator::Impl::Icd2& icd = impl_->icd2;
 
-	// Restored normal mapping. Trying a different empirical tweak elsewhere.
-	icd.sgb_row = impl_->ppu.ly;
-	icd.sgb_bank = (icd.sgb_row / 8) & 0x03;
+	// Mesen2 ProcessHBlank: `_row++; if((_row & 7) == 0) _bank = (_bank + 1) & 3;`
+	// Incremental advance — sgb_bank is intentionally NOT re-derived from
+	// sgb_row each call, so it persists across frames. 18 advances per
+	// frame × 4-bank wrap = phase shifts every 2 frames (the BIOS uses
+	// $6000's low bits to detect when a fresh band lands in a new bank).
+	icd.sgb_row = static_cast<uint8_t>(icd.sgb_row + 1);
+	if ((icd.sgb_row & 0x07) == 0)
+		icd.sgb_bank = static_cast<uint8_t>((icd.sgb_bank + 1) & 0x03);
 }
 
 void Emulator::OnPpuVBlank()
 {
 	if (!impl_) return;
-	impl_->icd2.sgb_row  = 0;
-	impl_->icd2.sgb_bank = 0;
+	// Mesen2 ProcessVBlank: just `_row = 0;`. _bank is intentionally
+	// NOT reset — it persists across frames, so the bank-to-band
+	// mapping shifts each frame (frame 1 starts at bank 0, frame 2
+	// starts at bank 2 because 18 % 4 = 2). The SNES BIOS reads
+	// $6000's low bits to know which bank holds the band that just
+	// finished; persisting _bank is what makes that signal work
+	// across frames.
+	impl_->icd2.sgb_row = 0;
 
-	// Phantom rotations: if the BIOS under-counted (wrote $6001 fewer
-	// than 18 times), advance read_slice for the missing slices so the
-	// running total reaches 18 before the realign. Together with the
-	// over-count clamp in the $6001 write path this caps the per-frame
-	// rotation at exactly 18 regardless of how the BIOS actually wrote.
-	const uint8_t advances = (impl_->icd2.frame_6001_count < 18)
-	                         ? impl_->icd2.frame_6001_count
-	                         : static_cast<uint8_t>(18);
-	const uint8_t missing  = static_cast<uint8_t>(18 - advances);
-	for (uint8_t i = 0; i < missing; ++i)
-	{
-		impl_->icd2.read_slice  = static_cast<uint8_t>(
-			(impl_->icd2.read_slice  + 1) % 18);
-		impl_->icd2.slice_index = static_cast<uint8_t>(
-			(impl_->icd2.slice_index + 1) % 18);
-	}
-
-	// Force-realign read_slice to 16 per frame so the first $6001 write
-	// of the next frame always advances to slice 17 (the wrap-read).
-	impl_->icd2.read_slice = 16;
-
-	// Visual-freeze on off-count frames. CaptureScanline next frame is
-	// a no-op so full_frame retains last frame's data and BIOS $7800
-	// reads stream identical bytes — GB game area visually freezes for
-	// one frame instead of jumping. Self-clears at the next VBlank.
+	// Visual-freeze on off-count frames carried forward from slice
+	// defenses. With 4-bank, freeze still skips lcd_ring writes so
+	// $7800 streams identical bytes from last frame.
 	impl_->icd2.freeze_capture   = (impl_->icd2.frame_6001_count != 18);
 	impl_->icd2.frame_6001_count = 0;
 }
@@ -1322,40 +1258,10 @@ void Emulator::CaptureScanline(const uint8_t *pixels)
 {
 	if (!impl_ || !pixels) return;
 	Emulator::Impl::Icd2 &icd = impl_->icd2;
-	// Visual-freeze for off-count frames: while freeze_capture is set,
-	// leave full_frame at the previous good frame's data so $7800 reads
-	// stream identical bytes and SNES VRAM uploads match the previous
-	// frame — visible jitter collapses to a one-frame freeze. Cleared
-	// at the next OnPpuVBlank.
 	if (icd.freeze_capture) return;
-	const uint8_t bank  = static_cast<uint8_t>(icd.sgb_bank & 0x03);
-	const uint8_t row   = static_cast<uint8_t>(icd.sgb_row  & 0x07);
-	const uint8_t slice = static_cast<uint8_t>((icd.sgb_row / 8) % 18);
-
-	// Legacy 4-bank ring (kept for state-save compatibility).
+	const uint8_t bank = static_cast<uint8_t>(icd.sgb_bank & 0x03);
+	const uint8_t row  = static_cast<uint8_t>(icd.sgb_row  & 0x07);
 	std::memcpy(&icd.lcd_ring[bank][row * 160], pixels, 160);
-	// Full 18-slice buffer — what $7800 actually reads from.
-	if (slice < 18)
-	{
-		std::memcpy(&icd.full_frame[slice][row * 160], pixels, 160);
-		// Update the planar mirror for this row (40 bytes: 20 tiles × 2
-		// bit-planes). Cost: 20 × 8 ops per scanline = ~28k ops/sec
-		// vs the millions of bit-extraction ops the read path was doing.
-		uint8_t *out = &icd.full_frame_planar[slice][row * 2];
-		for (int t = 0; t < 20; ++t)
-		{
-			const uint8_t *p = &pixels[t * 8];
-			uint8_t plane0 = 0, plane1 = 0;
-			for (int i = 0; i < 8; ++i)
-			{
-				const uint8_t pix = static_cast<uint8_t>(p[i] & 0x03);
-				plane0 = static_cast<uint8_t>(plane0 | (((pix >> 0) & 1) << (7 - i)));
-				plane1 = static_cast<uint8_t>(plane1 | (((pix >> 1) & 1) << (7 - i)));
-			}
-			out[t * 16 + 0] = plane0;
-			out[t * 16 + 1] = plane1;
-		}
-	}
 }
 
 static inline uint16_t BgrToHost(uint16_t bgr)
@@ -1816,32 +1722,6 @@ bool Emulator::StateLoad(const uint8_t *buffer, size_t size)
 	impl_->apu.sample_accum_r   = 0;
 	impl_->apu.sample_accum_cnt = 0;
 	impl_->apu.sample_timer     = impl_->apu.cycles_per_sample;
-
-	// Rebuild full_frame_planar from full_frame. The planar mirror is a
-	// derived view; if a snapshot from before this field existed gets
-	// loaded the planar buffer would be zeroed and $7800 reads would
-	// return zeros until the next GB scanline capture overwrites it.
-	for (int s = 0; s < 18; ++s)
-	{
-		for (int r = 0; r < 8; ++r)
-		{
-			uint8_t *out = &impl_->icd2.full_frame_planar[s][r * 2];
-			const uint8_t *row = &impl_->icd2.full_frame[s][r * 160];
-			for (int t = 0; t < 20; ++t)
-			{
-				const uint8_t *p = &row[t * 8];
-				uint8_t plane0 = 0, plane1 = 0;
-				for (int i = 0; i < 8; ++i)
-				{
-					const uint8_t pix = static_cast<uint8_t>(p[i] & 0x03);
-					plane0 = static_cast<uint8_t>(plane0 | (((pix >> 0) & 1) << (7 - i)));
-					plane1 = static_cast<uint8_t>(plane1 | (((pix >> 1) & 1) << (7 - i)));
-				}
-				out[t * 16 + 0] = plane0;
-				out[t * 16 + 1] = plane1;
-			}
-		}
-	}
 
 	// Re-point the exposed FrameBuffer at the (now-restored) PPU fb.
 	impl_->fb.pixels = impl_->ppu.framebuffer;


### PR DESCRIPTION
## Summary

Brings the working pieces from the `sbg_fixes` branch onto master while leaving out libco. Through bisection we found that:
- libco was **not** needed — master's per-scanline + per-ICD2-access sync model is sufficient.
- The 4-bank ICD2 protocol works fine on master's timing (the original bundled `e0822d59` commit on `sbg_fixes` was misattributed to libco).
- Per-opcode SNES→GB sync is incompatible with our per-dot RunCycles model and was reverted.

## What this fixes

- **Animaniacs cloud strip / Balloon Kid title parallax** — per-pixel PPU rendering re-samples SCX/SCY/BGP/LCDC/WX/WY at each dot.
- **Wario Land 2 / Balloon Fight color streaks** — per-dot CPU/PPU interleaving in RunCycles services HBlank-IRQ SCX writes before PPU advances further.
- **BIOS-mode frame jumps in Pokemon Red etc.** — Mesen2 4-bank protocol persists sgb_bank across frames so the bank-to-band phase shifts naturally without slice-rotation drift.
- **Tearing on hosts where RunFrame budget drifts out of VBlank** — RunFrame now spins to vblank past the cycle budget.
- **DK title at half FPS** — don't clear frame_ready after border capture (run-to-vblank loop reads it).
- **Audio gibberish on hosts with non-default audio buffer cadence** — drop the empirical S9xSGBGetSampleCount cap.
- **Runahead audio + double-present** — don't wipe sample ring on StateLoad; skip blit/present during Settings.InRunAhead.

## Test plan

- [x] Pokemon Red — boots clean, runs at 70fps, no jumps, no flashing.
- [x] Wario Land 2 — no streaks.
- [x] Balloon Fight — no streaks.
- [x] Animaniacs — cloud strip renders correctly.
- [x] Tetris / DK — no regressions vs master.