### PR TITLE
fix(gb): window WY-trigger latch — fix DMG window corruption (Zerd no Densetsu HUD)

### DIFF
--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -401,7 +401,7 @@ void RenderPixelCgb(Ppu &p, int x)
 	const int trigger_x = wx < 0 ? 0 : wx;
 	if (!p.window_active && x == trigger_x &&
 		(p.lcdc & 0x20) != 0 &&
-		static_cast<int>(p.ly) >= static_cast<int>(p.wy))
+		p.wy_triggered)
 	{
 		p.window_active  = true;
 		p.window_start_x = static_cast<int16_t>(x);
@@ -465,7 +465,7 @@ void RenderPixel(Ppu &p)
 		const int trigger_x = wx < 0 ? 0 : wx;
 		if (!p.window_active && x == trigger_x &&
 			(p.lcdc & 0x20) != 0 &&
-			static_cast<int>(p.ly) >= static_cast<int>(p.wy))
+			p.wy_triggered)
 		{
 			p.window_active  = true;
 			p.window_start_x = static_cast<int16_t>(x);
@@ -571,6 +571,7 @@ void PpuReset(Ppu &p)
 	p.sprite_count  = 0;
 	p.window_active = false;
 	p.window_start_x = 0;
+	p.wy_triggered  = false;
 	p.mode3_sprite_stall = 0;
 	p.latched_wx    = 0;
 	p.latched_bgp   = p.bgp;
@@ -637,6 +638,11 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 			// single BGP for its entire mode 3.
 			p.latched_wx  = p.wx;
 			p.latched_bgp = p.bgp;
+			// Arm the window WY-trigger once LY == WY while it's enabled. Sampled
+			// after this line's LYC/STAT handler ran in mode 2, so a window kept
+			// disabled across the WY line never arms.
+			if ((p.lcdc & 0x20) && p.ly == p.wy)
+				p.wy_triggered = true;
 			transitioned = true;
 		}
 		break;
@@ -707,6 +713,7 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 				p.frame_ready   = true;
 				p.window_line   = 0;
 				p.window_active = false;
+				p.wy_triggered  = false;
 				p.vblank_irq_delay = 24;
 				S9xSGBOnPpuVBlank();
 			}
@@ -789,6 +796,7 @@ void PpuStep(Ppu &p, Memory &mem, int32_t tcycles)
 		p.vblank_irq_delay = 0;
 		p.draw_x         = 0;
 		p.window_active  = false;
+		p.wy_triggered   = false;
 		p.mode3_sprite_stall = 0;
 		p.latched_wx     = p.wx;
 		p.latched_bgp    = p.bgp;

--- a/sgb/gb_ppu.h
+++ b/sgb/gb_ppu.h
@@ -70,6 +70,10 @@ struct Ppu
 	uint8_t   sprite_count    = 0;
 	bool      window_active   = false;   // window engaged on this LY
 	int16_t   window_start_x  = 0;       // x at which window engaged
+	// Window WY-trigger latch: set when LY == WY while the window is enabled,
+	// held until frame start. The window engages only once this is set (not a
+	// running LY>=WY test), so a window enabled AFTER WY has passed never arms.
+	bool      wy_triggered    = false;
 
 	// Set at mode 2 → 3 transition. Real DMG extends mode 3 by ~6 dots
 	// per OAM-scan-hit sprite and delays pixel emission by the same.

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -1846,7 +1846,7 @@ constexpr uint32_t SGB_STATE_MAGIC   = 0x21424753u;  // 'S''G''B''!' LE
 // v4: add CGB state - VRAM bank 1, WRAM banks 2-7, BG/OBJ palette RAM,
 //     VBK/SVBK/KEY1/double-speed, HDMA. v1-3 loads skip the v4 block and
 //     the CGB fields keep their reset defaults (correct for DMG/SGB carts).
-constexpr uint32_t SGB_STATE_VERSION = 4;
+constexpr uint32_t SGB_STATE_VERSION = 5;
 
 enum class IoMode : uint8_t { Size, Save, Load };
 
@@ -2031,6 +2031,14 @@ void VisitState(Emulator::Impl &impl, IoCtx &c)
 		IoField(c, impl.mem.hdma_len);
 		IoField(c, impl.mem.hdma_active);
 		IoField(c, impl.cgb_mode);
+	}
+
+	// v5: window WY-trigger latch. Older saves skip it (default false); since
+	// saves are taken at VBlank where the latch is always reset, this only
+	// matters for a load that lands mid-frame, which self-corrects next VBlank.
+	if (c.version >= 5)
+	{
+		IoField(c, impl.ppu.wy_triggered);
 	}
 }
 


### PR DESCRIPTION
## Root cause 

Our window-engage used a running `LY >= WY` test. Real hardware (and Mesen's `_wyEnableFlag`) uses a one-time **WY-trigger latch**: the window only becomes eligible on the scanline where `LY == WY` *while the window is enabled*, and stays armed for the rest of the frame.

Zerd sets `WY=0` but keeps the window **disabled** over the playfield (drawn by BG), then enables it for the bottom band via an `LYC=124` STAT handler. With `LY >= WY` the window wrongly engaged at line 124 with `window_line=0`, painting window-map row 0 (grass) over the HUD. With the latch it never arms (LY only equals 0 at line 0, where the window is off), so the BG draws the HUD — (`LCDC=$87`, window off, in the HUD band).

## Fix

- Add `Ppu::wy_triggered`, armed at the mode 2→3 boundary when `LCDC.5 && LY==WY`; reset at VBlank / LCD-off / reset.
- Both the DMG (`RenderPixel`) and CGB (`RenderPixelCgb`) engage checks now gate on `wy_triggered` instead of `ly >= wy`.
- Serialized in savestate **v5** (`SGB_STATE_VERSION` 4 → 5; older saves still load).

## Verification

A hand-built DMG repro ROM (window disabled on top, enabled at `LYC=124`, `WY=0`) reproduces the bug before the change (bottom band painted with window-map row 0) and is fixed after (BG draws the HUD).

**Zero framebuffer divergence** (before vs after) across DMG and CGB paths: Zelda: Link's Awakening DX, Kirby's Dream Land 2, Super Mario Land 2, One Piece, Star Trek 25th Anniversary, Tetris DX, Pokémon Yellow, Pokémon Crystal, Conker's Pocket Tales, Warriors of Might & Magic.