### PR TITLE
gb: Sachen header xform only while the boot ROM is mapped (fixes 4B-005)

### DIFF
--- a/sgb/gb_mbc.cpp
+++ b/sgb/gb_mbc.cpp
@@ -202,12 +202,11 @@ inline uint32_t SachenBankN(const MbcState &s)
 	return outer | inner;
 }
 
-// Sachen MMC1 header bit-permutation: when locked, reads in 0x0100-0x01FF
-// pass through the cart's A0/A6 and A1/A4 swaps so the bootstrap sees the
-// real Nintendo logo at 0x0104-0x0133. Outside that 256-byte window the
-// CPU sees raw ROM, so the game's actual entry point at 0x0100-0x0103
-// (encoded as e.g. `00 21 60 02` → unscrambles to `00 C3 60 6F` = JP $6F60)
-// transfers control to game code in a higher bank.
+// Sachen MMC1 header bit-permutation: while the boot ROM is mapped, reads in
+// 0x0100-0x01FF pass through the cart's A0/A6 and A1/A4 swaps so the boot ROM's
+// logo check sees the real Nintendo logo at 0x0104-0x0133. That is its only
+// purpose: once the boot ROM hands off (0xFF50) the lock clears and the CPU
+// sees raw ROM, so the game's real entry at 0x0100 executes unscrambled.
 inline uint16_t SachenLockedHeaderXform(uint16_t addr)
 {
 	if ((addr & 0xFF00u) != 0x0100u) return addr;

--- a/sgb/gb_mbc.h
+++ b/sgb/gb_mbc.h
@@ -43,11 +43,12 @@ struct MbcState
 	bool     rtc_latch      = false;
 	uint8_t  rtc_select     = 0;
 
-	// Sachen MMC1: outer-bank/mask + lock with simple unlock counter.
-	// While locked, ROM reads in 0x0100-0x01FF go through an A0/A6 and
-	// A1/A4 bit-permutation so the bootstrap sees the real Nintendo logo
-	// at 0x0104-0x0133. The cart unlocks once the game has issued ~0x30
-	// writes to addresses >= 0x8000 (VRAM/WRAM/SRAM/HRAM/IO).
+	// Sachen MMC1: outer-bank/mask + header lock. While locked, ROM reads in
+	// 0x0100-0x01FF go through an A0/A6 and A1/A4 bit-permutation so the boot
+	// ROM's logo check sees the real Nintendo logo at 0x0104-0x0133. The lock
+	// tracks the boot ROM: set while it is mapped, cleared at its 0xFF50 write
+	// (BIOS-less starts clear); the game itself runs unscrambled. unlock_ctr is
+	// vestigial, kept for savestate ABI.
 	uint8_t  sachen_outer_bank  = 0;
 	uint8_t  sachen_outer_mask  = 0;
 	bool     sachen_locked      = true;

--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -304,7 +304,11 @@ static void WriteIO(Memory &m, uint16_t addr, uint8_t value)
 			// Boot-ROM disable: writing any non-zero value (canonically 0x01)
 			// latches off the boot overlay so the cart bytes at 0x0000-0x00FF
 			// become visible. Real hardware: bit 0 disables, can't be re-enabled.
-			if (value != 0) m.boot_rom_enabled = false;
+			if (value != 0)
+			{
+				m.boot_rom_enabled = false;
+				if (m.cart) m.cart->mbc.sachen_locked = false;
+			}
 			return;
 		case 0xFF4D:
 			if (m.ppu && m.ppu->cgb) m.key1_armed = (value & 0x01) != 0;

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -479,6 +479,8 @@ void Emulator::Reset()
 		cs.r.sp = 0x0000;
 		cs.r.pc = 0x0000;
 	}
+
+	impl_->cart.mbc.sachen_locked = impl_->mem.boot_rom_enabled;
 }
 
 bool Emulator::LoadBootROM(const uint8_t *data, size_t size)


### PR DESCRIPTION
## What

The Sachen 4B-series address-bit-permutation exists only to make the boot ROM's Nintendo-logo check pass — the cart's own code is stored and runs **unscrambled**. We were keeping the xform live during cart execution, which mangled the entry: **4 in 1 (4B-005, Sachen-Commin)** decoded `$0100` to a stray `JP $0150` into a per-game logo checksum and hung in the Nintendo logo forever.

## Fix

Gate the header lock on the boot-ROM lifecycle:
- clear `sachen_locked` when the boot ROM disables itself (`$FF50` write), and
- start it clear in BIOS-less mode (`sachen_locked = boot_rom_enabled` at reset).

The cart then executes its real `$0100` entry raw — matching real hardware and Mesen (which reports no special mapper and runs these carts raw). `sachen_unlock_ctr` / `MbcNotifyHighWrite` are now vestigial.

## Testing

- **4B-005** now boots to its game-select menu and games play (confirmed in the GUI).
- **4B-007** still boots, no regression — now via the raw path.
- Validated headless through the full boot → cart path (BIOS and BIOS-less) for both carts: each reaches the menu, no `$0150` hang.