### PR TITLE
GB: load and SGB-boot logo-less Sachen carts (Beast Fighter)

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -1517,11 +1517,37 @@ static bool S9xRomBytesAreSachenScrambledGb(const uint8 *rom, int32 size)
     return true;
 }
 
+// Logo-less Sachen single-game carts (e.g. Beast Fighter) carry no Nintendo
+// logo at all — not even under the address swap — so the logo sniffs above miss
+// them and they fall through to the 65816 parser ("LoROM: Corrupt"). But every
+// Sachen cart presents a valid Game Boy header once its A0/A6 + A1/A4 address
+// swap is undone: a NOP;JP (or JP) entry into ROM plus a header checksum that
+// matches $014D (the standard $0134-$014C algorithm). That descrambled-but-valid
+// header identifies the cart without any logo bytes, and a non-GB ROM has
+// essentially no chance of satisfying both the entry shape and the checksum.
+static bool S9xRomBytesAreSachenScrambledGbHeader(const uint8 *rom, int32 size)
+{
+    if (size < 0x0200) return false;
+    uint16 entry;
+    if (rom[SachenScrambleAddr(0x0100)] == 0x00 && rom[SachenScrambleAddr(0x0101)] == 0xC3)
+        entry = static_cast<uint16>(rom[SachenScrambleAddr(0x0102)] | (rom[SachenScrambleAddr(0x0103)] << 8));
+    else if (rom[SachenScrambleAddr(0x0100)] == 0xC3)
+        entry = static_cast<uint16>(rom[SachenScrambleAddr(0x0101)] | (rom[SachenScrambleAddr(0x0102)] << 8));
+    else
+        return false;
+    if (entry >= 0x8000) return false;
+    uint8 sum = 0;
+    for (uint16 a = 0x0134; a <= 0x014C; ++a)
+        sum = static_cast<uint8>(sum - rom[SachenScrambleAddr(a)] - 1);
+    return sum == rom[SachenScrambleAddr(0x014D)];
+}
+
 static bool S9xRomBytesAreGb(const uint8 *rom, int32 size)
 {
     if (size < 0x150 || !rom) return false;
     if (memcmp(rom + 0x0104, kGbNintendoLogo, 48) == 0) return true;
-    return S9xRomBytesAreSachenScrambledGb(rom, size);
+    if (S9xRomBytesAreSachenScrambledGb(rom, size)) return true;
+    return S9xRomBytesAreSachenScrambledGbHeader(rom, size);
 }
 
 static std::string GBGameNameFromPath(const char *path)

--- a/sgb/gb_cart.cpp
+++ b/sgb/gb_cart.cpp
@@ -112,6 +112,32 @@ bool SachenHeaderRunsRaw(const std::vector<uint8_t> &rom)
 	return target < 0x0200;
 }
 
+// Logo-less Sachen single-game carts (e.g. Beast Fighter) carry no Nintendo
+// logo anywhere — not even under the address swap — so LooksLikeSachenScrambledLogo
+// can't see them and DecodeCartType rejects their forged $0147. Identify them
+// structurally instead: every Sachen cart presents a *valid Game Boy header*
+// once its A0/A6 + A1/A4 address swap is undone — a NOP;JP (or JP) entry into
+// ROM plus a header checksum that matches $014D (the standard $0134-$014C
+// algorithm the DMG boot uses). A non-GB ROM has essentially no chance of
+// satisfying both the entry shape and the checksum, so no logo bytes are needed
+// to recognise the cart.
+bool LooksLikeSachenScrambledHeader(const std::vector<uint8_t> &rom)
+{
+	if (rom.size() < 0x0200) return false;
+	auto rd = [&](uint16_t a) { return rom[SachenScrambleAddr(a)]; };
+	uint16_t entry;
+	if (rd(0x0100) == 0x00 && rd(0x0101) == 0xC3)
+		entry = static_cast<uint16_t>(rd(0x0102) | (rd(0x0103) << 8));
+	else if (rd(0x0100) == 0xC3)
+		entry = static_cast<uint16_t>(rd(0x0101) | (rd(0x0102) << 8));
+	else
+		return false;
+	if (entry >= 0x8000) return false;
+	uint8_t sum = 0;
+	for (uint16_t a = 0x0134; a <= 0x014C; ++a) sum = static_cast<uint8_t>(sum - rd(a) - 1);
+	return sum == rd(0x014D);
+}
+
 // MMM01: the menu lives in the LAST 32 KiB of ROM and carries its own
 // valid Nintendo logo at offset 0x0104 within that bank — that's how
 // real hardware powers on into the menu (upper ROM address lines are
@@ -197,6 +223,14 @@ std::string MakeSavPath(const std::string &rom_path)
 }
 
 } // anonymous
+
+bool SachenBootLogoByte(const Cart &c, uint16_t addr, uint8_t &out)
+{
+	if (c.mbc.type != MbcType::SachenMMC1) return false;
+	if (addr < 0x0104u || addr > 0x0133u) return false;
+	out = kGbNintendoLogo[addr - 0x0104u];
+	return true;
+}
 
 bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path)
 {
@@ -289,7 +323,22 @@ bool CartLoad(Cart &c, const uint8_t *data, size_t size, const char *path)
 		c.has_rtc     = false;
 		c.has_rumble  = false;
 	}
