### PR TITLE
qt+gtk: mix SPC over GB after S9xMixSamples in SGB BIOS mode

### DIFF
--- a/apu/apu.cpp
+++ b/apu/apu.cpp
@@ -375,6 +375,53 @@ void S9xAudioWaveformPushMix(const int16_t *src, int frames)
     audiowave::push(audiowave::buf_mix, audiowave::wpos_mix, src, frames);
 }
 
+void S9xMixSpcOverGB(int16_t *dest, int sample_count)
+{
+    if (!dest || sample_count <= 0) return;
+
+    const bool sgb_bios_mix = Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased();
+    const int frames = sample_count / 2;
+
+    if (!sgb_bios_mix)
+    {
+        S9xAudioWaveformPushMix(dest, frames);
+        return;
+    }
+
+    static const int GB_GAIN_Q8  = 242;
+    static const int SPC_GAIN_Q8 = 512;
+
+    int16_t spc_buf[2048];
+    int cap = (sample_count < 2048) ? sample_count : 2048;
+    int n = S9xPullSpcOutput(spc_buf, cap);
+    int i = 0;
+    for (; i < n; ++i)
+    {
+        int32_t gb    = ((int32_t)dest[i]    * GB_GAIN_Q8)  >> 8;
+        int32_t spc   = ((int32_t)spc_buf[i] * SPC_GAIN_Q8) >> 8;
+        int32_t mixed = gb + spc;
+        if (mixed >  32767) mixed =  32767;
+        if (mixed < -32768) mixed = -32768;
+        dest[i] = (int16_t)mixed;
+    }
+    for (; i < sample_count; ++i)
+    {
+        int32_t gb = ((int32_t)dest[i] * GB_GAIN_Q8) >> 8;
+        if (gb >  32767) gb =  32767;
+        if (gb < -32768) gb = -32768;
+        dest[i] = (int16_t)gb;
+    }
+
+    // Silence the SPC-over-GB mix until the GB completes its boot ROM
+    // (writes $FF50 → boot_handoff_captured). Same rationale as the
+    // win32 driver — bridges the audible click between BIOS-released
+    // and the GB taking over the audio path.
+    if (!S9xSGBBootHandoffCaptured())
+        memset(dest, 0, sample_count * sizeof(int16_t));
+
+    S9xAudioWaveformPushMix(dest, frames);
+}
+
 int S9xPullSpcOutput(int16_t *dst, int count)
 {
     if (!dst || count <= 0) return 0;

--- a/apu/apu.h
+++ b/apu/apu.h
@@ -63,6 +63,15 @@ int  S9xPullSpcOutput(int16_t *dst, int count);
 int  S9xSpcOutAvailable(void);
 void S9xAudioWaveformPushMix(const int16_t *src, int frames);
 
+// Host-side post-mix step for SGB BIOS mode. Call this on the buffer
+// returned by S9xMixSamples to overlay the SPC stream (running the SGB
+// BIOS sound engine and SOU_TRN samples) on top of the GB audio, with
+// the same gains/clip and boot-handoff click suppression the win32
+// driver uses. No-op when not in SGB BIOS released mode.
+// sample_count is the interleaved-stereo int16_t count (same units as
+// passed to S9xMixSamples).
+void S9xMixSpcOverGB(int16_t *dest, int sample_count);
+
 // Adaptive rate control hooks for the SGB BIOS-released mix mode drain
 // thread. Each call observes the stream's own buffer fill level and biases
 // its rate to keep it near target, decoupling GB and SPC pitch drift.

--- a/gtk/src/gtk_sound.cpp
+++ b/gtk/src/gtk_sound.cpp
@@ -183,6 +183,7 @@ void S9xSamplesAvailable(void *userdata)
     if ((int)temp_buffer.size() < samples)
         temp_buffer.resize(samples);
     S9xMixSamples((uint8_t *)temp_buffer.data(), samples);
+    S9xMixSpcOverGB(temp_buffer.data(), samples);
     driver->write_samples(temp_buffer.data(), samples);
 
     if (clear_leftover_samples)

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -561,6 +561,7 @@ void Snes9xController::SamplesAvailable()
         if (data.size() < samples)
             data.resize(samples);
         S9xMixSamples((uint8_t *)data.data(), samples);
+        S9xMixSpcOverGB(data.data(), samples);
         sound_output_function(data.data(), samples);
     }
     else


### PR DESCRIPTION
In SGB BIOS released mode S9xMixSamples writes GB-only audio and deliberately keeps the SPC resampler queued so the host layer can overlay the SPC stream on top (the SGB BIOS sound engine, SOU_TRN samples, and SGB-enhanced game audio like Animaniacs's tracks). The win32 driver does this via a static MixSpcOverGB; Qt and GTK did not, so SPC-side audio went unheard after the chime.

Factor the helper into apu/apu.{cpp,h} as S9xMixSpcOverGB (same gains, clip, boot-handoff click suppression as the win32 version) and call it after S9xMixSamples in both the Qt SamplesAvailable callback and the GTK S9xSamplesAvailable callback. No-op outside SGB BIOS released mode.