### PR TITLE
win32: fix multi-bind/single-bind input config glitches

### DIFF
--- a/win32/InputCustom.cpp
+++ b/win32/InputCustom.cpp
@@ -627,6 +627,7 @@ static LRESULT CALLBACK InputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam, L
         icp->maxKeys   = MAX_BIND_KEYS;
         icp->capturing = false;
         icp->inContextMenu = false;
+        icp->modeRefresh = false;
 
         // Assign the window text specified in the call to CreateWindow.
         SetWindowText(hwnd, ((CREATESTRUCT *)lParam)->lpszName);
@@ -732,8 +733,11 @@ static LRESULT CALLBACK InputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam, L
     }
 	case WM_USER+44:
 	{
-		// Don't overwrite while actively capturing input (display is managed by WM_KEYDOWN)
-		if (icp->capturing)
+		// Don't overwrite while actively capturing input (display is managed by WM_KEYDOWN),
+		// except for the one-shot refresh right after a binding-mode change.
+		bool modeRefresh = icp->capturing && icp->modeRefresh;
+		icp->modeRefresh = false;
+		if (icp->capturing && !modeRefresh)
 			break;
 
 		// Multi-bind protocol: wParam = pointer to WORD[MAX_BIND_KEYS] array, lParam = count
@@ -765,6 +769,15 @@ static LRESULT CALLBACK InputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam, L
 			col = CheckButtonKey(wParam);
 		}
 
