### PR TITLE
fix(gb): LY=LYC STAT re-latch — unblocks chained-LYC raster effects

### DIFF
--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -95,10 +95,11 @@ void RecomputeStatLine(Ppu &p, Memory &mem)
 	// match set), loads VRAM, then re-waits for that same match while the
 	// LCD is still off before re-enabling it; recomputing here would see
 	// LY(0) != LYC(145), clear bit 2 and hang the wait forever.
+	const bool lyc_match = (p.ly == p.lyc) && !p.lyc_relatch;
 	uint8_t new_stat = static_cast<uint8_t>((p.stat & 0xF8) | static_cast<uint8_t>(p.mode));
 	if (p.lcdc & 0x80)
 	{
-		if (p.ly == p.lyc) new_stat |= 0x04;
+		if (lyc_match) new_stat |= 0x04;
 	}
 	else
 	{
@@ -120,7 +121,7 @@ void RecomputeStatLine(Ppu &p, Memory &mem)
 	bool line_high = false;
 	if (p.lcdc & 0x80)
 	{
-		if ((p.stat & 0x40) && (p.ly == p.lyc))                 line_high = true;
+		if ((p.stat & 0x40) && lyc_match)                       line_high = true;
 		if ((p.stat & 0x20) && p.mode == PpuMode::OamScan)       line_high = true;
 		if ((p.stat & 0x10) && p.mode == PpuMode::VBlank)        line_high = true;
 		if ((p.stat & 0x08) && p.mode == PpuMode::HBlank)        line_high = true;
@@ -130,6 +131,20 @@ void RecomputeStatLine(Ppu &p, Memory &mem)
 	if (line_high && !p.stat_line_high)
 		mem.if_ = static_cast<uint8_t>(mem.if_ | IRQ_LCDSTAT);
 	p.stat_line_high = line_high;
+}
+
+// Re-latch the LY==LYC comparator at a scanline boundary. First recompute
+// with the coincidence suppressed (drops the STAT line if LYC was the only
+// source holding it high), then the caller's end-of-step RecomputeStatLine
+// re-asserts it so a still-valid LY==LYC match produces a fresh 0->1 edge.
+// Models the real-hardware "LyForCompare briefly = -1" window that lets a
+// chained-LYC raster effect keep firing even while the HBlank STAT IRQ holds
+// the line high otherwise. See Ppu::lyc_relatch.
+inline void RelatchLyc(Ppu &p, Memory &mem)
+{
+	p.lyc_relatch = true;
+	RecomputeStatLine(p, mem);
+	p.lyc_relatch = false;
 }
 
 // Sample one BG pixel at (x, ly) using the CURRENT register values.
@@ -721,6 +736,7 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 			{
 				p.mode = PpuMode::OamScan;
 			}
+			RelatchLyc(p, mem);
 			transitioned = true;
 		}
 		break;
@@ -738,6 +754,7 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 		if (p.ly == 153 && p.mode_clock == 4)
 		{
 			p.ly = 0;
+			RelatchLyc(p, mem);
 			transitioned = true;
 		}
 		if (p.mode_clock >= LINE_DOTS)
@@ -759,6 +776,7 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 					p.ly   = 0;
 					p.mode = PpuMode::OamScan;
 				}
+				RelatchLyc(p, mem);
 			}
 			transitioned = true;
 		}

--- a/sgb/gb_ppu.h
+++ b/sgb/gb_ppu.h
@@ -129,6 +129,18 @@ struct Ppu
 	// LCDSTAT interrupt only when this transitions 0 → 1.
 	bool     stat_line_high = false;
 
+	// LY==LYC comparator re-latch. Real hardware momentarily de-asserts the
+	// LYC coincidence at the very start of each scanline (Pan Docs / Mesen
+	// "LyForCompare = -1" window) before re-asserting it against the new LY.
+	// That produces a fresh STAT rising edge for an LY==LYC match even when
+	// another enabled source (HBlank/OAM) was already holding the STAT line
+	// high across the line boundary — without it a chained-LYC raster handler
+	// stalls whenever the HBlank STAT IRQ is also enabled (Ken Griffey Jr.'s
+	// Slugfest's per-scanline field-palette gradient). Transient: set true
+	// only for the single suppressed RecomputeStatLine call at each scanline
+	// boundary, so it is never observed between dots and is not serialized.
+	bool     lyc_relatch = false;
+
 	// VBlank IRQ latency. Real DMG samples IF on the LAST M-cycle of the
 	// current instruction, so when LY transitions to 144 mid-instruction the
 	// current LDH/CP/JR can still observe LY=144 before IRQ dispatch. Our


### PR DESCRIPTION
## Bug
*Ken Griffey Jr.'s Slugfest* (MBC5, CGB-only, double-speed) — the batting/fielding **background** flickers clean↔garbled every other frame while the sprites stay correct.


## Root cause — missing LY==LYC comparator re-latch
The field is drawn by a **chained-LYC per-scanline CGB background-palette gradient** (the STAT handler writes a band's palette via `FF69` and re-points `LYC` to the next band). On alternate frames the game *also* enables the HBlank (mode 0) STAT IRQ.

When the HBlank source held the STAT line high across a scanline boundary, our edge detector produced **no fresh rising edge** for the `LY==LYC` match, so the LYC handler chain stalled → the palette stayed flat → the field's tiles rendered with the wrong colors.

Diagnosed via the headless framebuffer harness (STAT edges by source):

| | clean frame | garbled frame |
|---|---|---|
| STAT edges | **LYC=18**, HBlank=17 | **LYC=0**, HBlank=93–143 |
| per-scanline palettes | 18 distinct | 1 (constant) |

## Fix
Real hardware (and Mesen, `GbPpu::ProcessVisibleScanline`) momentarily de-asserts the `LY==LYC` comparison at the start of each scanline (`LyForCompare = -1`) before re-asserting it against the new LY — producing a fresh STAT rising edge even while another enabled source already holds the line high.

`RelatchLyc()` models this at the three scanline boundaries (HBlank→OamScan, the LY153→0 quirk, and the VBlank LY advance): one suppressed `RecomputeStatLine` drops the line if LYC was the only holder, then the normal end-of-dot recompute re-asserts it. The `lyc_relatch` flag is transient — never observed between dots, not serialized.
