### PR TITLE
fix(gb): HBLANK HDMA dest auto-advance + same-H-blank VBK

### DIFF
--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -47,6 +47,7 @@ void MemReset(Memory &m)
 	m.hdma5        = 0xFF;
 	m.hdma_src = m.hdma_dst = m.hdma_len = 0;
 	m.hdma_active  = false;
+	m.hdma_hblank_latch = false;
 }
 
 static uint8_t ReadIO(Memory &m, uint16_t addr);
@@ -376,6 +377,31 @@ static void DoGdma(Memory &m, uint16_t src, uint16_t dst, uint16_t blocks)
 	}
 }
 
+static void HdmaTransferBlock(Memory &m)
+{
+	for (uint32_t i = 0; i < 0x10; ++i)
+	{
+		const uint8_t b = MemRead(m, static_cast<uint16_t>(m.hdma_src + i));
+		MemWrite(m, static_cast<uint16_t>(0x8000 + ((m.hdma_dst + i) & 0x1FFF)), b);
+	}
+	m.hdma_src = static_cast<uint16_t>(m.hdma_src + 0x10);
+	m.hdma_dst = static_cast<uint16_t>(m.hdma_dst + 0x10);
+	m.hdma1 = static_cast<uint8_t>(m.hdma_src >> 8);
+	m.hdma2 = static_cast<uint8_t>(m.hdma_src & 0xF0);
+	m.hdma3 = static_cast<uint8_t>(m.hdma_dst >> 8);
+	m.hdma4 = static_cast<uint8_t>(m.hdma_dst & 0xF0);
+	--m.hdma_len;
+	if (m.hdma_len == 0)
+	{
+		m.hdma_active = false;
+		m.hdma5       = 0xFF;
+	}
+	else
+	{
+		m.hdma5 = static_cast<uint8_t>((m.hdma_len - 1) & 0x7F);
+	}
+}
+
 static void HdmaTrigger(Memory &m, uint8_t value)
 {
 	const uint16_t src    = static_cast<uint16_t>(((m.hdma1 << 8) | m.hdma2) & 0xFFF0);
@@ -389,6 +415,12 @@ static void HdmaTrigger(Memory &m, uint8_t value)
 		m.hdma_len    = blocks;
 		m.hdma_active = true;
 		m.hdma5       = static_cast<uint8_t>(value & 0x7F);
+		if (m.ppu && (m.ppu->lcdc & 0x80) &&
+		    m.ppu->mode == PpuMode::HBlank && !m.hdma_hblank_latch)
+		{
+			HdmaTransferBlock(m);
+			m.hdma_hblank_latch = true;
+		}
 	}
 	else if (m.hdma_active)
 	{
@@ -410,24 +442,10 @@ static void HdmaTrigger(Memory &m, uint8_t value)
 
 void MemHdmaHBlank(Memory &m)
 {
+	m.hdma_hblank_latch = false;
 	if (!m.hdma_active) return;
-	for (uint32_t i = 0; i < 0x10; ++i)
-	{
-		const uint8_t b = MemRead(m, static_cast<uint16_t>(m.hdma_src + i));
-		MemWrite(m, static_cast<uint16_t>(0x8000 + ((m.hdma_dst + i) & 0x1FFF)), b);
-	}
-	m.hdma_src = static_cast<uint16_t>(m.hdma_src + 0x10);
-	m.hdma_dst = static_cast<uint16_t>(m.hdma_dst + 0x10);
-	--m.hdma_len;
-	if (m.hdma_len == 0)
-	{
-		m.hdma_active = false;
-		m.hdma5       = 0xFF;
-	}
-	else
-	{
-		m.hdma5 = static_cast<uint8_t>((m.hdma_len - 1) & 0x7F);
-	}
+	HdmaTransferBlock(m);
+	m.hdma_hblank_latch = true;
 }
 
 } // namespace SGB

--- a/sgb/gb_memory.h
+++ b/sgb/gb_memory.h
@@ -59,6 +59,7 @@ struct Memory
 	uint8_t  hdma5 = 0xFF;        // 0xFF55 status
 	uint16_t hdma_src = 0, hdma_dst = 0, hdma_len = 0;
 	bool     hdma_active = false;
+	bool     hdma_hblank_latch = false;
 };
 
 uint8_t MemRead(Memory &m, uint16_t addr);


### PR DESCRIPTION
## Summary

*The Little Mermaid II: Pinball Frenzy* (MBC5, CGB-only) garbled every complex screen — the 3-character bubble attract, the title splash, the language/menu screens, and in-game pinball — while static logos rendered fine. Root cause: the game streams VRAM as **many single-block HBLANK-mode HDMA transfers, one per scanline**, which tripped two bugs in our HBLANK HDMA path.

### Bug 1 — source/dest registers never auto-advanced
The game writes the destination (`FF53/FF54`) **once**, then re-arms each scanline rewriting only the **source** (`FF51/FF52`), relying on the destination advancing per block. `MemHdmaHBlank` advanced only the internal pointer and never wrote it back to `FF51–FF54`, so every re-arm reloaded the stale dest and ~30 blocks piled onto the same 16 VRAM bytes. (The GDMA path already did this writeback since the NASCAR 2000 fix; the HBLANK path was the asymmetric one.)

### Bug 2 — VRAM bank (VBK) captured one scanline late
Our transfer was deferred to the next `mode3→0`. The bubbles/menu screens toggle `VBK` per scanline (bank-1 tile data interleaved with bank-0), so by the deferred transfer time the game had already flipped VBK and the bank-1 blocks landed in bank 0. Real hardware transfers the block **in the H-blank it is armed in**, capturing the live VBK.

## Fix
- Factor the 16-byte copy into `HdmaTransferBlock()`, which advances **and writes the new source/dest back to `FF51–FF54`** after each block.
- An HBLANK transfer armed while the PPU is already in H-blank now copies its first block **immediately** (capturing the live VBK), gated to one block per H-blank by a transient `hdma_hblank_latch`.

Matches Mesen's `GbDmaController` (`ProcessDmaBlock` keeps the advanced src/dest; `ProcessHdma` starts right away when armed during HBL).