### PR TITLE
New sgb fixes

### DIFF
--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -1296,21 +1296,25 @@ void Emulator::OnPpuVBlank()
 	    impl_->has_rom && impl_->cart.header.sgb_flag == 0x03;
 	const bool cgb_enhanced =
 	    impl_->has_rom && impl_->cart.header.cgb_flag != 0;
+	const bool border_installed =
+	    impl_->sgb_state.border.tiles_loaded &&
+	    impl_->sgb_state.border.map_loaded;
+	const bool skip_bg3_wipe = cgb_enhanced || border_installed;
 	if (impl_->boot_handoff_captured && sgb_enhanced)
 	{
 		if (impl_->handoff_frames < 30)
 		{
 			std::memset(&::Memory.VRAM[0x7000], 0, 0x0800);
-			if (!cgb_enhanced)
+			if (!skip_bg3_wipe)
 			{
-				std::memset(&::Memory.VRAM[0xE000], 0, 0x2000);
+				std::memset(&::Memory.VRAM[0xE000], 0, 0x1680);
 				std::memset(::PPU.OAMData, 0, sizeof ::PPU.OAMData);
 			}
 		}
 		impl_->handoff_frames++;
 	}
 
-	if (impl_->boot_handoff_captured && sgb_enhanced && !cgb_enhanced)
+	if (impl_->boot_handoff_captured && sgb_enhanced && !skip_bg3_wipe)
 	{
 		static const uint8_t kBiosStagedSig[16] = {
 			0x01, 0x10, 0x02, 0x10, 0x03, 0x10, 0x04, 0x10,

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -1244,6 +1244,12 @@ bool Emulator::IsHandshakePending() const
 	return impl_->icd2.synth_remaining > 0 || impl_->icd2.queue_count > 0;
 }
 
+bool Emulator::IsBootHandoffCaptured() const
+{
+	if (!impl_) return false;
+	return impl_->boot_handoff_captured;
+}
+
 void Emulator::OnPpuHBlank()
 {
 	if (!impl_) return;
@@ -2139,6 +2145,11 @@ bool S9xSGBBIOSGBIsReleased(void)
 bool S9xSGBBIOSHandshakePending(void)
 {
 	return SGB::Instance().IsHandshakePending();
+}
+
+bool S9xSGBBootHandoffCaptured(void)
+{
+	return SGB::Instance().IsBootHandoffCaptured();
 }
 
 bool S9xSGBGetROMBytes(const unsigned char **out_data, size_t *out_size)

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -1288,23 +1288,23 @@ void Emulator::OnPpuVBlank()
 	// TODO: add libco for better GB-SNES sync and remove this hack.
 	const bool sgb_enhanced =
 	    impl_->has_rom && impl_->cart.header.sgb_flag == 0x03;
+	const bool cgb_enhanced =
+	    impl_->has_rom && impl_->cart.header.cgb_flag != 0;
 	if (impl_->boot_handoff_captured && sgb_enhanced)
 	{
 		if (impl_->handoff_frames < 30)
 		{
 			std::memset(&::Memory.VRAM[0x7000], 0, 0x0800);
-			std::memset(&::Memory.VRAM[0xE000], 0, 0x2000);
-			std::memset(::PPU.OAMData, 0, sizeof ::PPU.OAMData);
+			if (!cgb_enhanced)
+			{
+				std::memset(&::Memory.VRAM[0xE000], 0, 0x2000);
+				std::memset(::PPU.OAMData, 0, sizeof ::PPU.OAMData);
+			}
 		}
 		impl_->handoff_frames++;
 	}
 
-	// Suppress visible artifact at the BIOS fade-in moment without touching
-	// unrelated VRAM regions. Same SGB-enhanced gating as above — plain GB
-	// carts don't go through the BIOS fade-in path that produces this
-	// artifact, and we never want to zero BG3 on them.
-	// TODO: add libco for better sync and remove this hack.
-	if (impl_->boot_handoff_captured && sgb_enhanced)
+	if (impl_->boot_handoff_captured && sgb_enhanced && !cgb_enhanced)
 	{
 		static const uint8_t kBiosStagedSig[16] = {
 			0x01, 0x10, 0x02, 0x10, 0x03, 0x10, 0x04, 0x10,

--- a/sgb/sgb.h
+++ b/sgb/sgb.h
@@ -161,6 +161,8 @@ public:
 	// True while synth handshake packets are still pending drain.
 	bool    IsHandshakePending() const;
 
+	bool    IsBootHandoffCaptured() const;
+
 	// GB PPU scanline event hooks for SGB row/bank counter advance.
 	void    OnPpuHBlank();
 	void    OnPpuVBlank();
@@ -345,6 +347,8 @@ bool          S9xSGBBIOSGBIsReleased (void);
 // real GB packets must not clobber a pending synth packet before the
 // BIOS reads it, so the GB is paused until the handshake drains out.
 bool          S9xSGBBIOSHandshakePending (void);
+
+bool          S9xSGBBootHandoffCaptured (void);
 
 // ---- Integration hooks for RetroAchievements -------------------------------
 // Expose the loaded GB ROM so the platform can hash it under the GameBoy /

--- a/win32/CXAudio2.cpp
+++ b/win32/CXAudio2.cpp
@@ -540,8 +540,8 @@ static void MixSpcOverGB(uint8 *dest, int sample_words)
     int i = 0;
     for (; i < n; ++i)
     {
-        int32_t gb  = ((int32_t)out16[i]   * GB_GAIN_Q8)  >> 8;
-        int32_t spc = ((int32_t)spc_buf[i] * SPC_GAIN_Q8) >> 8;
+        int32_t gb    = ((int32_t)out16[i]   * GB_GAIN_Q8)  >> 8;
+        int32_t spc   = ((int32_t)spc_buf[i] * SPC_GAIN_Q8) >> 8;
         int32_t mixed = gb + spc;
         if (mixed >  32767) mixed =  32767;
         if (mixed < -32768) mixed = -32768;
@@ -554,6 +554,17 @@ static void MixSpcOverGB(uint8 *dest, int sample_words)
         if (gb < -32768) gb = -32768;
         out16[i] = (int16_t)gb;
     }
+
+    // Silence the SPC-over-GB mix until the GB completes its boot ROM
+    // (writes $FF50 → boot_handoff_captured). Bridges the audible click
+    // between BIOS-released and the GB taking over the audio path —
+    // the click sample stayed in DSound's queue from the pre-release
+    // SPC stream and emerged after the mix path switched, so neither
+    // muting GB nor SPC individually killed it. Zeroing the post-mix
+    // output through this window is the only thing that does.
+    if (!S9xSGBBootHandoffCaptured())
+        memset(out16, 0, sample_words * sizeof(int16_t));
+
     S9xAudioWaveformPushMix(out16, frames);
 }
 


### PR DESCRIPTION
- FIx residual spc=>mix audio after the SGB chime animation by silencing the tail.
- Fix an issue where BG3 tiles were  overriden, causing regression in games.