### PR TITLE
GB: add M161 mapper support (Mani 4-in-1 multicart)

### DIFF
--- a/sgb/gb_cart.cpp
+++ b/sgb/gb_cart.cpp
@@ -119,6 +119,24 @@ bool LooksLikeMmm01(const std::vector<uint8_t> &rom)
 	return true;
 }
 
+// M161 (Mani 4-in-1 "Tetris Set"): a write-once register selects one of up to
+// eight raw 32 KiB pages into $0000-$7FFF — the menu is page 0, the sub-games
+// follow. The $0147 byte is forged (this cart claims MBC3+TIMER+BATTERY), so
+// identify it structurally: a second Nintendo logo at the first sub-game page
+// ($8000) that no single-game cart carries.
+bool LooksLikeM161(const std::vector<uint8_t> &rom)
+{
+	if (rom.size() < 0x10000) return false;          // need >= menu + one game
+	if (rom.size() % 0x8000)  return false;          // 32 KiB-page aligned
+	auto logo_at = [&](size_t base) {
+		if (base + 0x0104 + 48 > rom.size()) return false;
+		for (int i = 0; i < 48; ++i)
+			if (rom[base + 0x0104 + i] != kGbNintendoLogo[i]) return false;
+		return true;
+	};
+	return logo_at(0x0000) && logo_at(0x8000);
+}
+
 std::string MakeSavPath(const std::string &rom_path)
 {
 	if (rom_path.empty()) return {};
@@ -216,6 +234,13 @@ bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path)
 		// MMM01+RAM+BATTERY); Mani forgeries report MBC1/MBC3 there
 		// so fall back to false unless we see the real MMM01 type.
 		c.has_battery = (h.cart_type == 0x0D);
+		c.has_rtc     = false;
+		c.has_rumble  = false;
+	}
+	else if (LooksLikeM161(c.rom))
+	{
+		c.mbc.type    = MbcType::M161;
+		c.has_battery = false;
 		c.has_rtc     = false;
 		c.has_rumble  = false;
 	}

--- a/sgb/gb_mbc.cpp
+++ b/sgb/gb_mbc.cpp
@@ -133,6 +133,7 @@ void MbcReset(MbcState &s)
 	s.mmm01_ram_bank_mask     = 0xFF;
 	s.mmm01_just_locked       = false;
 
+	if (s.type == MbcType::M161) s.rom_bank = 0;   // power-on page 0 = menu
 	if (s.type == MbcType::TAMA5) Tama5SeedRtc(s);
 }
 
@@ -354,6 +355,12 @@ inline void Tama5Trigger(Cart &c)
 
 uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<uint8_t> &sram, uint16_t addr)
 {
+	if (s.type == MbcType::M161 && addr < 0x8000)
+	{
+		// One 32 KiB page covers the whole $0000-$7FFF window.
+		const uint32_t page = s.rom_bank & 0x07;
+		return static_cast<uint8_t>(ReadRom(rom, (page << 15) | (addr & 0x7FFF)));
+	}
 	if (addr < 0x4000)
 	{
 		// Bank 0 region — mostly direct, except for MBC1 mode 1 quirk,
@@ -758,6 +765,17 @@ void MbcWrite(Cart &c, uint16_t addr, uint8_t value)
 					default: break;
 				}
 			}
+		}
+		break;
+
+	case MbcType::M161:
+		// Write-once page register: the first write to $0000-$7FFF latches the
+		// selected 32 KiB page; later writes (e.g. a sub-game's own $2000 bank
+		// poke) are ignored. mbc1_mode is reused as the "latched" flag.
+		if (addr < 0x8000 && !s.mbc1_mode)
+		{
+			s.rom_bank  = value & 0x07;
+			s.mbc1_mode = true;
 		}
 		break;
 

--- a/sgb/gb_mbc.h
+++ b/sgb/gb_mbc.h
@@ -25,7 +25,8 @@ enum class MbcType : uint8_t
 	HuC3       = 9,  // MBC-like, with RTC command interface + IR
 	MMM01      = 10, // Nintendo multicart meta-mapper (Mani / Taito 4-in-1)
 	SachenMMC1 = 11, // Sachen 4B-series unlicensed multicarts
-	TAMA5      = 12  // Bandai Tamagotchi — register port + EEPROM + RTC
+	TAMA5      = 12, // Bandai Tamagotchi — register port + EEPROM + RTC
+	M161       = 13  // write-once 32 KiB-page multicart (Mani 4-in-1 "Tetris Set")
 };
 
 struct MbcState


### PR DESCRIPTION
## Problem

**Mani 4 in 1 - Tetris + Alleyway + Yakuman + Tennis (China)** boots to its game-select menu, but choosing any of the four games just bounces back to the menu — the game never runs.

## Root cause

The cart **forges its `$0147` header byte** to `$10` (MBC3+TIMER+BATTERY), so it was emulated as MBC3. Its real controller is **M161**: a write-once register whose low 3 bits select one raw 32 KiB page mapped over the *entire* `$0000-$7FFF` window.

The menu (page 0) launches a sub-game with a single write + jump:

```
LD A,($C008)   ; selected game index 0..3
INC A          ; -> 1..4
LD ($4000),A   ; M161 page select
JP $0100       ; run the now-remapped game
```

Under MBC3 that `$4000` write only sets the RAM-bank/RTC select — **ROM mapping never moves** — so `$0000-$3FFF` stays the menu and `JP $0100` re-runs the menu's own startup. Hence the bounce-back.

## Fix

- **Detect M161 structurally** rather than trusting the forged header: a Nintendo logo at **both** `$0000` and `$8000`. A single-game cart only has one logo; this multicart stacks the menu + sub-games as raw 32 KiB blocks, each with its own logo/header (`TETRIS SET`, `TETRIS`, `ALLEY WAY`, `YAKUMAN`, `TENNIS`). Ordered after the existing Sachen/MMM01 checks.
- **Map the selected 32 KiB page** over `$0000-$7FFF` (`physical = (page<<15) | (addr & 0x7FFF)`); power-on is page 0 (menu).
- **Write-once latch** so a sub-game's own defensive `$2000` bank poke (Tetris does this at `$0254`) can't dislodge the page. The latch reuses the existing `mbc1_mode` field — **no new `MbcState` member, so GB savestates are unchanged**.

## Validation

Simulated against the real 256 KiB ROM: detection fires, every selection maps to the correct game, and the write-once latch holds against the sub-game `$2000` poke (Power-on→`TETRIS SET`; `$4000<-1..4` → `TETRIS` / `ALLEY WAY` / `YAKUMAN` / `TENNIS`).

Files: `sgb/gb_mbc.h`, `sgb/gb_mbc.cpp`, `sgb/gb_cart.cpp` (+45/-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)