+		if (modeRefresh)
+		{
+			if (icp->numKeys == 0)
+				strcpy(temp, "...");
+			else if (icp->maxKeys > 1 && icp->numKeys < icp->maxKeys)
+				strcat(temp, ", ...");
+			col = RGB( 0,255,0);
+		}
+
 		if(!IsWindowEnabled(hwnd))
 		{
 			col = RGB( 192,192,192);
@@ -782,30 +795,9 @@ static LRESULT CALLBACK InputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam, L
 	{
 		// Set maxKeys: wParam = new maxKeys value
 		int newMax = max(1, min((int)wParam, MAX_BIND_KEYS));
-		bool changed = (newMax != icp->maxKeys);
+		if (newMax != icp->maxKeys && icp->capturing)
+			icp->modeRefresh = true;
 		icp->maxKeys = newMax;
-
-		if (changed && icp->capturing)
-		{
-			col = RGB( 0,255,0);
-			icp->crForeGnd = ((~col) & 0x00ffffff);
-			icp->crBackGnd = col;
-			if (icp->maxKeys > 1 && icp->numKeys > 0)
-			{
-				TranslateMultiKey(icp->keys, icp->numKeys, temp);
-				if (icp->numKeys < icp->maxKeys)
-					strcat(temp, ", ...");
-				SetWindowText(hwnd, _tFromChar(temp));
-			}
-			else
-			{
-				icp->numKeys = 0;
-				memset(icp->keys, 0, sizeof(icp->keys));
-				SetWindowText(hwnd, _T("..."));
-			}
-			InvalidateRect(icp->hwnd, NULL, FALSE);
-			UpdateWindow(icp->hwnd);
-		}
 		break;
 	}
 
@@ -1083,6 +1075,7 @@ static LRESULT CALLBACK HotInputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam
         icp->maxKeys   = 1;
         icp->capturing = false;
         icp->inContextMenu = false;
+        icp->modeRefresh = false;
 
         // Assign the window text specified in the call to CreateWindow.
         SetWindowText(hwnd, ((CREATESTRUCT *)lParam)->lpszName);
@@ -1316,8 +1309,11 @@ static LRESULT CALLBACK HotInputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam
 		break;
 	case WM_USER+44:
 	{
-		// Don't overwrite while actively capturing input (display is managed by WM_KEYDOWN)
-		if (icp->capturing)
+		// Don't overwrite while actively capturing input (display is managed by WM_KEYDOWN),
+		// except for the one-shot refresh right after a binding-mode change.
+		bool modeRefresh = icp->capturing && icp->modeRefresh;
+		icp->modeRefresh = false;
+		if (icp->capturing && !modeRefresh)
 			break;
 
 		// Set a hotkey field
@@ -1364,6 +1360,17 @@ static LRESULT CALLBACK HotInputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam
 			else
 				col = RGB(192,192,192);
 		}
+
+		if (modeRefresh)
+		{
+			if (icp->numKeys == 0)
+				strcpy(temp, "...");
+			else if (icp->maxKeys > 1 && icp->numKeys < icp->maxKeys)
+				strcat(temp, ", ...");
+			if (IsWindowEnabled(hwnd))
+				col = RGB( 0,255,0);
+		}
+
 		icp->crForeGnd = ((~col) & 0x00ffffff);
 		icp->crBackGnd = col;
 		SetWindowText(hwnd,_tFromChar(temp));
@@ -1376,32 +1383,12 @@ static LRESULT CALLBACK HotInputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam
 	{
 		// Set maxKeys: wParam = new maxKeys value
 		int newMax = max(1, min((int)wParam, MAX_BIND_KEYS));
-		bool changed = (newMax != icp->maxKeys);
-		icp->maxKeys = newMax;
-
-		if (changed && icp->capturing)
+		if (newMax != icp->maxKeys && icp->capturing)
 		{
 			keyPressLock = false;
-			col = RGB( 0,255,0);
-			icp->crForeGnd = ((~col) & 0x00ffffff);
-			icp->crBackGnd = col;
-			if (icp->maxKeys > 1 && icp->numKeys > 0)
-			{
-				TranslateMultiHotKey(icp->keys, icp->mods, icp->numKeys, temp);
-				if (icp->numKeys < icp->maxKeys)
-					strcat(temp, ", ...");
-				SetWindowText(hwnd, _tFromChar(temp));
-			}
-			else
-			{
-				icp->numKeys = 0;
-				memset(icp->keys, 0, sizeof(icp->keys));
-				memset(icp->mods, 0, sizeof(icp->mods));
-				SetWindowText(hwnd, _T("..."));
-			}
-			InvalidateRect(icp->hwnd, NULL, FALSE);
-			UpdateWindow(icp->hwnd);
+			icp->modeRefresh = true;
 		}
+		icp->maxKeys = newMax;
 		break;
 	}
 

--- a/win32/InputCustom.cpp
+++ b/win32/InputCustom.cpp
@@ -781,7 +781,31 @@ static LRESULT CALLBACK InputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam, L
 	case WM_USER+47:
 	{
 		// Set maxKeys: wParam = new maxKeys value
-		icp->maxKeys = max(1, min((int)wParam, MAX_BIND_KEYS));
+		int newMax = max(1, min((int)wParam, MAX_BIND_KEYS));
+		bool changed = (newMax != icp->maxKeys);
+		icp->maxKeys = newMax;
+
+		if (changed && icp->capturing)
+		{
+			col = RGB( 0,255,0);
+			icp->crForeGnd = ((~col) & 0x00ffffff);
+			icp->crBackGnd = col;
+			if (icp->maxKeys > 1 && icp->numKeys > 0)
+			{
+				TranslateMultiKey(icp->keys, icp->numKeys, temp);
+				if (icp->numKeys < icp->maxKeys)
+					strcat(temp, ", ...");
+				SetWindowText(hwnd, _tFromChar(temp));
+			}
+			else
+			{
+				icp->numKeys = 0;
+				memset(icp->keys, 0, sizeof(icp->keys));
+				SetWindowText(hwnd, _T("..."));
+			}
+			InvalidateRect(icp->hwnd, NULL, FALSE);
+			UpdateWindow(icp->hwnd);
+		}
 		break;
 	}
 
@@ -1351,7 +1375,33 @@ static LRESULT CALLBACK HotInputCustomWndProc(HWND hwnd, UINT msg, WPARAM wParam
 	case WM_USER+47:
 	{
 		// Set maxKeys: wParam = new maxKeys value
-		icp->maxKeys = max(1, min((int)wParam, MAX_BIND_KEYS));
+		int newMax = max(1, min((int)wParam, MAX_BIND_KEYS));
+		bool changed = (newMax != icp->maxKeys);
+		icp->maxKeys = newMax;
+
+		if (changed && icp->capturing)
+		{
+			keyPressLock = false;
+			col = RGB( 0,255,0);
+			icp->crForeGnd = ((~col) & 0x00ffffff);
+			icp->crBackGnd = col;
+			if (icp->maxKeys > 1 && icp->numKeys > 0)
+			{
+				TranslateMultiHotKey(icp->keys, icp->mods, icp->numKeys, temp);
+				if (icp->numKeys < icp->maxKeys)
+					strcat(temp, ", ...");
+				SetWindowText(hwnd, _tFromChar(temp));
+			}
+			else
+			{
+				icp->numKeys = 0;
+				memset(icp->keys, 0, sizeof(icp->keys));
+				memset(icp->mods, 0, sizeof(icp->mods));
+				SetWindowText(hwnd, _T("..."));
+			}
+			InvalidateRect(icp->hwnd, NULL, FALSE);
+			UpdateWindow(icp->hwnd);
+		}
 		break;
 	}
 

--- a/win32/InputCustom.h
+++ b/win32/InputCustom.h
@@ -32,6 +32,7 @@ typedef struct
     int      maxKeys;               // max allowed keys (1=single, MAX_BIND_KEYS=multi)
     bool     capturing;             // true while actively waiting for input
     bool     inContextMenu;         // true while right-click context menu is open
+    bool     modeRefresh;           // one-shot: let next refresh through while capturing after a mode change
 } InputCust;
 COLORREF CheckButtonKey( WORD Key);
 COLORREF CheckHotKey( WORD Key, int modifiers);

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -10441,7 +10441,7 @@ static void UpdateBindingMode(HWND hDlg, int index)
 	int bindMode = SendDlgItemMessage(hDlg, IDC_BINDINGCOMBO, CB_GETCURSEL, 0, 0);
 	bool isMulti = (bindMode == 1);
 	ShowWindow(GetDlgItem(hDlg, IDC_ALLOWMULTIBIND), isMulti ? SW_SHOW : SW_HIDE);
-	int maxKeys = (isMulti && IsDlgButtonChecked(hDlg, IDC_ALLOWMULTIBIND)) ? MAX_BIND_KEYS : 1;
+	int maxKeys = isMulti ? MAX_BIND_KEYS : 1;
 	SetInputMaxKeys(hDlg, maxKeys);
 	set_buttoninfo(index, hDlg);
 }