-	else if (!DecodeCartType(h.cart_type, c.mbc.type, c.has_battery, c.has_rtc, c.has_rumble))
+	else if (DecodeCartType(h.cart_type, c.mbc.type, c.has_battery, c.has_rtc, c.has_rumble))
+	{
+		// Recognized standard cart type — fields set by DecodeCartType.
+	}
+	else if (LooksLikeSachenScrambledHeader(c.rom))
+	{
+		// Logo-less Sachen single-game cart: forged $0147 and no stored logo,
+		// but a valid GB header hides under the Sachen address swap. The
+		// scrambled header is the cart's real loader, so the xform stays on.
+		c.mbc.type        = MbcType::SachenMMC1;
+		c.has_battery     = false;
+		c.has_rtc         = false;
+		c.has_rumble      = false;
+		c.sachen_runs_raw = false;
+	}
+	else
 	{
 		c.rom.clear();
 		return false;

--- a/sgb/gb_cart.h
+++ b/sgb/gb_cart.h
@@ -61,6 +61,14 @@ bool CartLoadBattery(Cart &c);
 bool CartSaveBatteryToPath(const Cart &c, const char *path);
 bool CartLoadBatteryFromPath(Cart &c, const char *path);
 
+// While the boot ROM is mapped, a Sachen cart's mapper feeds the boot the
+// Nintendo logo at 0x0104-0x0133 (logo-less single-game carts store none, and
+// even the 4B multicarts only descramble to it) so the DMG/SGB boot logo check
+// passes — exactly as the hardware does. Returns true and the canonical byte
+// for a SachenMMC1 cart in that range; callers gate this on boot_rom_enabled so
+// the running game still reads its real (address-swapped) header afterwards.
+bool SachenBootLogoByte(const Cart &c, uint16_t addr, uint8_t &out);
+
 } // namespace SGB
 
 #endif

--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -87,6 +87,16 @@ uint8_t MemRead(Memory &m, uint16_t addr)
 	{
 		return m.boot_rom[addr];
 	}
+	// While the boot ROM is mapped, a Sachen cart's mapper supplies the Nintendo
+	// logo at 0x0104-0x0133 so the DMG/SGB boot logo check passes — what the
+	// hardware does (logo-less single-game carts store none). Gated on
+	// boot_rom_enabled, so once the boot hands off the running game reads its
+	// real address-swapped header and the cart's own self-check still matches.
+	if (m.boot_rom_enabled && m.cart)
+	{
+		uint8_t logo;
+		if (SachenBootLogoByte(*m.cart, addr, logo)) return logo;
+	}
 	if (addr < 0x8000)
 	{
 		return m.cart ? MbcRead(m.cart->mbc, m.cart->rom, m.cart->sram, addr, m.cart->mbc1_multicart) : 0xFF;


### PR DESCRIPTION
## Problem

Single-game Sachen carts that store **no Nintendo logo anywhere** (e.g. *Beast Fighter*) failed two ways:

1. **Misrouted to the SNES parser** — the zipped-ROM content sniff keys on the Nintendo logo, so a logo-less cart fell through to the 65816 loader and showed `"???" LoROM: Corrupt`.
2. **Rejected by the SGB BIOS** — once routed to the GB core (BIOS-less), it ran; but under the SGB/SGB2 BIOS the GB-side boot transmits the cart logo to the SNES SGB system ROM, which checks it against the real Nintendo logo, rejects the garbage, and never releases the GB (the boot never reaches `$0150`).

## Fix (models the Sachen mapper hardware — no workarounds)

- **Detection** (`memmap.cpp`, `sgb/gb_cart.cpp`): recognize the cart structurally — its header is a *valid GB header* once the Sachen `A0↔A6 / A1↔A4` address swap is undone (a `NOP;JP` entry into ROM **plus** a matching `$0134-$014C → $014D` checksum). No logo bytes; verified to match only logo-less Sachen carts with zero false positives on plain-GB/SNES ROMs.
- **Boot-window logo injection** (`sgb/gb_memory.cpp`, `SachenBootLogoByte`): while the boot ROM is mapped (`boot_rom_enabled`), a `SachenMMC1` cart's `$0104-$0133` reads return the canonical Nintendo logo — exactly what the mapper does on real hardware so the boot logo check passes. After hand-off (`$FF50`) the running game reads its real address-swapped header, so the cart's own self-check still matches.

Reuses the existing `kGbNintendoLogo` constant (no new bytes).

## Verification

- Boots in **SGB / SGB2** (confirmed) and **BIOS-less**.
- **Provably neutral** for the 4B Sachen multicarts — they already descramble to the same logo, so the injection returns identical bytes; before/after behavior is byte-identical and there are **zero regressions** (incl. a normal SGB/MBC1 title).
- The detector matches **only** the logo-less cart in the test library; the multicarts are still caught by the existing scrambled-logo check first (routing unchanged).