### PR TITLE
gb: add MBC1 multicart (MBC1M) support

### DIFF
--- a/sgb/gb_cart.cpp
+++ b/sgb/gb_cart.cpp
@@ -137,6 +137,19 @@ bool LooksLikeM161(const std::vector<uint8_t> &rom)
 	return logo_at(0x0000) && logo_at(0x8000);
 }
 
+// MBC1 multicart (MBC1M): a "menu + games" compilation where the 2-bit BANK2
+// register drives ROM A18-A19 (instead of A19-A20), so it selects a 256 KiB
+// game slot and BANK1 keeps only its low 4 bits. The header still reports plain
+// MBC1, so identify it structurally: a second Nintendo logo at the start of the
+// bank-0x10 slot ($40000) that a single-game cart never carries.
+bool LooksLikeMbc1Multicart(const std::vector<uint8_t> &rom)
+{
+	if (rom.size() < 0x44000) return false;          // need at least slot 1's header
+	for (int i = 0; i < 48; ++i)
+		if (rom[0x40104 + i] != kGbNintendoLogo[i]) return false;
+	return true;
+}
+
 std::string MakeSavPath(const std::string &rom_path)
 {
 	if (rom_path.empty()) return {};
@@ -249,6 +262,7 @@ bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path)
 		c.rom.clear();
 		return false;
 	}
+	c.mbc1_multicart = (c.mbc.type == MbcType::MBC1) && LooksLikeMbc1Multicart(c.rom);
 	MbcReset(c.mbc);
 
 	// ----- Cart RAM allocation -----
@@ -291,10 +305,11 @@ void CartUnload(Cart &c)
 	c.sram.clear();
 	c.header      = {};
 	c.path.clear();
-	c.has_battery = false;
-	c.has_rtc     = false;
-	c.has_rumble  = false;
-	c.sram_dirty  = false;
+	c.has_battery    = false;
+	c.has_rtc        = false;
+	c.has_rumble     = false;
+	c.sram_dirty     = false;
+	c.mbc1_multicart = false;
 	MbcReset(c.mbc);
 	c.mbc.type    = MbcType::None;
 }

--- a/sgb/gb_cart.h
+++ b/sgb/gb_cart.h
@@ -42,6 +42,10 @@ struct Cart
 	bool                  has_rtc     = false;
 	bool                  has_rumble  = false;
 	bool                  sram_dirty  = false;
+	// MBC1 multicart wiring (MBC1M): BANK2 selects a 256 KiB game slot. Static
+	// per-ROM, re-derived at load — kept out of MbcState so it never touches
+	// the blob-serialized savestate layout.
+	bool                  mbc1_multicart = false;
 };
 
 bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path);

--- a/sgb/gb_mbc.cpp
+++ b/sgb/gb_mbc.cpp
@@ -163,23 +163,30 @@ inline void WriteSram(Cart &c, uint32_t offset, uint8_t value)
 }
 
 // Effective 0x0000-0x3FFF bank for MBC1 — normally 0, but mode 1 with
-// a >= 1MB cart can expose banks 0x20/0x40/0x60.
-inline uint32_t Mbc1Bank0(const MbcState &s)
+// a >= 1MB cart can expose banks 0x20/0x40/0x60. On a multicart the 2-bit
+// BANK2 register drives one bit lower (A18-A19), so it shifts by 4 and the
+// game slot's bank 0 (the menu / sub-game header) appears here.
+inline uint32_t Mbc1Bank0(const MbcState &s, bool multicart)
 {
 	if (!s.mbc1_mode) return 0;
-	return (s.ram_bank & 0x03) << 5;
+	return (s.ram_bank & 0x03) << (multicart ? 4 : 5);
 }
 
