### PR TITLE
gb: GBC-only carts honor SGB BIOS preference (restore lockout)

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -1578,11 +1578,10 @@ static void EmitSGBLoadBanner(const char *gb_path, uint8 bios_mode)
     Settings.InitialInfoStringTimeout = saved;
 }
 
-// Game Boy header $0143 CGB flag: $80 = CGB-enhanced (also runs on DMG/SGB),
-// $C0 = CGB-only. CGB-only carts can't run under the SGB BIOS (it boots them
-// monochrome and they lock out: "designed only for Game Boy Color"), so they
-// are forced into the BIOS-less CGB path. CGB-enhanced carts still honour the
-// SGB-BIOS preference and run correctly either way.
+// Game Boy header $0143 CGB flag: $80 = CGB-enhanced, $C0 = CGB-only. Both
+// honour the SGB-BIOS preference: under the SGB BIOS a CGB-only cart boots
+// monochrome and shows its own "designed only for Game Boy Color" lockout,
+// exactly as on real hardware. The BIOS-less fallback runs CGB carts in colour.
 static uint8 GbBytesCgbFlag(const uint8 *rom, size_t size)
 {
     return size > 0x143 ? rom[0x143] : 0;
@@ -1619,7 +1618,6 @@ bool8 CMemory::LoadROM (const char *filename)
 
         const uint8 gbFlag    = GbFileCgbFlag(filename);
         const bool  gbCgb     = (gbFlag & 0x80) != 0;
-        const bool  gbCgbOnly = (gbFlag == 0xC0);
 
         std::string bios_path;
         uint8 bios_mode = 0;
@@ -1634,7 +1632,7 @@ bool8 CMemory::LoadROM (const char *filename)
             else bios_path.clear();
         }
 
-        if (!gbCgbOnly && bios_mode && LoadROMWithSGBBIOS(filename, bios_path.c_str()))
+        if (bios_mode && LoadROMWithSGBBIOS(filename, bios_path.c_str()))
         {
             EmitSGBLoadBanner(filename, bios_mode);
             return TRUE;
@@ -1694,7 +1692,6 @@ bool8 CMemory::LoadROM (const char *filename)
 
             const uint8 gbFlag    = GbBytesCgbFlag(ROM, (size_t)totalFileSize);
             const bool  gbCgb     = (gbFlag & 0x80) != 0;
-            const bool  gbCgbOnly = (gbFlag == 0xC0);
 
             std::string bios_path;
             uint8 bios_mode = 0;
@@ -1709,7 +1706,7 @@ bool8 CMemory::LoadROM (const char *filename)
                 else bios_path.clear();
             }
 
-            if (!gbCgbOnly && bios_mode &&
+            if (bios_mode &&
                 LoadROMWithSGBBIOSBytes(ROM, (uint32)totalFileSize,
                                          filename, bios_path.c_str()))
             {


### PR DESCRIPTION
## Problem

The CGB auto-switch (`3b8ae071`) special-cased CGB-only (`$0143=$C0`) carts with a `!gbCgbOnly` guard, forcing them to skip the SGB BIOS and boot bios-less in CGB color. That removed the authentic SGB behavior: a GBC-only game booted on the SGB shows its own *"this game can only be played on Game Boy Color"* lockout. Worse, selecting an SGB BIOS for such a cart did nothing — there was no way to reach the lockout.

## Fix

Drop the `!gbCgbOnly` guard (and the now-unused `gbCgbOnly` var) from both the direct `.gb/.gbc` path and the `.zip` container path in `CMemory::LoadROM`, so `$C0` carts honor the SGB BIOS preference exactly like CGB-enhanced (`$80`) carts already did.

| BIOS preference | DMG `$00` | CGB-enhanced `$80` | CGB-only `$C0` |
|---|---|---|---|
| **SGB1 / SGB2** | plays via SGB | runs monochrome via SGB | **shows the GBC-only lockout** ← restored |
| **No BIOS** | bios-less DMG | bios-less CGB color | bios-less CGB color (plays) |

`GameBoyRunMode = gbCgb ? 0 : 1` in the bios-less fallback is untouched, so "No BIOS" still plays GBC-only games in color. Selecting the BIOS is now how you choose lockout-vs-play, matching real hardware (the SGB is DMG-class).

## Testing

- **1942 (`$00`, pure DMG):** still loads and plays normally under the SGB BIOS — unchanged.
- **Lockout:** load a true GBC-only (`$C0`) game (e.g. Pokémon Crystal) with SGB1/SGB2 selected → lockout screen; switch BIOS to **None** → plays in CGB color.