### PR TITLE
libretro: add SGB / GB / GBC support (SuperSnes9x core)

### DIFF
--- a/apu/apu.cpp
+++ b/apu/apu.cpp
@@ -495,6 +495,54 @@ void S9xSpcResetDrc(void)
     spc::resampler.time_ratio(base_ratio);
 }
 
+// Frame-synchronous SPC rate match for SGB BIOS mode. The host output is paced
+// by the GB sample count, which runs a few percent off the SPC's native rate,
+// so a frontend that drains once per emulated frame sees the SPC resampler
+// buffer drift: overflow -> dropped samples (noise) and under-drain -> pitch
+// drift (bass). S9xSpcAdjustRate's tiny per-call trim only converges when
+// called at audio cadence (win32's drain thread); for the once-per-frame
+// frontends (libretro/gtk/qt) drive spc::drc_scale (production rate) with a PI
+// controller that holds the resampler buffer near half-full, converging in a
+// few frames. Call once per drained frame while in BIOS mode after GB release.
+static double spc_sync_integ = 0.0;
+
+void S9xSpcSyncReset(void)
+{
+    // Clear the integrator and the SGB production trim only. drc_scale is the
+    // SGB-specific rate trim (1.0 == no scaling), so resetting it is correct
+    // for non-SGB audio; deliberately NOT touching time_ratio so the normal
+    // SNES resampler ratio (which may carry a timing hack) is left intact.
+    spc_sync_integ = 0.0;
+    spc::drc_scale = 1.0;
+}
+
+void S9xSpcSyncToConsumption(void)
+{
+    const int cap = spc::resampler.buffer_size;
+    if (cap <= 0) return;
+
+    const double base_ratio = (double)Settings.SoundInputRate /
+                              (double)Settings.SoundPlaybackRate;
+    spc::resampler.time_ratio(base_ratio);
+
+    const int    filled = spc::resampler.space_filled();
+    const int    target = cap / 2;                        // aim half-full: max headroom both ways
+    const double err    = (double)(filled - target) / (double)cap;   // ~[-0.5, +0.5]
+
+    // PI on production rate. drc_scale > 1 slows the SPC (fewer samples);
+    // buffer too full (err > 0) -> raise drc_scale -> drains. The integrator
+    // absorbs the steady-state offset (drc_scale settles ~ native/GB ratio).
+    const double Kp = 0.80, Ki = 0.08, I_CLAMP = 0.40;
+    spc_sync_integ += Ki * err;
+    if (spc_sync_integ >  I_CLAMP) spc_sync_integ =  I_CLAMP;
+    if (spc_sync_integ < -I_CLAMP) spc_sync_integ = -I_CLAMP;
+
+    double scale = 1.0 + Kp * err + spc_sync_integ;
+    if (scale < 0.5) scale = 0.5;
+    if (scale > 1.5) scale = 1.5;
+    spc::drc_scale = scale;
+}
+
 void S9xAudioWaveformEnable(bool enable)
 {
     audiowave::enabled = enable;

--- a/apu/apu.h
+++ b/apu/apu.h
@@ -84,6 +84,12 @@ extern unsigned int S9xSGBMixVolumeGB;
 void   S9xSpcAdjustRate(double drc_factor);
 void   S9xSpcResetDrc(void);
 double S9xSpcGetTimeRatio(void);
+// PI rate-match for once-per-frame frontends in SGB BIOS mode (libretro/gtk/qt).
+// Drives spc::drc_scale to hold the SPC resampler buffer near half-full so it
+// stays locked to the GB-paced consumption. S9xSpcSyncReset clears the
+// integrator (call when leaving BIOS mode).
+void   S9xSpcSyncToConsumption(void);
+void   S9xSpcSyncReset(void);
 
 #define DSP_INTERPOLATION_NONE     0
 #define DSP_INTERPOLATION_LINEAR   1

--- a/gtk/src/gtk_sound.cpp
+++ b/gtk/src/gtk_sound.cpp
@@ -11,6 +11,7 @@
 #include "common/audio/s9x_sound_driver.hpp"
 #include "snes9x.h"
 #include "apu/apu.h"
+#include "sgb/sgb.h"
 
 #ifdef USE_PORTAUDIO
 #include "common/audio/s9x_sound_driver_portaudio.hpp"
@@ -195,6 +196,13 @@ void S9xSamplesAvailable(void *userdata)
         S9xSGBMixVolumeSPC = clamp_pct(gui_config->sgb_mix_volume_spc);
         S9xSGBMixVolumeGB  = clamp_pct(gui_config->sgb_mix_volume_gb);
     }
+
+    // SGB BIOS mode: lock the SPC resampler to the GB-paced consumption so it
+    // doesn't drift into under/overrun (crackle) and pitch drift (bass). The
+    // closed-loop trim matches the win32 driver; only runs after the GB is
+    // released, so normal SNES audio and the boot splash are left untouched.
+    if (Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased())
+        S9xSpcAdjustRate(1.0);
 
     S9xMixSamples((uint8_t *)temp_buffer.data(), samples);
     S9xMixSpcOverGB(temp_buffer.data(), samples);