-inline uint32_t Mbc1BankN(const MbcState &s)
+inline uint32_t Mbc1BankN(const MbcState &s, bool multicart)
 {
 	uint32_t lo = s.rom_bank & 0x1F;
 	if (lo == 0) lo = 1;
-	uint32_t hi = (s.ram_bank & 0x03) << 5;
-	return lo | hi;
+	// Multicart wiring leaves BANK1 only 4 effective bits and shifts BANK2
+	// down to bits 4-5, so each BANK2 value selects a 256 KiB game slot.
+	if (multicart)
+		return (lo & 0x0F) | ((s.ram_bank & 0x03) << 4);
+	return lo | ((s.ram_bank & 0x03) << 5);
 }
 
-inline uint32_t Mbc1RamBank(const MbcState &s)
+inline uint32_t Mbc1RamBank(const MbcState &s, bool multicart)
 {
+	// Multicarts carry no cart RAM — BANK2 is the game selector, not a RAM bank.
+	if (multicart) return 0;
 	return s.mbc1_mode ? (s.ram_bank & 0x03) : 0;
 }
 
@@ -353,7 +360,7 @@ inline void Tama5Trigger(Cart &c)
 
 } // anonymous
 
-uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<uint8_t> &sram, uint16_t addr)
+uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<uint8_t> &sram, uint16_t addr, bool mbc1_multicart)
 {
 	if (s.type == MbcType::M161 && addr < 0x8000)
 	{
@@ -369,7 +376,7 @@ uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<
 		uint16_t eff_addr = addr;
 		if (s.type == MbcType::MBC1)
 		{
-			bank = Mbc1Bank0(s);
+			bank = Mbc1Bank0(s, mbc1_multicart);
 		}
 		else if (s.type == MbcType::SachenMMC1)
 		{
@@ -387,7 +394,7 @@ uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<
 		uint32_t bank = 1;
 		switch (s.type)
 		{
-			case MbcType::MBC1: bank = Mbc1BankN(s); break;
+			case MbcType::MBC1: bank = Mbc1BankN(s, mbc1_multicart); break;
 			case MbcType::MBC3: bank = s.rom_bank ? s.rom_bank : 1; break;
 			case MbcType::MBC5: bank = s.rom_bank; break;
 			case MbcType::HuC1: bank = s.rom_bank ? s.rom_bank : 1; break;
@@ -472,7 +479,7 @@ uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<
 		uint32_t bank = 0;
 		switch (s.type)
 		{
-			case MbcType::MBC1: bank = Mbc1RamBank(s); break;
+			case MbcType::MBC1: bank = Mbc1RamBank(s, mbc1_multicart); break;
 			case MbcType::MBC3: bank = s.ram_bank & 0x07; break;
 			case MbcType::MBC5: bank = s.ram_bank & 0x0F; break;
 			case MbcType::MMM01: bank = Mmm01RamBank(s) & 0x0F; break;
@@ -519,7 +526,7 @@ void MbcWrite(Cart &c, uint16_t addr, uint8_t value)
 		else if (addr >= 0xA000 && addr < 0xC000)
 		{
 			if (!s.ram_enable) break;
-			WriteSram(c, (Mbc1RamBank(s) * 0x2000u) + (addr - 0xA000u), value);
+			WriteSram(c, (Mbc1RamBank(s, c.mbc1_multicart) * 0x2000u) + (addr - 0xA000u), value);
 		}
 		break;
 

--- a/sgb/gb_mbc.h
+++ b/sgb/gb_mbc.h
@@ -83,7 +83,7 @@ struct MbcState
 struct Cart;
 
 void MbcReset(MbcState &s);
-uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<uint8_t> &sram, uint16_t addr);
+uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<uint8_t> &sram, uint16_t addr, bool mbc1_multicart = false);
 void    MbcWrite(Cart &c, uint16_t addr, uint8_t value);
 
 // Notify the mapper of a CPU write to addr >= 0x8000 (VRAM/WRAM/SRAM/HRAM/IO).

--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -89,7 +89,7 @@ uint8_t MemRead(Memory &m, uint16_t addr)
 	}
 	if (addr < 0x8000)
 	{
-		return m.cart ? MbcRead(m.cart->mbc, m.cart->rom, m.cart->sram, addr) : 0xFF;
+		return m.cart ? MbcRead(m.cart->mbc, m.cart->rom, m.cart->sram, addr, m.cart->mbc1_multicart) : 0xFF;
 	}
 	if (addr < 0xA000)
 	{
@@ -97,7 +97,7 @@ uint8_t MemRead(Memory &m, uint16_t addr)
 	}
 	if (addr < 0xC000)
 	{
-		return m.cart ? MbcRead(m.cart->mbc, m.cart->rom, m.cart->sram, addr) : 0xFF;
+		return m.cart ? MbcRead(m.cart->mbc, m.cart->rom, m.cart->sram, addr, m.cart->mbc1_multicart) : 0xFF;
 	}
 	if (addr < 0xD000)
 	{

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -521,7 +521,7 @@ void Emulator::PrimeBIOSHandshake()
 			// bit-permutation (and any future mapper that munges header
 			// reads) feeds the SGB BIOS the same bytes a real cart bus
 			// would. Plain MBCs return the raw ROM byte unchanged.
-			icd.synth_packets[p][b] = MbcRead(impl_->cart.mbc, rom, impl_->cart.sram, addr);
+			icd.synth_packets[p][b] = MbcRead(impl_->cart.mbc, rom, impl_->cart.sram, addr, impl_->cart.mbc1_multicart);
 		}
 	}
 
@@ -848,12 +848,12 @@ uint8_t Emulator::PeekRAByte(uint32_t addr) const
 		const uint16_t a = static_cast<uint16_t>(addr);
 		if (a < 0x8000)
 			return MbcRead(const_cast<MbcState &>(impl_->cart.mbc),
-			               impl_->cart.rom, impl_->cart.sram, a);
+			               impl_->cart.rom, impl_->cart.sram, a, impl_->cart.mbc1_multicart);
 		if (a < 0xA000)        // VRAM — not exposed (would need PPU sync)
 			return 0;
 		if (a < 0xC000)        // External cart RAM (current bank)
 			return MbcRead(const_cast<MbcState &>(impl_->cart.mbc),
-			               impl_->cart.rom, impl_->cart.sram, a);
+			               impl_->cart.rom, impl_->cart.sram, a, impl_->cart.mbc1_multicart);
 		if (a < 0xE000)        // WRAM 0xC000-0xDFFF
 			return impl_->mem.wram[a - 0xC000];
 		if (a < 0xFE00)        // Echo RAM mirrors C000-DDFF


