### PR TITLE
sgb: route GB cart .sav through CMemory::Save/LoadSRAM into SRAM_DIR

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -269,6 +269,9 @@ void S9xEndScreenRefresh (void)
 	}
 #endif
 
+	if (S9xSGBTakeSramDirty())
+		CPU.SRAMModified = TRUE;
+
 	if (CPU.SRAMModified)
 	{
 		if (!CPU.AutoSaveTimer)

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2305,6 +2305,15 @@ bool8 CMemory::LoadSRAM (const char *filename)
 	FILE	*file;
 	int		size, len;
 
+	if (S9xSGBIsActive() && S9xSGBHasBattery())
+	{
+		std::string sav(filename);
+		size_t dot = sav.rfind('.');
+		if (dot != std::string::npos) sav.replace(dot, std::string::npos, ".sav");
+		else                          sav += ".sav";
+		S9xSGBLoadBatteryFromPath(sav.c_str());
+	}
+
 	ClearSRAM();
 
 	if (Multi.cartType && Multi.sramSizeB)
@@ -2374,6 +2383,15 @@ bool8 CMemory::LoadSRAM (const char *filename)
 
 bool8 CMemory::SaveSRAM (const char *filename)
 {
+	if (S9xSGBIsActive() && S9xSGBHasBattery())
+	{
+		std::string sav(filename);
+		size_t dot = sav.rfind('.');
+		if (dot != std::string::npos) sav.replace(dot, std::string::npos, ".sav");
+		else                          sav += ".sav";
+		S9xSGBSaveBatteryToPath(sav.c_str());
+	}
+
 	if (Settings.SuperFX && ROMType < 0x15) // doesn't have SRAM
 		return (TRUE);
 

--- a/sgb/gb_cart.cpp
+++ b/sgb/gb_cart.cpp
@@ -166,18 +166,16 @@ void CartUnload(Cart &c)
 	c.has_battery = false;
 	c.has_rtc     = false;
 	c.has_rumble  = false;
+	c.sram_dirty  = false;
 	MbcReset(c.mbc);
 	c.mbc.type    = MbcType::None;
 }
 
-bool CartSaveBattery(const Cart &c)
+bool CartSaveBatteryToPath(const Cart &c, const char *path)
 {
-	if (!c.has_battery || c.sram.empty() || c.path.empty()) return false;
+	if (!c.has_battery || c.sram.empty() || !path || !*path) return false;
 
-	const std::string sav = MakeSavPath(c.path);
-	if (sav.empty()) return false;
-
-	FILE *f = fopen(sav.c_str(), "wb");
+	FILE *f = fopen(path, "wb");
 	if (!f) return false;
 
 	const size_t written = fwrite(c.sram.data(), 1, c.sram.size(), f);
@@ -185,14 +183,11 @@ bool CartSaveBattery(const Cart &c)
 	return written == c.sram.size();
 }
 
-bool CartLoadBattery(Cart &c)
+bool CartLoadBatteryFromPath(Cart &c, const char *path)
 {
-	if (!c.has_battery || c.sram.empty() || c.path.empty()) return false;
+	if (!c.has_battery || c.sram.empty() || !path || !*path) return false;
 
-	const std::string sav = MakeSavPath(c.path);
-	if (sav.empty()) return false;
-
-	FILE *f = fopen(sav.c_str(), "rb");
+	FILE *f = fopen(path, "rb");
 	if (!f) return false;
 
 	// Cap at the allocated SRAM; ignore any trailing RTC bytes for now
@@ -201,6 +196,20 @@ bool CartLoadBattery(Cart &c)
 	const size_t got  = fread(c.sram.data(), 1, want, f);
 	fclose(f);
 	return got == want;
+}
+
+bool CartSaveBattery(const Cart &c)
+{
+	if (c.path.empty()) return false;
+	const std::string sav = MakeSavPath(c.path);
+	return CartSaveBatteryToPath(c, sav.c_str());
+}
+
+bool CartLoadBattery(Cart &c)
+{
+	if (c.path.empty()) return false;
+	const std::string sav = MakeSavPath(c.path);
+	return CartLoadBatteryFromPath(c, sav.c_str());
 }
 
 } // namespace SGB