--- a/gtk/src/gtk_sound.cpp
+++ b/gtk/src/gtk_sound.cpp
@@ -197,12 +197,16 @@ void S9xSamplesAvailable(void *userdata)
         S9xSGBMixVolumeGB  = clamp_pct(gui_config->sgb_mix_volume_gb);
     }
 
-    // SGB BIOS mode: lock the SPC resampler to the GB-paced consumption so it
-    // doesn't drift into under/overrun (crackle) and pitch drift (bass). The
-    // closed-loop trim matches the win32 driver; only runs after the GB is
-    // released, so normal SNES audio and the boot splash are left untouched.
+    // SGB BIOS mode: the host output is paced by the GB sample count, which
+    // runs a few percent off the SPC's native rate. Drive the SPC production
+    // rate (PI controller) to hold its resampler buffer matched to that cadence
+    // -- otherwise it overflows (dropped samples -> noise) and the under-drain
+    // pitches it down (bass). Reset the trim outside BIOS mode so a SNES game
+    // loaded afterward isn't left with the SGB rate scaling.
     if (Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased())
-        S9xSpcAdjustRate(1.0);
+        S9xSpcSyncToConsumption();
+    else
+        S9xSpcSyncReset();
 
     S9xMixSamples((uint8_t *)temp_buffer.data(), samples);
     S9xMixSpcOverGB(temp_buffer.data(), samples);

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -33,7 +33,7 @@ else ifneq (,$(findstring rpi,$(platform)))
    override platform += unix
 endif
 
-TARGET_NAME	= snes9x
+TARGET_NAME	= supersnes9x
 
 LIBS     =
 

--- a/libretro/Tupfile
+++ b/libretro/Tupfile
@@ -1,3 +1,3 @@
-TARGET_NAME=snes9x
+TARGET_NAME=supersnes9x
 CORE_DIR=$(TUP_CWD)/..
 include_rules

--- a/libretro/libretro-win32.vcxproj
+++ b/libretro/libretro-win32.vcxproj
@@ -74,25 +74,25 @@
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>snes9x_libretro_debug</TargetName>
+    <TargetName>supersnes9x_libretro_debug</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='libretro Debug|x64'">
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>snes9x_libretro_debug</TargetName>
+    <TargetName>supersnes9x_libretro_debug</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='libretro Release|Win32'">
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>snes9x_libretro</TargetName>
+    <TargetName>supersnes9x_libretro</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='libretro Release|x64'">
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>snes9x_libretro</TargetName>
+    <TargetName>supersnes9x_libretro</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='libretro Debug|Win32'">
     <ClCompile>

--- a/libretro/libretro-win32.vcxproj.filters
+++ b/libretro/libretro-win32.vcxproj.filters
@@ -16,6 +16,9 @@
     <Filter Include="libretro">
       <UniqueIdentifier>{7445db59-72e6-42a3-963c-c352087333b1}</UniqueIdentifier>
     </Filter>
+    <Filter Include="s9x-source\SGB">
+      <UniqueIdentifier>{a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\65c816.h">
@@ -361,6 +364,45 @@
     </ClCompile>
     <ClCompile Include="..\sha256.cpp">
       <Filter>s9x-source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\sgb.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\sgb_packet.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\sgb_state.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_cpu.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_ops.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_ops_cb.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_memory.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_mbc.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_ppu.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_apu.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_timer.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_joypad.cpp">
+      <Filter>s9x-source\SGB</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sgb\gb_cart.cpp">
+      <Filter>s9x-source\SGB</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -791,15 +791,17 @@ void S9xSyncSpeed() {
 
     size_t avail = S9xGetSampleCount();
 
-    // In SGB BIOS mode the host output is paced by the GB sample count, so the
-    // SPC resampler has to be rate-locked to that cadence or it drifts into
-    // under/overrun (crackle) and pitch drift (bass). S9xSpcAdjustRate runs a
-    // closed-loop trim that holds the SPC buffer near its target fill, matching
-    // the win32 driver (CXAudio2::ProcessSound). Scoped to BIOS mode after the
-    // GB is released; normal SNES audio and the pre-release boot splash (which
-    // use the standard SPC path) are left untouched.
+    // In SGB BIOS mode the host output is paced by the GB sample count, which
+    // runs a few percent off the SPC's native rate. Drive the SPC production
+    // rate (PI controller) to hold its resampler buffer matched to that cadence
+    // -- otherwise it overflows (dropped samples -> noise) and the under-drain
+    // pitches it down (bass). Reset the trim outside BIOS mode so a SNES game
+    // loaded afterward isn't left with the SGB rate scaling. Normal SNES audio
+    // and the pre-release boot splash use the standard SPC path either way.
     if (Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased())
-        S9xSpcAdjustRate(1.0);
+        S9xSpcSyncToConsumption();
+    else
+        S9xSpcSyncReset();
 
     if (audio_buffer.size() < avail)
         audio_buffer.resize(avail);

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -14,6 +14,7 @@
 #include "display.h"
 #include "conffile.h"
 #include "crosshairs.h"
+#include "sgb/sgb.h"
 #include <stdio.h>
 #include <vector>
 #include <string>
@@ -614,6 +615,22 @@ static void update_variables(void)
     else
         Settings.SeparateEchoBuffer = false;
 
+    // Super Game Boy BIOS preference for .gb/.gbc content. 2 = prefer a real
+    // SNES SGB BIOS in the system dir (SGB2 then SGB1), falling back to the
+    // built-in BIOS-less GB core; 1 = SGB1 only; 0 = always BIOS-less.
+    var.key = "snes9x_sgb_bios";
+    var.value = NULL;
+    Settings.SGB_BIOSPreference = 2;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+    {
+        if (!strcmp(var.value, "off"))
+            Settings.SGB_BIOSPreference = 0;
+        else if (!strcmp(var.value, "sgb1"))
+            Settings.SGB_BIOSPreference = 1;
+        else
+            Settings.SGB_BIOSPreference = 2;
+    }
+
     var.key = "snes9x_blargg";
     var.value = NULL;
 
@@ -776,7 +793,7 @@ void retro_get_system_info(struct retro_system_info *info)
 #define GIT_VERSION ""
 #endif
     info->library_version = VERSION GIT_VERSION;
-    info->valid_extensions = "smc|sfc|swc|fig|bs";
+    info->valid_extensions = "smc|sfc|swc|fig|bs|gb|gbc|dmg|sgb";
     info->need_fullpath = false;
     info->block_extract = false;
 }
@@ -1114,6 +1131,14 @@ bool retro_load_game(const struct retro_game_info *game)
             extract_directory(g_rom_dir, game->path, sizeof(g_rom_dir));
         }
 