### PR DESCRIPTION
## What

Adds MBC1 multicart (MBC1M) support to the SGB/GB core.

Some MBC1 compilation carts ("menu + games") are wired so the 2-bit **BANK2** register selects a 256 KiB game slot — it drives ROM A18–A19 instead of A19–A20, leaving BANK1 only 4 effective bits. The cart header still reports plain MBC1, so with the standard `BANK2<<5` banking the menu's game selection lands on the wrong slots.

### Symptom (Mortal Kombat & Mortal Kombat II (Japan))
The 1 MB cart lays out as `slot0 = menu`, `slot1 = MK1`, `slot2 = MK2`, `slot3 = padding`:

| BANK2 | `<<5` (old) → phys bank | `<<4` (fixed) → phys bank |
|-------|-------------------------|----------------------------|
| 1 (pick MK1) | `0x20` = **MK2** ❌ | `0x10` = **MK1** ✅ |
| 2 (pick MK2) | `0x40` → wraps to `0x00` = **menu** ❌ | `0x20` = **MK2** ✅ |

So picking MK1 loaded MK2, and picking MK2 bounced back to the menu.

## How

- **Detect MBC1M structurally**: resolved type is MBC1 **and** the Nintendo logo is replicated at the start of the bank-`0x10` slot (`$40104`) — a marker a single-game cart never carries.
- **Store the flag on `Cart`, not `MbcState`**: `MbcState` is blob-serialized into GB savestates by `sizeof`, so a new field there would break every existing state. The flag is re-derived at load, so savestates stay compatible.
- When set, the MBC1 banking helpers shift BANK2 by 4, so each BANK2 value selects a 256 KiB game slot (`BANK1 low 4 bits | BANK2<<4`).