@@ -10911,7 +10911,7 @@ static void UpdateHotkeyBindingMode(HWND hDlg)
 	int bindMode = SendDlgItemMessage(hDlg, IDC_BINDINGCOMBO_HK, CB_GETCURSEL, 0, 0);
 	bool isMulti = (bindMode == 1);
 	ShowWindow(GetDlgItem(hDlg, IDC_ALLOWMULTIBIND_HK), isMulti ? SW_SHOW : SW_HIDE);
-	int maxKeys = (isMulti && IsDlgButtonChecked(hDlg, IDC_ALLOWMULTIBIND_HK)) ? MAX_BIND_KEYS : 1;
+	int maxKeys = isMulti ? MAX_BIND_KEYS : 1;
 	SetHotkeyMaxKeys(hDlg, maxKeys);
 	set_hotkeyinfo(hDlg, true);
 }


### PR DESCRIPTION
Fixes #99 and two related glitches in the controller/hotkey input-config dialogs.

## 1. Single↔Multi loses the ability to multi-bind (#99)
The dialog computed the per-button max key count two inconsistent ways:
- **On open** (`WM_INITDIALOG`): based on the Single/Multi combo alone.
- **On combo/checkbox change** (`UpdateBindingMode` / `UpdateHotkeyBindingMode`): also required the "Enabled" checkbox.

So with Multi mode on but "Enabled" unchecked (the case when `AllowMultipleBindings=FALSE` while `MultiBindingMode=TRUE`), multi-bind worked on first open but broke the instant you toggled Single→Multi — exactly "switch to single, back to multi, now I can't multi-bind unless I enable it."

`AllowMultipleBindings` (the "Enabled" checkbox) is a separate, documented runtime flag — *"process all bindings per button, else use only the first"* — that gates whether extras fire **in-game**; it shouldn't govern editor capacity. Fixed by making the update helpers derive `maxKeys` from the Single/Multi combo alone, matching `WM_INITDIALOG`.

## 2. Focused field stays stuck in the old mode
A focused (capturing/green) field only had its `maxKeys` updated on a mode change; its display was never refreshed, because the normal field-refresh path (`WM_USER+44`) deliberately skips fields that are actively capturing. So switching to Single left the field still showing the multi key list. Now the field exits and re-enters capture for the new mode.

## 3. Mode switch showed "..." instead of the existing binding
When re-entering capture on a mode switch, the field showed `"..."` even when the button already had a binding. Now it shows the real binding: the primary key for Single, the full list + `", ..."` for Multi, and `"..."` only when the button truly has no binding.

Implemented via a one-shot `modeRefresh` flag set in `WM_USER+47` and consumed by the next `WM_USER+44` (which carries the committed binding from the parent arrays and already clamps to `maxKeys`).

All three fixes apply to both the controller and hotkey config dialogs.