+        // Game Boy / Game Boy Color / Super Game Boy content takes priority:
+        // route it straight to LoadROMMem (which hands .gb/.gbc carts to the
+        // SGB subsystem) so the BS-X/Sufami header sniffs below can't grab it.
+        if (S9xRomBytesAreGb((const uint8 *) game->data, (int32) game->size)) {
+            rom_loaded = Memory.LoadROMMem((const uint8_t*)game->data, game->size, g_basename);
+        }
+
+        else
         if (is_SufamiTurbo_Cart((uint8 *) game->data, game->size)) {
             if ((rom_loaded = LoadBIOS(biosrom,"STBIOS.bin",0x40000)))
             rom_loaded = Memory.LoadMultiCartMem((const uint8_t*)game->data, game->size, 0, 0, biosrom, 0x40000);
@@ -1873,9 +1898,13 @@ void* retro_get_memory_data(unsigned type)
 
     switch(type)
     {
+        case RETRO_MEMORY_SNES_GAME_BOY_RAM:
         case RETRO_MEMORY_SNES_SUFAMI_TURBO_A_RAM:
         case RETRO_MEMORY_SAVE_RAM:
-            data = Memory.SRAM;
+            // A loaded GB/SGB cart keeps its battery RAM in the SGB cart, not
+            // in Memory.SRAM — expose that so the frontend persists the .srm.
+            // S9xSGBIsActive() is true in both BIOS and BIOS-less GB modes.
+            data = S9xSGBIsActive() ? (void *) S9xSGBGetSRAM() : (void *) Memory.SRAM;
             break;
         case RETRO_MEMORY_SNES_SUFAMI_TURBO_B_RAM:
             data = Multi.sramB;
@@ -1905,8 +1934,14 @@ size_t retro_get_memory_size(unsigned type)
     size_t size;
 
     switch(type) {
+        case RETRO_MEMORY_SNES_GAME_BOY_RAM:
         case RETRO_MEMORY_SNES_SUFAMI_TURBO_A_RAM:
         case RETRO_MEMORY_SAVE_RAM:
+            if (S9xSGBIsActive())
+            {
+                size = S9xSGBGetSRAMSize();
+                break;
+            }
             size = (unsigned) (Memory.SRAMSize ? (1 << (Memory.SRAMSize + 3)) * 128 : 0);
             if (size > 0x20000)
             size = 0x20000;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -631,6 +631,20 @@ static void update_variables(void)
             Settings.SGB_BIOSPreference = 2;
     }
 
+    // Per-source SGB mix volumes (0..100). Consumed by S9xMixSpcOverGB;
+    // only affect GB/SGB content. Defaults match the desktop frontends.
+    var.key = "snes9x_sgb_mix_volume_spc";
+    var.value = NULL;
+    S9xSGBMixVolumeSPC = 50;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+        S9xSGBMixVolumeSPC = (unsigned int) atoi(var.value);
+
+    var.key = "snes9x_sgb_mix_volume_gb";
+    var.value = NULL;
+    S9xSGBMixVolumeGB = 50;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+        S9xSGBMixVolumeGB = (unsigned int) atoi(var.value);
+
     var.key = "snes9x_blargg";
     var.value = NULL;
 
@@ -781,6 +795,12 @@ void S9xSyncSpeed() {
         audio_buffer.resize(avail);
 
     S9xMixSamples((uint8*)&audio_buffer[0], avail);
+    // Merge the SGB BIOS-mode SPC stream over the GB output (and apply the
+    // SGB mix gains). S9xMixSamples leaves the SPC ring intact in BIOS mode
+    // expecting this second pass; gtk/qt/win32 all call it right after
+    // S9xMixSamples. Without it the SPC (SGB BIOS sound engine) is silent.
+    // No-op outside SGB modes.
+    S9xMixSpcOverGB(&audio_buffer[0], (int)avail);
     audio_batch_cb(&audio_buffer[0], avail >> 1);
 }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -793,7 +793,7 @@ void retro_get_system_info(struct retro_system_info *info)
 #define GIT_VERSION ""
 #endif
     info->library_version = VERSION GIT_VERSION;
-    info->valid_extensions = "smc|sfc|swc|fig|bs|gb|gbc|dmg|sgb";
+    info->valid_extensions = "smc|sfc|swc|fig|bs|st|gb|gbc|dmg|sgb";
     info->need_fullpath = false;
     info->block_extract = false;
 }

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -791,6 +791,16 @@ void S9xSyncSpeed() {
 
     size_t avail = S9xGetSampleCount();
 
+    // In SGB BIOS mode the host output is paced by the GB sample count, so the
+    // SPC resampler has to be rate-locked to that cadence or it drifts into
+    // under/overrun (crackle) and pitch drift (bass). S9xSpcAdjustRate runs a
+    // closed-loop trim that holds the SPC buffer near its target fill, matching
+    // the win32 driver (CXAudio2::ProcessSound). Scoped to BIOS mode after the
+    // GB is released; normal SNES audio and the pre-release boot splash (which
+    // use the standard SPC path) are left untouched.
+    if (Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased())
+        S9xSpcAdjustRate(1.0);
+
     if (audio_buffer.size() < avail)
         audio_buffer.resize(avail);
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -788,7 +788,7 @@ void retro_get_system_info(struct retro_system_info *info)
 {
     memset(info,0,sizeof(retro_system_info));
 
-    info->library_name = "Snes9x";
+    info->library_name = "SuperSnes9x";
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -79,6 +79,30 @@ struct retro_core_option_definition option_defs_us[] = {
       "auto"
    },
    {
+      "snes9x_sgb_mix_volume_spc",
+      "Super Game Boy: SPC Mix Volume",
+      "Volume of the SNES SPC stream (the Super Game Boy BIOS sound engine - sound effects, voice clips, border jingles) when mixed under Game Boy audio in SGB BIOS mode. Only affects GB/SGB content; ignored by SNES games and in BIOS-less mode.",
+      {
+         { "0", NULL }, { "10", NULL }, { "20", NULL }, { "30", NULL },
+         { "40", NULL }, { "50", NULL }, { "60", NULL }, { "70", NULL },
+         { "80", NULL }, { "90", NULL }, { "100", NULL },
+         { NULL, NULL },
+      },
+      "50"
+   },
+   {
+      "snes9x_sgb_mix_volume_gb",
+      "Super Game Boy: GB Mix Volume",
+      "Volume of the Game Boy audio stream when running GB/SGB content. In SGB BIOS mode it is balanced against the SPC stream; in BIOS-less mode it acts as a plain Game Boy volume control (set to 100 for full-volume Game Boy).",
+      {
+         { "0", NULL }, { "10", NULL }, { "20", NULL }, { "30", NULL },
+         { "40", NULL }, { "50", NULL }, { "60", NULL }, { "70", NULL },
+         { "80", NULL }, { "90", NULL }, { "100", NULL },
+         { NULL, NULL },
+      },
+      "50"
+   },
+   {
       "snes9x_aspect",
       "Preferred Aspect Ratio",
       "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -67,6 +67,18 @@ struct retro_core_option_definition option_defs_us[] = {
       "auto"
    },
    {
+      "snes9x_sgb_bios",
+      "Super Game Boy BIOS Mode (Reload Game)",
+      "Choose how Game Boy / Super Game Boy content boots. 'Prefer SGB BIOS' uses a real SNES Super Game Boy BIOS placed in the system directory (sgb2.sfc / SGB2.sfc / sgb.sfc / SGB.sfc) for authentic SGB sound and borders - preferring SGB2 then SGB1 - and falls back to the built-in BIOS-less core if none is found. 'SGB1 BIOS only' restricts the search to an SGB1 BIOS. 'BIOS-less' always runs the built-in Game Boy core directly. Note: Game Boy Color content runs in monochrome DMG-compatibility mode (no color hardware emulation).",
+      {
+         { "auto", "Prefer SGB BIOS (SGB2 > SGB1 > BIOS-less)" },
+         { "sgb1", "SGB1 BIOS only" },
+         { "off",  "BIOS-less (built-in core)" },
+         { NULL, NULL },
+      },
+      "auto"
+   },
+   {
       "snes9x_aspect",
       "Preferred Aspect Ratio",
       "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",

--- a/libretro/supersnes9x_libretro.info
+++ b/libretro/supersnes9x_libretro.info
@@ -1,0 +1,48 @@
+# Software Information
+display_name = "Nintendo - SNES / SFC / SGB / GB / GBC (SuperSnes9x)"
+categories = "Emulator"
+authors = "Snes9x Team"
+corename = "SuperSnes9x"
+supported_extensions = "smc|sfc|swc|fig|bs|st|gb|gbc|dmg|sgb"
+license = "Non-commercial"
+permissions = ""
+display_version = "1.63"
+
+# Hardware Information
+manufacturer = "Nintendo"
+systemname = "SNES / SFC / SGB / GB / GBC"
+systemid = "super_nes"
+
+# Firmware / BIOS
+firmware_count = 4
+firmware0_desc = "BS-X.bin (BS-X - Sore wa Namae o Nusumareta Machi no Monogatari (Japan) (Rev 1))"
+firmware0_path = "BS-X.bin"
+firmware0_opt = "true"
+firmware1_desc = "STBIOS.bin (Sufami Turbo (Japan))"
+firmware1_path = "STBIOS.bin"
+firmware1_opt = "true"
+firmware2_desc = "sgb.sfc (Super Game Boy BIOS - optional, enables authentic SGB mode for GB/GBC)"
+firmware2_path = "sgb.sfc"
+firmware2_opt = "true"
+firmware3_desc = "sgb2.sfc (Super Game Boy 2 BIOS - optional, preferred SGB mode for GB/GBC)"
+firmware3_path = "sgb2.sfc"
+firmware3_opt = "true"
+notes = "(!) BS-X.bin (md5): fed4d8242cfbed61343d53d48432aced|(!) STBIOS.bin (md5): d3a44ba7d42a74d3ac58cb9c14c6a5ca|(!) Super Game Boy BIOS (sgb.sfc / sgb2.sfc) is optional: without it, GB/GBC content runs on the built-in BIOS-less core. Place it in the system directory.|(!) Game Boy Color content runs in monochrome DMG-compatibility mode (no color hardware emulation)."
+
+# Libretro Features
+savestate = "true"
+savestate_features = "deterministic"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+core_options_version = "1.3"
+load_subsystem = "true"
+supports_no_game = "false"
+database = "Nintendo - Super Nintendo Entertainment System|Nintendo - Sufami Turbo|Nintendo - Satellaview|Nintendo - Game Boy|Nintendo - Game Boy Color"
+hw_render = "false"
+needs_fullpath = "false"
+disk_control = "false"
+
+description = "SuperSnes9x is a Snes9x-based core extended to also load and run Game Boy (.gb), Super Game Boy (.sgb), and Game Boy Color (.gbc) content via the bundled SGB subsystem, in addition to SNES/SFC, Satellaview and Sufami Turbo. Game Boy and Super Game Boy are fully supported (BIOS or BIOS-less); .gbc runs in monochrome DMG-compatibility mode. Place a real Super Game Boy BIOS (sgb.sfc / sgb2.sfc) in the system directory for authentic SGB sound and borders."

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -1449,6 +1449,25 @@ bool8 CMemory::LoadROMMem (const uint8 *source, uint32 sourceSize, const char* o
     else
         ROMFilename = "MemoryROM";
 
+    // In-memory GB/SGB detection — mirror LoadROM so libretro and other
+    // in-memory callers route .gb/.gbc carts (including ones wrapped in a
+    // container) into the SGB subsystem instead of the 65816 parser.
+    {
+        int gb = LoadGBFromBytes(source, sourceSize, optional_rom_filename);
+        if (gb > 0) return TRUE;
+        if (gb < 0) return FALSE;
+    }
+
+    // Not a GB ROM — tear down any previous SGB session so a SNES ROM loaded
+    // after a GB ROM runs on the 65816 path.
+    if (Settings.SuperGameBoy || Settings.SGB_BIOSModeActive)
+    {
+        S9xSGBDeinit();
+        Settings.SuperGameBoy       = FALSE;
+        Settings.SGB_BIOSModeActive = FALSE;
+    }
+    Settings.GBRomPath[0] = '\0';
+
     do
     {
         memset(ROM,0, MAX_ROM_SIZE);
@@ -1542,7 +1561,7 @@ static bool S9xRomBytesAreSachenScrambledGbHeader(const uint8 *rom, int32 size)
     return sum == rom[SachenScrambleAddr(0x014D)];
 }
 
-static bool S9xRomBytesAreGb(const uint8 *rom, int32 size)
+bool S9xRomBytesAreGb(const uint8 *rom, int32 size)
 {
     if (size < 0x150 || !rom) return false;
     if (memcmp(rom + 0x0104, kGbNintendoLogo, 48) == 0) return true;
@@ -1599,6 +1618,77 @@ static uint8 GbFileCgbFlag(const char *filename)
     }
     fclose(f);
     return flag;
+}
+
+// Detect and load a Game Boy ROM straight from a memory buffer. Mirrors the
+// content-sniff branch in LoadROM so in-memory callers (LoadROMMem, and thus
+// the libretro core) route .gb/.gbc carts into the SGB subsystem too instead
+// of feeding them to the 65816 parser.
+//   returns  1 : handled — loaded as a GB/SGB cart (caller should return TRUE)
+//            0 : not a GB ROM — caller continues with the normal SNES path
+//           -1 : GB ROM but the load failed (caller should return FALSE)
+int CMemory::LoadGBFromBytes (const uint8 *rom, uint32 size, const char *filename)
+{
+    if (!S9xRomBytesAreGb(rom, static_cast<int32>(size)))
+        return 0;
+
+    if (filename && *filename)
+    {
+        strncpy(Settings.GBRomPath, filename, sizeof(Settings.GBRomPath) - 1);
+        Settings.GBRomPath[sizeof(Settings.GBRomPath) - 1] = '\0';
+    }
+    else
+        Settings.GBRomPath[0] = '\0';
+
+    const uint8 gbFlag    = GbBytesCgbFlag(rom, (size_t)size);
+    const bool  gbCgb     = (gbFlag & 0x80) != 0;
+    const bool  gbCgbOnly = (gbFlag == 0xC0);
+
+    std::string bios_path;
+    uint8 bios_mode = 0;
+    if (Settings.SGB_BIOSPreference >= 2 && FindSGB_BIOS(2, filename, bios_path))
+    {
+        bios_mode = 2;
+    }
+    else if (Settings.SGB_BIOSPreference >= 1)
+    {
+        bios_path.clear();
+        if (FindSGB_BIOS(1, filename, bios_path)) bios_mode = 1;
+        else bios_path.clear();
+    }
+
+    if (!gbCgbOnly && bios_mode &&
+        LoadROMWithSGBBIOSBytes(rom, size, filename, bios_path.c_str()))
+    {
+        EmitSGBLoadBanner(filename, bios_mode);
+        return 1;
+    }
+
+    // BIOS-less fallback — the legacy path that runs our GB core directly in
+    // S9xMainLoop, gated on Settings.SuperGameBoy.
+    S9xDeleteCheats();
+    if (Settings.SuperGameBoy) S9xSGBDeinit();
+    if (Settings.SGB_BIOSModeActive) Settings.SGB_BIOSModeActive = FALSE;
+    Settings.SuperGameBoy      = TRUE;
+    Settings.GameBoyRunMode    = gbCgb ? 0 : 1;   // CGB carts run BIOS-less in CGB mode
+    Settings.GBClockMultiplier = 1.0f;
+
+    if (!S9xSGBInit() ||
+        !S9xSGBLoadROMBytes(rom, static_cast<size_t>(size), filename))
+    {
+        Settings.SuperGameBoy = FALSE;
+        Settings.GBRomPath[0] = '\0';
+        return -1;
+    }
+    S9xSGBSetAudioRate(Settings.SoundPlaybackRate);
+    S9xInitCheatData();
+    if (filename && *filename)
+    {
+        ROMFilename = filename;
+        S9xLoadCheatFile(S9xGetFilename(".cht", CHEAT_DIR).c_str());
+    }
+    EmitSGBLoadBanner(filename, 0);
+    return 1;
 }
 
 bool8 CMemory::LoadROM (const char *filename)
@@ -1687,54 +1777,10 @@ bool8 CMemory::LoadROM (const char *filename)
         // because FileLoader accepted the extension. If the unzipped
         // content carries the Nintendo logo it's a GB cart — route
         // into the SGB subsystem instead of the 65816 parser.
-        if (S9xRomBytesAreGb(ROM, totalFileSize))
         {
-            strncpy(Settings.GBRomPath, filename, sizeof(Settings.GBRomPath) - 1);
-            Settings.GBRomPath[sizeof(Settings.GBRomPath) - 1] = '\0';
-
-            const uint8 gbFlag    = GbBytesCgbFlag(ROM, (size_t)totalFileSize);
-            const bool  gbCgb     = (gbFlag & 0x80) != 0;
-
-            std::string bios_path;
-            uint8 bios_mode = 0;
-            if (Settings.SGB_BIOSPreference >= 2 && FindSGB_BIOS(2, filename, bios_path))
-            {
-                bios_mode = 2;
-            }
-            else if (Settings.SGB_BIOSPreference >= 1)
-            {
-                bios_path.clear();
-                if (FindSGB_BIOS(1, filename, bios_path)) bios_mode = 1;
-                else bios_path.clear();
-            }
-
-            if (bios_mode &&
-                LoadROMWithSGBBIOSBytes(ROM, (uint32)totalFileSize,
-                                         filename, bios_path.c_str()))
-            {
-                EmitSGBLoadBanner(filename, bios_mode);
-                return TRUE;
-            }
-
-            // BIOS-less fallback (legacy path).
-            S9xDeleteCheats();
-            if (Settings.SGB_BIOSModeActive) Settings.SGB_BIOSModeActive = FALSE;
-            Settings.SuperGameBoy      = TRUE;
-            Settings.GameBoyRunMode    = gbCgb ? 0 : 1;
-            Settings.GBClockMultiplier = 1.0f;
-            if (!S9xSGBInit() ||
-                !S9xSGBLoadROMBytes(ROM, static_cast<size_t>(totalFileSize), filename))
-            {
-                Settings.SuperGameBoy = FALSE;
-                Settings.GBRomPath[0] = '\0';
-                return FALSE;
-            }
-            S9xSGBSetAudioRate(Settings.SoundPlaybackRate);
-            S9xInitCheatData();
-            ROMFilename = filename;
-            S9xLoadCheatFile(S9xGetFilename(".cht", CHEAT_DIR).c_str());
-            EmitSGBLoadBanner(filename, 0);
-            return TRUE;
+            int gb = LoadGBFromBytes(ROM, (uint32)totalFileSize, filename);
+            if (gb > 0) return TRUE;
+            if (gb < 0) return FALSE;
         }
 
         CheckForAnyPatch(filename, HeaderCount != 0, totalFileSize);

--- a/memmap.h
+++ b/memmap.h
@@ -115,6 +115,10 @@ struct CMemory
 	bool8	LoadROMWithSGBBIOS (const char *gb_path, const char *bios_path);
 	bool8	LoadROMWithSGBBIOSBytes (const uint8 *gb_bytes, uint32 gb_size,
 	                                  const char *gb_path, const char *bios_path);
+	// Detect+load a Game Boy ROM from a memory buffer, routing it into the
+	// SGB subsystem. Returns 1 = handled (loaded as GB/SGB), 0 = not a GB
+	// ROM, -1 = GB ROM but the load failed.
+	int		LoadGBFromBytes (const uint8 *rom, uint32 size, const char *filename);
     bool8	LoadROMInt (int32);
     bool8   LoadMultiCartMem (const uint8 *, uint32, const uint8 *, uint32, const uint8 *, uint32);
 	bool8	LoadMultiCart (const char *, const char *);
@@ -215,6 +219,10 @@ inline bool S9xInterlaceField()
 void S9xAutoSaveSRAM (void);
 bool8 LoadZip(const char *, uint32 *, uint8 *);
 bool8 S9xSGBBIOSAvailable(uint8 mode, const char *gb_rom_path);
+// Content-sniff a buffer for a Game Boy cart (Nintendo logo at 0x0104, incl.
+// the Sachen scrambled variant). Lets in-memory callers route GB carts away
+// from the SNES/BS-X/Sufami load paths.
+bool S9xRomBytesAreGb(const uint8 *rom, int32 size);
 
 enum s9xwrap_t
 {

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -8,6 +8,7 @@ namespace fs = std::filesystem;
 #include "snes9x.h"
 #include "memmap.h"
 #include "apu/apu.h"
+#include "sgb/sgb.h"
 #include "gfx.h"
 #include "snapshot.h"
 #include "controls.h"
@@ -572,6 +573,13 @@ void Snes9xController::SamplesAvailable()
         int samples = S9xGetSampleCount();
         if (data.size() < samples)
             data.resize(samples);
+        // SGB BIOS mode: lock the SPC resampler to the GB-paced consumption so
+        // it doesn't drift into under/overrun (crackle) and pitch drift (bass).
+        // Matches the win32 driver; only after GB release, so normal SNES audio
+        // and the boot splash are left untouched.
+        if (Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased())
+            S9xSpcAdjustRate(1.0);
+
         S9xMixSamples((uint8_t *)data.data(), samples);
         S9xMixSpcOverGB(data.data(), samples);
         sound_output_function(data.data(), samples);

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -573,12 +573,16 @@ void Snes9xController::SamplesAvailable()
         int samples = S9xGetSampleCount();
         if (data.size() < samples)
             data.resize(samples);
-        // SGB BIOS mode: lock the SPC resampler to the GB-paced consumption so
-        // it doesn't drift into under/overrun (crackle) and pitch drift (bass).
-        // Matches the win32 driver; only after GB release, so normal SNES audio
-        // and the boot splash are left untouched.
+        // SGB BIOS mode: the host output is paced by the GB sample count, which
+        // runs a few percent off the SPC's native rate. Drive the SPC production
+        // rate (PI controller) to hold its resampler buffer matched to that
+        // cadence -- otherwise it overflows (noise) and the under-drain pitches
+        // it down (bass). Reset the trim outside BIOS mode so a SNES game loaded
+        // afterward isn't left with the SGB rate scaling.
         if (Settings.SGB_BIOSModeActive && S9xSGBBIOSGBIsReleased())
-            S9xSpcAdjustRate(1.0);
+            S9xSpcSyncToConsumption();
+        else
+            S9xSpcSyncReset();
 
         S9xMixSamples((uint8_t *)data.data(), samples);
         S9xMixSpcOverGB(data.data(), samples);

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -814,6 +814,18 @@ size_t Emulator::GetROMSize() const
 	return impl_->cart.rom.size();
 }
 
+uint8_t *Emulator::GetSRAMData()
+{
+	if (!impl_->has_rom || impl_->cart.sram.empty()) return nullptr;
+	return impl_->cart.sram.data();
+}
+
+size_t Emulator::GetSRAMSize() const
+{
+	if (!impl_->has_rom) return 0;
+	return impl_->cart.sram.size();
+}
+
 const uint8_t *Emulator::GBLayerMask() const
 {
 	if (!impl_->has_rom) return nullptr;
@@ -2399,6 +2411,8 @@ bool S9xSGBHasBattery(void)         { return SGB::Instance().HasBattery(); }
 bool S9xSGBSaveBatteryToPath(const char *path) { return SGB::Instance().SaveBatteryToPath(path); }
 bool S9xSGBLoadBatteryFromPath(const char *path) { return SGB::Instance().LoadBatteryFromPath(path); }
 bool S9xSGBTakeSramDirty(void)      { return SGB::Instance().TakeSramDirty(); }
+unsigned char *S9xSGBGetSRAM(void)  { return SGB::Instance().GetSRAMData(); }
+size_t S9xSGBGetSRAMSize(void)      { return SGB::Instance().GetSRAMSize(); }
 void S9xSGBRunFrame(void)           { SGB::Instance().RunFrame(); }
 void S9xSGBRunCycles(int tcycles)   { SGB::Instance().RunCycles(static_cast<int32_t>(tcycles)); }
 

--- a/sgb/sgb.h
+++ b/sgb/sgb.h
@@ -72,6 +72,12 @@ public:
 	bool LoadBatteryFromPath(const char *path);
 	bool TakeSramDirty();
 
+	// Raw cart battery-RAM accessor so a host (e.g. the libretro core) can
+	// expose it as a savable memory region. Returns nullptr / 0 when the
+	// loaded cart has no SRAM.
+	uint8_t       *GetSRAMData();
+	size_t         GetSRAMSize() const;
+
 	// Raw cart ROM accessor for hashing / external introspection. Returns
 	// nullptr when no ROM is loaded.
 	const uint8_t *GetROMData() const;
@@ -480,5 +486,11 @@ bool S9xSGBHasBattery(void);
 bool S9xSGBSaveBatteryToPath(const char *path);
 bool S9xSGBLoadBatteryFromPath(const char *path);
 bool S9xSGBTakeSramDirty(void);
+
+// Raw cart battery-RAM pointer + size, for hosts that persist save RAM via a
+// memory-region API (e.g. libretro's RETRO_MEMORY_SAVE_RAM). nullptr / 0 when
+// the loaded cart has no battery-backed SRAM.
+unsigned char *S9xSGBGetSRAM(void);
+size_t         S9xSGBGetSRAMSize(void);
 
 #endif


### PR DESCRIPTION
## Summary

Brings **Game Boy / Super Game Boy / Game Boy Color** support to the libretro core by wiring the bundled `sgb/` emulator into the libretro frontend, and rebrands the core as **SuperSnes9x**.

- **GB / SGB** — fully supported: authentic BIOS mode (real SNES SGB1/SGB2 BIOS in the system dir) and a BIOS-less fallback.
- **GBC** — `.gbc` loads and runs in **monochrome DMG-compatibility mode** (the bundled core has no CGB color hardware — parity with the desktop builds; full color would be a separate, much larger effort).

The snes9x core already routes GB execution, audio, video, save states and reset through the SGB subsystem when a GB cart is active — the gaps were all in the libretro layer.

## Changes

- **memmap** — extract the GB detect+load logic out of `LoadROM` into a reusable `CMemory::LoadGBFromBytes()` and call it from `LoadROMMem` too, so in-memory loads (libretro's path) route `.gb`/`.gbc` carts into the SGB subsystem like file loads already did. Tear down a prior SGB session on the non-GB in-memory path. Expose `S9xRomBytesAreGb()`.
- **sgb** — add `S9xSGBGetSRAM()` / `S9xSGBGetSRAMSize()` to expose GB cart battery RAM to a host memory-region API.
- **libretro**
  - advertise `gb|gbc|dmg|sgb` (and `st`) in `valid_extensions`, aligned with the info file's `supported_extensions`
  - route GB content ahead of the BS-X/Sufami sniffs in `retro_load_game`
  - expose GB cart SRAM via `RETRO_MEMORY_SAVE_RAM`, gated on `S9xSGBIsActive()` (covers both BIOS and BIOS-less modes)
  - new **Super Game Boy BIOS Mode** core option (prefer SGB BIOS / SGB1 only / BIOS-less; default prefer-BIOS)
- **Rename + branding** — `TARGET_NAME` → `supersnes9x` (Makefile, Tupfile, MSVC `.vcxproj`) so the core builds as `supersnes9x_libretro.{so,dll,…}`; `library_name` → `SuperSnes9x`; add `supersnes9x_libretro.info` with display name *"Nintendo - SNES / SFC / SGB / GB / GBC (SuperSnes9x)"*, Game Boy / Game Boy Color databases for playlist scanning, and the SGB BIOS as optional firmware.

## What works for free (verified)

Audio (`S9xMixSamples`/`S9xGetSampleCount`), video (256×224 SGB composite via the existing `video_cb`), save states (`S9xFreezeSize`/`S9xFreezeGameMem` embed the SGB blob), reset, and BIOS lookup (`BIOS_DIR` = RetroArch system dir).

## Testing

Built `supersnes9x_libretro.so` (Linux) and cross-compiled `supersnes9x_libretro.dll` (Windows x64 via mingw-w64; self-contained — depends only on `KERNEL32.dll` + `msvcrt.dll`). Drove the core with a `dlopen` harness like a frontend would:

- DMG `.gb`, SGB-flagged `.gb`, and `.gbc` → all load, render 256×224, push audio, no crashes
- Battery cart (MBC5+RAM) → `RETRO_MEMORY_SAVE_RAM` exposes the 8 KB cart SRAM in **both** BIOS-less and BIOS modes
- Real `SGB2.sfc` in the system dir → loads via the SGB LoROM map (genuine BIOS mode)
- SNES regression (Street Fighter II Turbo) → unaffected

## Notes

- GBC color emulation is out of scope here (no color PPU, VRAM/WRAM banking, HDMA, or KEY1 double-speed) — `.gbc` runs DMG-compat mono.
- To get the display title in RetroArch, drop `supersnes9x_libretro.info` into RetroArch's `info/` directory (matched to the core by filename).
