### PR TITLE
gb: Pokémon Red/Blue 2-in-1 (Duz) MBC3 multicart support + SGB reset fix

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -177,6 +177,13 @@ void S9xSoftReset (void)
 
 	memset(Memory.FillRAM, 0, 0x8000);
 
+	// SGB BIOS mode: clear SNES WRAM/VRAM so the SGB BIOS state machine cold-boots — a soft reset that preserves it leaves a GB game that sends no SGB palette packets stuck on a black screen.
+	if (Settings.SGB_BIOSModeActive)
+	{
+		memset(Memory.RAM,  0x55, sizeof(Memory.RAM));
+		memset(Memory.VRAM, 0x00, sizeof(Memory.VRAM));
+	}
+
 	if (Settings.BS)
 		S9xResetBSX();
 

--- a/sgb/gb_cart.cpp
+++ b/sgb/gb_cart.cpp
@@ -134,6 +134,7 @@ bool LooksLikeM161(const std::vector<uint8_t> &rom)
 			if (rom[base + 0x0104 + i] != kGbNintendoLogo[i]) return false;
 		return true;
 	};
+	if (rom[0x8148] != 0x00) return false;           // page 1 must be a 32 KiB game, not a banked 2-in-1 header
 	return logo_at(0x0000) && logo_at(0x8000);
 }
 
@@ -147,6 +148,24 @@ bool LooksLikeMbc1Multicart(const std::vector<uint8_t> &rom)
 	if (rom.size() < 0x44000) return false;          // need at least slot 1's header
 	for (int i = 0; i < 48; ++i)
 		if (rom[0x40104 + i] != kGbNintendoLogo[i]) return false;
+	return true;
+}
+
+// Duz "2-in-1" multicart (e.g. Pokemon Red/Blue): a multi-MB ROM that reports
+// plain MBC3 but carries a boot menu in banks 0-1 and each sub-game starting at
+// a 32 KiB page boundary, each with its own Nintendo logo. The menu programs the
+// ROM base via a register port in the SRAM window. Identify it by the second
+// logo at $8000 (which a single game never carries) over a banked sub-game
+// header — the same marker M161 rejects, but here the cart is genuinely MBC3.
+bool LooksLikeDuzMulticart(const std::vector<uint8_t> &rom)
+{
+	if (rom.size() < 0x80000) return false;
+	if (rom[0x8148] == 0x00)  return false;          // $8000 is a real banked game, not a 32 KiB M161 page
+	for (int i = 0; i < 48; ++i)
+	{
+		if (rom[0x0104 + i] != kGbNintendoLogo[i]) return false;
+		if (rom[0x8104 + i] != kGbNintendoLogo[i]) return false;
+	}
 	return true;
 }
 
@@ -263,6 +282,7 @@ bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path)
 		return false;
 	}
 	c.mbc1_multicart = (c.mbc.type == MbcType::MBC1) && LooksLikeMbc1Multicart(c.rom);
+	c.duz_multicart  = (c.mbc.type == MbcType::MBC3) && LooksLikeDuzMulticart(c.rom);
 	MbcReset(c.mbc);
 
 	// ----- Cart RAM allocation -----
@@ -310,6 +330,7 @@ void CartUnload(Cart &c)
 	c.has_rumble     = false;
 	c.sram_dirty     = false;
 	c.mbc1_multicart = false;
+	c.duz_multicart  = false;
 	MbcReset(c.mbc);
 	c.mbc.type    = MbcType::None;
 }

--- a/sgb/gb_cart.h
+++ b/sgb/gb_cart.h
@@ -46,6 +46,8 @@ struct Cart
 	// per-ROM, re-derived at load — kept out of MbcState so it never touches
 	// the blob-serialized savestate layout.
 	bool                  mbc1_multicart = false;
+	// Duz "2-in-1" MBC3 multicart: $C0 to $0000 unlocks an $A000/$A100 register port whose reg $A3<<1 is the ROM base bank added to every access.
+	bool                  duz_multicart  = false;
 };
 
 bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path);

--- a/sgb/gb_mbc.cpp
+++ b/sgb/gb_mbc.cpp
@@ -387,6 +387,10 @@ uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<
 		{
 			bank = Mmm01Rom0Bank(s, rom.size());
 		}
+		else if (s.type == MbcType::MBC3)
+		{
+			bank = s.sachen_outer_bank;   // Duz multicart base bank; 0 for normal MBC3
+		}
 		return static_cast<uint8_t>(ReadRom(rom, (bank * 0x4000u) + eff_addr));
 	}
 	if (addr < 0x8000)
