### PR TITLE
win32: mask GetAsyncKeyState high bit when reading hotkey modifiers

### DIFF
--- a/snes9x.h
+++ b/snes9x.h
@@ -9,7 +9,7 @@
 
 #ifndef VERSION
 #define VERSION	"1.63"
-#define PATCH_VERSION "19"
+#define PATCH_VERSION "20"
 #define VERSION_DISPLAY VERSION "." PATCH_VERSION
 #endif
 

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -987,11 +987,11 @@ int HandleKeyMessage(WPARAM wParam, LPARAM lParam)
 	if(!(wParam == 0 || wParam == VK_ESCAPE)) // if it's the 'disabled' key, it's never pressed as a hotkey
 	{
 		int modifiers = 0;
-		if(GetAsyncKeyState(VK_MENU))
+		if(GetAsyncKeyState(VK_MENU) & 0x8000)
 			modifiers |= CUSTKEY_ALT_MASK;
-		if(GetAsyncKeyState(VK_CONTROL))
+		if(GetAsyncKeyState(VK_CONTROL) & 0x8000)
 			modifiers |= CUSTKEY_CTRL_MASK;
-		if(GetAsyncKeyState(VK_SHIFT))
+		if(GetAsyncKeyState(VK_SHIFT) & 0x8000)
 			modifiers |= CUSTKEY_SHIFT_MASK;
 
 		{
@@ -1826,11 +1826,11 @@ LRESULT CALLBACK WinProc(
 	case WM_CUSTKEYUP:
 		{
 			int modifiers = 0;
-			if(GetAsyncKeyState(VK_MENU) || wParam == VK_MENU)
+			if((GetAsyncKeyState(VK_MENU) & 0x8000) || wParam == VK_MENU)
 				modifiers |= CUSTKEY_ALT_MASK;
-			if(GetAsyncKeyState(VK_CONTROL)|| wParam == VK_CONTROL)
+			if((GetAsyncKeyState(VK_CONTROL) & 0x8000) || wParam == VK_CONTROL)
 				modifiers |= CUSTKEY_CTRL_MASK;
-			if(GetAsyncKeyState(VK_SHIFT)|| wParam == VK_SHIFT)
+			if((GetAsyncKeyState(VK_SHIFT) & 0x8000) || wParam == VK_SHIFT)
 				modifiers |= CUSTKEY_SHIFT_MASK;
 
 			// Master hotkey key-up: reset hold timer


### PR DESCRIPTION
## Problem

Reported on Win10 (not reproducible on Win11): after pausing/fast-forwarding/etc. via a hotkey, opening any emulator menu and pressing Shift or Ctrl, then returning to the game, the **first** hotkey press does nothing — it only triggers on the second press.

## Root cause

The hotkey handler read the Alt/Ctrl/Shift modifier state from the **raw** `GetAsyncKeyState` return value:

```cpp
if(GetAsyncKeyState(VK_SHIFT)) modifiers |= CUSTKEY_SHIFT_MASK;
```

`GetAsyncKeyState` returns two independent bits:
- `0x8000` — key is **currently held** (what we want)
- `0x0001` — key was **pressed since the last call for that key** (stale, racy "recently pressed" flag)

Pressing a modifier inside a menu sets the low bit. While the menu is open / emulation is paused, nothing calls `GetAsyncKeyState` on that modifier to clear it. On the next `WM_KEYDOWN`, the handler reads the stale `0x0001`, fabricates a phantom modifier, and the exact-match test (`modifiers == binding->modifiers`) fails against an unmodified hotkey binding — so the press is swallowed. That read clears the low bit, so the second press matches and fires.

The low bit is documented as unreliable and is shared across processes, which is why Win11 (some background process polls it away) doesn't show it but Win10 does. Every other "is key down" check in the file already masks `& 0x8000` (or `GetKeyState & 0x80`); these modifier reads were the only ones that didn't.

## Fix

Mask with `& 0x8000` on both the keydown (`wsnes9x.cpp:990-994`) and keyup (`1829-1833`) modifier reads. The keyup `|| wParam == VK_*` clauses are preserved so releasing the modifier key itself still registers. The deliberately-unmasked `VK_PAUSE` read in `win32.cpp` is intentional and left untouched.

Also bumps `PATCH_VERSION` 19 → 20.