### PR TITLE
fix(win32): pre-fill + sign-extend New Value in Cheat Search add dialog

### DIFF
--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -13626,6 +13626,7 @@ INT_PTR CALLBACK DlgCheatSearchAdd(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lP
 					memset(buf,0,sizeof(TCHAR) * 12);
 					_stprintf(buf, formatstring, new_cheat->new_val);
 					SetDlgItemText(hDlg, IDC_NC_CURRVAL, buf);
+					SetDlgItemText(hDlg, IDC_NC_NEWVAL, buf);
 					memset(buf,0,sizeof(TCHAR) * 12);
 					_stprintf(buf, formatstring, new_cheat->saved_val);
 					SetDlgItemText(hDlg, IDC_NC_PREVVAL, buf);
@@ -13636,12 +13637,16 @@ INT_PTR CALLBACK DlgCheatSearchAdd(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lP
 				}
 				break; //HEX
 			case 2:
+			{
+			int shift = 32 - new_cheat->size * 8;
 			memset(buf,0,sizeof(TCHAR) * 12);
-			_stprintf(buf, TEXT("%d"), new_cheat->new_val);
+			_stprintf(buf, TEXT("%d"), (int32)(new_cheat->new_val << shift) >> shift);
 			SetDlgItemText(hDlg, IDC_NC_CURRVAL, buf);
+			SetDlgItemText(hDlg, IDC_NC_NEWVAL, buf);
 			memset(buf,0,sizeof(TCHAR) * 12);
-			_stprintf(buf, TEXT("%d"), new_cheat->saved_val);
+			_stprintf(buf, TEXT("%d"), (int32)(new_cheat->saved_val << shift) >> shift);
 			SetDlgItemText(hDlg, IDC_NC_PREVVAL, buf);
+			}
 			if(new_cheat->size==1)
 			{
 				//-128


### PR DESCRIPTION
Adding a cheat from the Cheat Search results errored with "Range Error" for the Signed and Hexadecimal data types because the New Value field was only pre-filled in the Unsigned case, leaving it empty for the others — clicking OK then hit the empty-field validation path.

Pre-fill IDC_NC_NEWVAL with the current value in the Signed and Hex cases too, matching Unsigned.

Also sign-extend the Signed display: new_val/saved_val are raw uint32 bytes, so 0x80 rendered as "128" instead of "-128" and then failed the signed-range check on OK (128 is outside -128..127). Sign-extend by the cheat's byte size before formatting so it shows and saves -128 (byte 0x80) correctly.