@@ -395,7 +399,7 @@ uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<
 		switch (s.type)
 		{
 			case MbcType::MBC1: bank = Mbc1BankN(s, mbc1_multicart); break;
-			case MbcType::MBC3: bank = s.rom_bank ? s.rom_bank : 1; break;
+			case MbcType::MBC3: bank = (s.rom_bank ? s.rom_bank : 1) + s.sachen_outer_bank; break;
 			case MbcType::MBC5: bank = s.rom_bank; break;
 			case MbcType::HuC1: bank = s.rom_bank ? s.rom_bank : 1; break;
 			case MbcType::HuC3: bank = s.rom_bank; break;
@@ -557,6 +561,8 @@ void MbcWrite(Cart &c, uint16_t addr, uint8_t value)
 	case MbcType::MBC3:
 		if (addr < 0x2000)
 		{
+			if (c.duz_multicart && value == 0xC0) { s.sachen_outer_mask = 1; break; }   // unlock Duz register port
+			if (c.duz_multicart) s.sachen_outer_mask = 0;
 			s.ram_enable = ((value & 0x0F) == 0x0A);
 		}
 		else if (addr < 0x4000)
@@ -581,6 +587,13 @@ void MbcWrite(Cart &c, uint16_t addr, uint8_t value)
 		}
 		else if (addr >= 0xA000 && addr < 0xC000)
 		{
+			if (c.duz_multicart && s.sachen_outer_mask)
+			{
+				// Register port: $A000 latches the index, $A100 writes it. Only $A3 (ROM base, in 32 KiB pages) affects banking.
+				if (addr & 0x0100) { if (s.sachen_unlock_ctr == 0xA3) s.sachen_outer_bank = static_cast<uint8_t>(value << 1); }
+				else                 s.sachen_unlock_ctr = value;
+				break;
+			}
 			if (!s.ram_enable) break;
 			if (s.rtc_select >= 0x08 && s.rtc_select <= 0x0C)
 			{


### PR DESCRIPTION
## Summary

Adds support for the unlicensed **"Pokémon Red/Blue 2-in-1" (Duz)** Game Boy multicart and fixes a related SGB-mode reset bug. Three commits, all core (no debugger code):

### 1. Fix M161 misdetection
`LooksLikeM161` matched any cart carrying Nintendo logos at `$0000` **and** `$8000` — which these 2-in-1 carts also have (the second game's relocated header). It now requires the `$8000` page to declare a 32 KiB ROM (`rom[$8148] == 0`) as genuine M161 sub-games do; a banked sub-game header is non-zero and falls through to MBC3. Verified the real M161 cart (*Mani 4-in-1 "Tetris Set"*) still detects correctly.

### 2. Duz multicart game-select controller
The cart reports plain MBC3 but carries a boot menu in banks 0–1 with each sub-game at a 32 KiB page boundary. The menu unlocks a register port by writing `$C0` to `$0000`, then writes a register index (`$A0`–`$A3`) to `$A000` and data to `$A100`. Register **`$A3`** is the ROM base in 32 KiB pages, so:

```
physical_bank = (A3 << 1) + MBC3 logical bank
```

applied to both the fixed bank-0 region and the `$4000` window (Blue → base bank 2, Red → base bank 66; verified by byte-diffing against the stock ROMs).

- Detection is a per-ROM `Cart::duz_multicart` flag, re-derived at load (like `mbc1_multicart`).
- Mapper state reuses unused `MbcState` fields — **no struct growth**, so GB savestates stay byte-compatible.

### 3. SGB BIOS cold-boot on soft reset
In SGB **BIOS mode**, Emulation→Reset left the menu on a black screen. `S9xSoftReset` preserved SNES WRAM, where the SGB BIOS keeps its boot/display state machine — so it resumed mid-state and never re-ran its boot→display handshake. Games that re-send SGB palette packets recover; this menu sends none, so it stayed black. Now clears WRAM/VRAM in BIOS mode like the hard-reset path, so the BIOS cold-boots. Gated on `SGB_BIOSModeActive` — normal SNES and BIOS-less SGB resets are unchanged.

## Testing
- Both games boot and play from the menu; reset returns to the menu in BIOS mode.
- M161 *Tetris Set* still detected; normal MBC3 carts unaffected (flag false, base 0).
- Stock SGB game reset still works.