### PR TITLE
GB: don't trigger HALT bug when an EI is pending (EI;HALT)

### DIFF
--- a/sgb/gb_ops.cpp
+++ b/sgb/gb_ops.cpp
@@ -164,8 +164,8 @@ void Dispatch(CpuState &s, Memory &mem, uint8_t op)
 	case 0x75: MemWrite(mem, s.r.hl, s.r.l); s.t_cycles += 8; break;                           // LD (HL),L
 	case 0x76:  // HALT
 		s.t_cycles += 4;
-		if (!s.ime && (mem.ie & mem.if_ & IRQ_ALL)) s.halt_bug = true;
-		else                                         s.halted   = true;
+		if (!s.ime && !s.ime_pending && (mem.ie & mem.if_ & IRQ_ALL)) s.halt_bug = true;
+		else                                                          s.halted   = true;
 		break;
 	case 0x77: MemWrite(mem, s.r.hl, s.r.a); s.t_cycles += 8; break;                           // LD (HL),A
 	case 0x78: s.r.a = s.r.b; s.t_cycles += 4; break;                                          // LD A,B


### PR DESCRIPTION
## Problem

`Spot (Japan)` (plain DMG, ROM-only, 32 KB) boots to a blank/white screen under SGB2 — it polls input and reacts, but the main thread has derailed into garbage. The same ROM runs fine in Mesen, so it's an emulation bug in our GB core.

## Root cause

The game runs `EI; HALT` every frame with a VBlank/STAT IRQ already pending (`IE=$03`, `IF` bit 0 latent from reset). The HALT-bug detection in `sgb/gb_ops.cpp` (opcode `$76`) was:

```c
if (!s.ime && (mem.ie & mem.if_ & IRQ_ALL)) s.halt_bug = true;
```

In `Cpu::Step`, the `EI`'s IME promotion happens **after** the instruction dispatches, so during the `HALT` dispatch `s.ime` is still 0 → `halt_bug` was wrongly armed. That stale flag then **survived the interrupt dispatch** (`ServiceInterrupts` pushes PC=`$058F`, sets PC=`$0040`, and returns early without consuming it). On the next fetch the vector opcode `C3` at `$0040` was read (PC→`$0041`), then `halt_bug` rewound `PC-- → $0040`, so the `JP` read its operand from `[$0040:$0041] = C3 99` → **`JP $99C3`** instead of `JP $0499`.

On real hardware `EI; HALT` counts as IME-enabled and never triggers the halt bug.

## Fix

Gate `halt_bug` on `!ime_pending` so `EI; HALT` halts normally and services the interrupt:

```c
if (!s.ime && !s.ime_pending && (mem.ie & mem.if_ & IRQ_ALL)) s.halt_bug = true;
else                                                          s.halted   = true;
```

`DI; HALT` (IME truly 0, no pending EI) still gets the genuine halt bug. With this, `halt_bug` can never be armed while IME is about to enable, so it can't leak through `ServiceInterrupts` (which only runs with IME=1).

## Impact

`EI; HALT` with a pending IRQ is a very common idiom, so this likely improves other GB titles too, not just Spot. One-line change, no debugger/tooling code.