### PR TITLE
sgb: blank last visible scanline in BIOS-mode OverlayBiosBorder

### DIFF
--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -1323,9 +1323,14 @@ static constexpr uint16_t BORDER_FADE_FRAMES = 24;
 
 void Emulator::OverlayBiosBorder(uint16_t *dest, uint32_t pitch_pixels)
 {
-	(void)dest;
-	(void)pitch_pixels;
-	if (!impl_->has_rom) return;
+	if (!impl_->has_rom || !dest) return;
+
+	const int last_y = (int)PPU.ScreenHeight - 1;
+	if (last_y < 0) return;
+	const int width = (IPPU.RenderedScreenWidth > 0) ? IPPU.RenderedScreenWidth
+	                                                 : SNES_WIDTH;
+	uint16_t *row = dest + (uint32_t)last_y * pitch_pixels;
+	for (int x = 0; x < width; ++x) row[x] = 0;
 }
 
 int32_t Emulator::DrainAudio(int16_t *out, int32_t max_samples)


### PR DESCRIPTION
Visible as a one-pixel-tall "extra row" at the bottom of the SGB border during fades and scene transitions in titles like Kirby's Dream Land 2: some frames showed the GB-area backdrop ($7FFF white) bleeding into the border's intended black bottom edge.

Root cause is a render/INIDISP timing race specific to BIOS mode. The SGB BIOS NMI handler writes INIDISP=$80 (force-blank) at VBlank start (V=225 HC=12+), but S9xEndScreenRefresh's FLUSH_REDRAW commits line 223 at V=225 HC=0 — before the NMI handler runs. On frames where the BIOS's alternating dma_swap pattern wipes the bottom-row BG tilemap, all layers are transparent at tile row 27, the FLUSH lands with ForcedBlanking=0, and the backdrop (CGRAM[0], which fades to white during transitions) shows through. Real hardware doesn't show this because INIDISP=$80 always lands during VBlank before the LCD scans the next frame, but snes9x's per-batch ForcedBlanking check applies the old value to the late scanline.

OverlayBiosBorder runs from S9xEndScreenRefresh in BIOS mode only, right after the FLUSH. Zeroing the last visible row there matches real- hardware behavior with a five-line change strictly gated on Settings.SGB_BIOSModeActive, avoiding a core-PPU timing refactor that would risk regressing non-SGB games.