### PR TITLE
fix(gb): NASCAR 2000 (GBC) title + menu — CGB STAT-write gate & GDMA register advance

### DIFF
--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -398,6 +398,12 @@ static void HdmaTrigger(Memory &m, uint8_t value)
 	else
 	{
 		DoGdma(m, src, dst, blocks);
+		const uint16_t end_src = static_cast<uint16_t>(src + blocks * 0x10);
+		const uint16_t end_dst = static_cast<uint16_t>(dst + blocks * 0x10);
+		m.hdma1 = static_cast<uint8_t>(end_src >> 8);
+		m.hdma2 = static_cast<uint8_t>(end_src & 0xF0);
+		m.hdma3 = static_cast<uint8_t>(end_dst >> 8);
+		m.hdma4 = static_cast<uint8_t>(end_dst & 0xF0);
 		m.hdma5 = 0xFF;
 	}
 }

--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -883,10 +883,13 @@ void PpuWriteReg(Ppu &p, Memory &mem, uint16_t addr, uint8_t value)
 			// per frame and walking the per-scanline SCY/SCX/BGP table
 			// way past one entry per line. The road perspective falls
 			// apart into stripes.
+			// DMG/SGB-only: CGB fixed the STAT-write spurious-IRQ bug. Gating on
+			// !p.cgb stops NASCAR 2000's per-line STAT=$08 rewrite from double-
+			// firing the handler (which scrambled the digitized title).
 			const uint8_t old_enables = static_cast<uint8_t>(p.stat & 0x78);
 			const uint8_t new_enables = static_cast<uint8_t>(value & 0x78);
 			const bool    newly_set   = (~old_enables & new_enables) != 0;
-			if (newly_set && !p.stat_line_high && (p.lcdc & 0x80))
+			if (!p.cgb && newly_set && !p.stat_line_high && (p.lcdc & 0x80))
 			{
 				const bool any_source_active =
 					p.mode == PpuMode::HBlank ||


### PR DESCRIPTION
Two independent CGB rendering bugs in the `sgb/` Game Boy core that together broke **NASCAR 2000 (USA, Europe)**'s digitized title screen and in-game menu. Both verified pixel-exact against a SameBoy headless reference.

## 1. Title middle scrambled — DMG STAT-write quirk applied on CGB (`gb_ppu.cpp`)
The DMG "STAT write bug" (a spurious LCDSTAT IRQ when a STAT source is active during a `$FF41` write) was applied on CGB as well. NASCAR's per-scanline palette handler rewrites `STAT=$08` every line; on CGB that double-fired the handler, advancing its SCY/palette table at double rate and scrambling the digitized title. CGB silicon fixed this bug (DMG/SGB only — matches Mesen and SameBoy), so it's now gated on `!p.cgb`.

## 2. Title top/bottom bands + menu header/footer garbage — GDMA source register not advancing (`gb_memory.cpp`)
Real CGB hardware leaves the HDMA source/dest registers (`$FF51-54`) pointing at the **end** of a completed GDMA (`src+len` / `dst+len`). NASCAR uploads each BG-map region as a paired index/attribute GDMA from one WRAM buffer, relying on the source register auto-advancing (`$DB80` index → `$DBC0` attribute) without rewriting it between the two transfers. `DoGdma` never advanced the registers, so the attribute GDMA re-read the index source and the attribute plane (VRAM bank 1) rendered as a byte-for-byte copy of the tile-index plane — garbling the title's "PRESS START" band and the in-game menu header/footer. Now advances `hdma1-4` to the end of the transfer after a GDMA, matching SameBoy (whose `$FF55` handler keeps the per-transfer-incremented source).