### PR TITLE
gb: Sachen — keep header xform for high-bank-entry carts (fixes 4B-008 regression)

### DIFF
--- a/sgb/gb_cart.cpp
+++ b/sgb/gb_cart.cpp
@@ -100,6 +100,18 @@ bool LooksLikeSachenScrambledLogo(const std::vector<uint8_t> &rom)
 	return true;
 }
 
+bool SachenHeaderRunsRaw(const std::vector<uint8_t> &rom)
+{
+	if (rom.size() < 0x0200) return false;
+	auto rd = [&](uint16_t a) { return rom[SachenScrambleAddr(a)]; };
+	const uint8_t e0 = rd(0x0100), e1 = rd(0x0101), e2 = rd(0x0102), e3 = rd(0x0103);
+	uint16_t target;
+	if (e0 == 0xC3)                    target = static_cast<uint16_t>(e1 | (e2 << 8));
+	else if (e0 == 0x00 && e1 == 0xC3) target = static_cast<uint16_t>(e2 | (e3 << 8));
+	else                               return false;
+	return target < 0x4000;
+}
+
 // MMM01: the menu lives in the LAST 32 KiB of ROM and carries its own
 // valid Nintendo logo at offset 0x0104 within that bank — that's how
 // real hardware powers on into the menu (upper ROM address lines are
@@ -242,10 +254,11 @@ bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path)
 	// additional Nintendo logo at the last 32 KiB of ROM (the boot menu).
 	if (LooksLikeSachenScrambledLogo(c.rom))
 	{
-		c.mbc.type     = MbcType::SachenMMC1;
-		c.has_battery  = false;
-		c.has_rtc      = false;
-		c.has_rumble   = false;
+		c.mbc.type      = MbcType::SachenMMC1;
+		c.has_battery   = false;
+		c.has_rtc       = false;
+		c.has_rumble    = false;
+		c.sachen_runs_raw = SachenHeaderRunsRaw(c.rom);
 	}
 	else if (LooksLikeMmm01(c.rom))
 	{

--- a/sgb/gb_cart.h
+++ b/sgb/gb_cart.h
@@ -48,6 +48,7 @@ struct Cart
 	bool                  mbc1_multicart = false;
 	// Duz "2-in-1" MBC3 multicart: $C0 to $0000 unlocks an $A000/$A100 register port whose reg $A3<<1 is the ROM base bank added to every access.
 	bool                  duz_multicart  = false;
+	bool                  sachen_runs_raw = false;
 };
 
 bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path);

--- a/sgb/gb_mbc.cpp
+++ b/sgb/gb_mbc.cpp
@@ -202,11 +202,10 @@ inline uint32_t SachenBankN(const MbcState &s)
 	return outer | inner;
 }
 
-// Sachen MMC1 header bit-permutation: while the boot ROM is mapped, reads in
-// 0x0100-0x01FF pass through the cart's A0/A6 and A1/A4 swaps so the boot ROM's
-// logo check sees the real Nintendo logo at 0x0104-0x0133. That is its only
-// purpose: once the boot ROM hands off (0xFF50) the lock clears and the CPU
-// sees raw ROM, so the game's real entry at 0x0100 executes unscrambled.
+// Sachen MMC1 header bit-permutation: while locked, reads in 0x0100-0x01FF pass
+// through the cart's A0/A6 and A1/A4 swaps so the boot ROM's logo check sees the
+// real Nintendo logo at 0x0104-0x0133. Whether the lock survives the boot hand-
+// off is per-cart — see Cart::sachen_runs_raw and gb_memory.cpp 0xFF50.
 inline uint16_t SachenLockedHeaderXform(uint16_t addr)
 {
 	if ((addr & 0xFF00u) != 0x0100u) return addr;

--- a/sgb/gb_mbc.h
+++ b/sgb/gb_mbc.h
@@ -45,10 +45,10 @@ struct MbcState
 
 	// Sachen MMC1: outer-bank/mask + header lock. While locked, ROM reads in
 	// 0x0100-0x01FF go through an A0/A6 and A1/A4 bit-permutation so the boot
-	// ROM's logo check sees the real Nintendo logo at 0x0104-0x0133. The lock
-	// tracks the boot ROM: set while it is mapped, cleared at its 0xFF50 write
-	// (BIOS-less starts clear); the game itself runs unscrambled. unlock_ctr is
-	// vestigial, kept for savestate ABI.
+	// ROM's logo check sees the real Nintendo logo at 0x0104-0x0133. Carts that
+	// run raw after boot (Cart::sachen_runs_raw, e.g. 4B-005) drop the lock at
+	// the 0xFF50 hand-off; the rest keep the xform for their scrambled high-bank
+	// entry and clear it later via unlock_ctr.
 	uint8_t  sachen_outer_bank  = 0;
 	uint8_t  sachen_outer_mask  = 0;
 	bool     sachen_locked      = true;

--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -307,7 +307,7 @@ static void WriteIO(Memory &m, uint16_t addr, uint8_t value)
 			if (value != 0)
 			{
 				m.boot_rom_enabled = false;
-				if (m.cart) m.cart->mbc.sachen_locked = false;
+				if (m.cart && m.cart->sachen_runs_raw) m.cart->mbc.sachen_locked = false;
 			}
 			return;
 		case 0xFF4D:

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -480,7 +480,7 @@ void Emulator::Reset()
 		cs.r.pc = 0x0000;
 	}
 
-	impl_->cart.mbc.sachen_locked = impl_->mem.boot_rom_enabled;
+	impl_->cart.mbc.sachen_locked = impl_->mem.boot_rom_enabled || !impl_->cart.sachen_runs_raw;
 }
 
 bool Emulator::LoadBootROM(const uint8_t *data, size_t size)


### PR DESCRIPTION
## What

Follow-up to #111. That PR dropped the Sachen header xform at the boot hand-off so 4B-005 would run raw — but it regressed carts whose scrambled entry is a real high-bank loader: **4 in 1 (4B-008)** decodes `$0100` to `JP $6200`, yet with the xform already gone the CPU ran the *raw* entry (`JP $00CE` into `$FF`-filled memory) and spun in the `RST $38` loop.

## Fix

Discriminate at load with `Cart::sachen_runs_raw` (non-serialized, derived like `mbc1_multicart`/`duz_multicart`): true only when the scrambled entry decodes to a `JP` **below `$4000`** — i.e. into the header region itself, where there is no real loader (4B-005).

- `runs_raw` carts drop `sachen_locked` at the `$FF50` hand-off (and start unlocked in BIOS-less mode) → real `$0100` entry runs raw.
- All other Sachen carts keep the xform for their scrambled high-bank entry (4B-007 `JP $6F60`, 4B-008 `JP $6200`) and unlock via the existing counter — restoring their pre-#111 behavior.

## Testing

Headless through the full boot → cart path, BIOS and BIOS-less:

| cart | result |
|------|--------|
| 4B-005 | ✅ runs raw → menu |
| 4B-007 | ✅ xform kept → `$6F60` loader |
| 4B-008 | ✅ xform kept → `$6200` loader (was the `RST $38` hang) |