### PR TITLE
gb: latch STAT LYC-coincidence flag while the LCD is off

### DIFF
--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -88,9 +88,22 @@ inline uint8_t ApplyPalette(uint8_t palette, uint8_t color_idx)
 
 void RecomputeStatLine(Ppu &p, Memory &mem)
 {
-	// Rebuild the low 3 bits of STAT (mode + LYC coincidence).
+	// Rebuild the low 3 bits of STAT (mode + LYC coincidence). With the LCD
+	// off the PPU comparator is frozen, so the coincidence flag latches the
+	// value it held when the LCD was disabled rather than being recomputed
+	// from the parked LY. Mr. Do! disables the LCD at line 145 (LYC=145
+	// match set), loads VRAM, then re-waits for that same match while the
+	// LCD is still off before re-enabling it; recomputing here would see
+	// LY(0) != LYC(145), clear bit 2 and hang the wait forever.
 	uint8_t new_stat = static_cast<uint8_t>((p.stat & 0xF8) | static_cast<uint8_t>(p.mode));
-	if (p.ly == p.lyc) new_stat |= 0x04;
+	if (p.lcdc & 0x80)
+	{
+		if (p.ly == p.lyc) new_stat |= 0x04;
+	}
+	else
+	{
+		new_stat |= static_cast<uint8_t>(p.stat & 0x04);
+	}
 	p.stat = new_stat;
 
 	// Compute the combined IRQ line from the four source-enable flags.
@@ -590,7 +603,10 @@ void PpuStep(Ppu &p, Memory &mem, int32_t tcycles)
 		p.mode3_sprite_stall = 0;
 		p.latched_wx     = p.wx;
 		p.latched_bgp    = p.bgp;
-		p.stat = static_cast<uint8_t>(p.stat & 0xF8);
+		// Clear the mode bits (parked mode 0) but latch the LYC coincidence
+		// flag — the comparator is frozen while the LCD is off, so bit 2
+		// holds its disable-time value (see RecomputeStatLine / Mr. Do!).
+		p.stat = static_cast<uint8_t>(p.stat & 0xFC);
 		(void)mem;
 		return;
 	}


### PR DESCRIPTION
## Problem

Plain-DMG game **Mr. Do! (Europe)** (MBC1) freezes on a frozen title screen under SGB. The ROM is correct — it runs fine on real SGB hardware and in Mesen — so this was a PPU emulation bug.

## Root cause

The DMG PPU's LYC comparator stops when the LCD is disabled, so `STAT` bit 2 (the LY==LYC coincidence flag) holds the value it had at the moment the LCD was turned off. Mr. Do! relies on this idiom after the title:

1. wait for line 145, disable the LCD **at line 145** (so the LYC=145 match is latched **set**),
2. reload VRAM with the LCD off,
3. re-wait for that same LYC=145 coincidence **while the LCD is still off** (`$2FAD` → `$2E02`),
4. only then re-enable the LCD inside the gameplay loop body (`$3111`).

We were parking `LY` at 0 and **recomputing** bit 2 from the parked LY — both in `RecomputeStatLine` (called on the `LYC` write at `$2E04`) and in `PpuStep`'s LCD-off park. With `LY(0) != LYC(145)`, bit 2 cleared and step 3 spun forever at `$2E06`; the title stayed visible only because we hold the last framebuffer while the LCD is off.

## Fix

Latch bit 2 while the LCD is off instead of recomputing it:

- `RecomputeStatLine`: only recompute coincidence from `LY==LYC` when `LCDC.7` is set; otherwise preserve the existing flag.
- `PpuStep` LCD-off park: clear the mode bits with `& 0xFC` instead of `& 0xF8`, preserving bit 2.

The STAT-IRQ-line computation is still `LCDC.7`-guarded, so the prior LCD-off behaviour is unchanged for Pokémon Yellow (HBlank-IRQ storm) and Zerd no Densetsu (spurious STAT bit-6 raise), and re-enabling the LCD recomputes bit 2 live. This should also help any other game using the common "disable LCD in VBlank → reload → re-sync on LYC" idiom.

## Testing

- Mr. Do! (Europe) now boots past the title into gameplay (previously a hard hang).
- Change is narrowly scoped to `STAT` bit 2 while the LCD is off; matches real hardware / Mesen, so it converges toward correct rather than risking regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)