--- a/sgb/gb_cart.h
+++ b/sgb/gb_cart.h
@@ -41,6 +41,7 @@ struct Cart
 	bool                  has_battery = false;
 	bool                  has_rtc     = false;
 	bool                  has_rumble  = false;
+	bool                  sram_dirty  = false;
 };
 
 bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path);
@@ -49,6 +50,9 @@ void CartUnload(Cart &c);
 // Persist battery-backed SRAM (and RTC if present) to ".sav" alongside the ROM.
 bool CartSaveBattery(const Cart &c);
 bool CartLoadBattery(Cart &c);
+
+bool CartSaveBatteryToPath(const Cart &c, const char *path);
+bool CartLoadBatteryFromPath(Cart &c, const char *path);
 
 } // namespace SGB
 

--- a/sgb/gb_mbc.cpp
+++ b/sgb/gb_mbc.cpp
@@ -29,6 +29,7 @@
 //     0x4000-0x5FFF  RAM bank 0..0x0F (bit 3 of value = rumble on rumble carts)
 
 #include "gb_mbc.h"
+#include "gb_cart.h"
 
 namespace SGB {
 
@@ -57,10 +58,15 @@ inline uint8_t ReadSram(const std::vector<uint8_t> &sram, uint32_t offset)
 	return sram[offset % sram.size()];
 }
 
-inline void WriteSram(std::vector<uint8_t> &sram, uint32_t offset, uint8_t value)
+inline void WriteSram(Cart &c, uint32_t offset, uint8_t value)
 {
-	if (sram.empty()) return;
-	sram[offset % sram.size()] = value;
+	if (c.sram.empty()) return;
+	uint8_t &cell = c.sram[offset % c.sram.size()];
+	if (cell != value)
+	{
+		cell = value;
+		c.sram_dirty = true;
+	}
 }
 
 // Effective 0x0000-0x3FFF bank for MBC1 — normally 0, but mode 1 with
@@ -138,15 +144,16 @@ uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<
 	return 0xFF;
 }
 
