### PR TITLE
gb: Sachen runs-raw boundary is the header end ($0200), not $4000 (fixes 4B-009)

### DIFF
--- a/sgb/gb_cart.cpp
+++ b/sgb/gb_cart.cpp
@@ -109,7 +109,7 @@ bool SachenHeaderRunsRaw(const std::vector<uint8_t> &rom)
 	if (e0 == 0xC3)                    target = static_cast<uint16_t>(e1 | (e2 << 8));
 	else if (e0 == 0x00 && e1 == 0xC3) target = static_cast<uint16_t>(e2 | (e3 << 8));
 	else                               return false;
-	return target < 0x4000;
+	return target < 0x0200;
 }
 
 // MMM01: the menu lives in the LAST 32 KiB of ROM and carries its own


### PR DESCRIPTION
## What

Follow-up to #111 / #112. The runs-raw discriminator from #112 used a `< $4000` boundary to decide whether a Sachen cart's scrambled entry points at a real loader. **4 in 1 (4B-009)** decodes `$0100` to `JP $0200` — a real loader just past the header — so `$4000` wrongly tagged it runs-raw, dropped the xform, and ran the garbage raw entry (`JP $00CE` into `$FF`-filled memory) → the `RST $38` loop.

## Fix

The correct boundary is the **end of the scrambled header (`$0200`)**, not `$4000`. A cart only runs raw when its scrambled entry jumps **back into the header itself** (`< $0200`) — i.e. there's no real loader there (4B-005's `$0150` is a self-contained anti-piracy checksum). Any target at `$0200` or beyond is a real loader, so the xform must stay.

## Testing

Headless boot → cart, BIOS and BIOS-less — all four carts reach their menus:

| cart | scrambled entry | result |
|------|------|--------|
| 4B-005 | `JP $0150` (in header) | runs raw → menu |
| 4B-007 | `JP $6F60` | xform kept → loader |
| 4B-008 | `JP $6200` | xform kept → loader |
| 4B-009 | `JP $0200` | xform kept → loader (was the `RST $38` hang) |