-void MbcWrite(MbcState &s, std::vector<uint8_t> &sram, uint16_t addr, uint8_t value)
+void MbcWrite(Cart &c, uint16_t addr, uint8_t value)
 {
+	MbcState &s = c.mbc;
 	switch (s.type)
 	{
 
 	case MbcType::None:
 		if (addr >= 0xA000 && addr < 0xC000)
 		{
-			WriteSram(sram, addr - 0xA000, value);
+			WriteSram(c, addr - 0xA000, value);
 		}
 		break;
 
@@ -173,7 +180,7 @@ void MbcWrite(MbcState &s, std::vector<uint8_t> &sram, uint16_t addr, uint8_t va
 		else if (addr >= 0xA000 && addr < 0xC000)
 		{
 			if (!s.ram_enable) break;
-			WriteSram(sram, (Mbc1RamBank(s) * 0x2000u) + (addr - 0xA000u), value);
+			WriteSram(c, (Mbc1RamBank(s) * 0x2000u) + (addr - 0xA000u), value);
 		}
 		break;
 
@@ -197,7 +204,7 @@ void MbcWrite(MbcState &s, std::vector<uint8_t> &sram, uint16_t addr, uint8_t va
 		{
 			if (!s.ram_enable) break;
 			// 512 x 4-bit — only low nibble stored.
-			WriteSram(sram, (addr - 0xA000) & 0x01FF, static_cast<uint8_t>(value & 0x0F));
+			WriteSram(c, (addr - 0xA000) & 0x01FF, static_cast<uint8_t>(value & 0x0F));
 		}
 		break;
 
@@ -235,7 +242,7 @@ void MbcWrite(MbcState &s, std::vector<uint8_t> &sram, uint16_t addr, uint8_t va
 			}
 			else
 			{
-				WriteSram(sram, ((s.ram_bank & 0x07) * 0x2000u) + (addr - 0xA000u), value);
+				WriteSram(c, ((s.ram_bank & 0x07) * 0x2000u) + (addr - 0xA000u), value);
 			}
 		}
 		break;
@@ -261,7 +268,7 @@ void MbcWrite(MbcState &s, std::vector<uint8_t> &sram, uint16_t addr, uint8_t va
 		else if (addr >= 0xA000 && addr < 0xC000)
 		{
 			if (!s.ram_enable) break;
-			WriteSram(sram, ((s.ram_bank & 0x0F) * 0x2000u) + (addr - 0xA000u), value);
+			WriteSram(c, ((s.ram_bank & 0x0F) * 0x2000u) + (addr - 0xA000u), value);
 		}
 		break;
 

--- a/sgb/gb_mbc.h
+++ b/sgb/gb_mbc.h
@@ -41,9 +41,11 @@ struct MbcState
 	uint8_t  rtc_select     = 0;
 };
 
+struct Cart;
+
 void MbcReset(MbcState &s);
 uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<uint8_t> &sram, uint16_t addr);
-void    MbcWrite(MbcState &s, std::vector<uint8_t> &sram, uint16_t addr, uint8_t value);
+void    MbcWrite(Cart &c, uint16_t addr, uint8_t value);
 
 } // namespace SGB
 

--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -98,7 +98,7 @@ void MemWrite(Memory &m, uint16_t addr, uint8_t value)
 {
 	if (addr < 0x8000)
 	{
-		if (m.cart) MbcWrite(m.cart->mbc, m.cart->sram, addr, value);
+		if (m.cart) MbcWrite(*m.cart, addr, value);
 		return;
 	}
 	if (addr < 0xA000)
@@ -112,7 +112,7 @@ void MemWrite(Memory &m, uint16_t addr, uint8_t value)
 	}
 	if (addr < 0xC000)
 	{
-		if (m.cart) MbcWrite(m.cart->mbc, m.cart->sram, addr, value);
+		if (m.cart) MbcWrite(*m.cart, addr, value);
 		return;
 	}
 	if (addr < 0xE000)

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -601,7 +601,6 @@ bool Emulator::LoadROM(const uint8_t *data, size_t size, const char *path)
 
 void Emulator::UnloadROM()
 {
-	if (impl_->has_rom) CartSaveBattery(impl_->cart);
 	CartUnload(impl_->cart);
 	impl_->has_rom = false;
 	// Drop any staged boot ROM so a subsequent BIOS-less load starts at
@@ -610,6 +609,31 @@ void Emulator::UnloadROM()
 }
 
 bool Emulator::HasROM() const { return impl_->has_rom; }
+
+bool Emulator::HasBattery() const
+{
+	return impl_->has_rom && impl_->cart.has_battery && !impl_->cart.sram.empty();
+}
+
+bool Emulator::SaveBatteryToPath(const char *path) const
+{
+	if (!impl_->has_rom) return false;
+	return CartSaveBatteryToPath(impl_->cart, path);
+}
+
+bool Emulator::LoadBatteryFromPath(const char *path)
+{
+	if (!impl_->has_rom) return false;
+	return CartLoadBatteryFromPath(impl_->cart, path);
+}
+
+bool Emulator::TakeSramDirty()
+{
+	if (!impl_->has_rom) return false;
+	if (!impl_->cart.sram_dirty) return false;
+	impl_->cart.sram_dirty = false;
+	return true;
+}
 
 const uint8_t *Emulator::GetROMData() const
 {
@@ -1759,6 +1783,8 @@ bool Emulator::StateLoad(const uint8_t *buffer, size_t size)
 	impl_->mem.joypad = &impl_->joypad;
 	impl_->mem.cart   = &impl_->cart;
 
+	impl_->cart.sram_dirty = false;
+
 	// Reset only the sub-sample integration accumulator. The ring buffer
 	// is not serialized but also not wiped — it stays at its current
 	// in-memory positions so already-queued samples keep playing across
@@ -1805,6 +1831,10 @@ bool S9xSGBInit(void)               { return SGB::Instance().Init(); }
 void S9xSGBDeinit(void)             { SGB::Instance().Deinit(); }
 void S9xSGBReset(void)              { SGB::Instance().ColdReset(); }
 bool S9xSGBIsActive(void)           { return SGB::Instance().HasROM(); }
+bool S9xSGBHasBattery(void)         { return SGB::Instance().HasBattery(); }
+bool S9xSGBSaveBatteryToPath(const char *path) { return SGB::Instance().SaveBatteryToPath(path); }
+bool S9xSGBLoadBatteryFromPath(const char *path) { return SGB::Instance().LoadBatteryFromPath(path); }
+bool S9xSGBTakeSramDirty(void)      { return SGB::Instance().TakeSramDirty(); }
 void S9xSGBRunFrame(void)           { SGB::Instance().RunFrame(); }
 void S9xSGBRunCycles(int tcycles)   { SGB::Instance().RunCycles(static_cast<int32_t>(tcycles)); }
 

--- a/sgb/sgb.h
+++ b/sgb/sgb.h
@@ -58,6 +58,11 @@ public:
 	void UnloadROM();
 	bool HasROM() const;
 
+	bool HasBattery() const;
+	bool SaveBatteryToPath(const char *path) const;
+	bool LoadBatteryFromPath(const char *path);
+	bool TakeSramDirty();
+
 	// Raw cart ROM accessor for hashing / external introspection. Returns
 	// nullptr when no ROM is loaded.
 	const uint8_t *GetROMData() const;
@@ -368,5 +373,10 @@ bool          S9xSGBGetROMBytes (const unsigned char **out_data, size_t *out_siz
 // 0x10000-0x33FFF for the extended SRAM/CGB-WRAM bank window). Returns
 // 0 for unmapped or out-of-range addresses.
 unsigned char S9xSGBPeekRAByte (unsigned int addr);
+
+bool S9xSGBHasBattery(void);
+bool S9xSGBSaveBatteryToPath(const char *path);
+bool S9xSGBLoadBatteryFromPath(const char *path);
+bool S9xSGBTakeSramDirty(void);
 
 #endif


### PR DESCRIPTION
Before, the GB cart battery was only written from Emulator::UnloadROM — which fires on BIOS-mode switch / new-ROM-load, never on autosave or clean quit — and the path was hardcoded next to the ROM, ignoring the configured SRAM directory. In-game saves only made it to disk if the user happened to switch SGB1<->SGB2 before closing, and even then they landed in the ROM folder.

Track cart-RAM writes via Cart::sram_dirty (set in MbcWrite/WriteSram only when a byte actually changes), expose it as S9xSGBTakeSramDirty, and have S9xEndScreenRefresh fold it into CPU.SRAMModified so the existing AutoSaveDelay timer fires for SGB games. CMemory::SaveSRAM / LoadSRAM now also save/load <stem>.sav alongside the .srm in SRAM_DIR, so quit, ROM-switch, the menu, and the autosave timer all flush the GB battery. CartLoad still pulls a legacy ROM-dir .sav at load time as a migration fallback; LoadSRAM then overrides with the SRAM_DIR copy when present.

Derive the .sav path by replacing the trailing extension on the .srm filename directly — round-tripping through splitpath/makepath produced "C::\..." on Windows because splitpath returns drive="C:" and makepath prepends "drive + ':'" whenever dir doesn't itself carry a drive.