### PR TITLE
fix(gb): MBC6 mapper (dual half-bank windows + split SRAM) — Net de Get

### DIFF
--- a/sgb/gb_cart.cpp
+++ b/sgb/gb_cart.cpp
@@ -57,7 +57,7 @@ bool DecodeCartType(uint8_t code, MbcType &mbc, bool &battery, bool &rtc, bool &
 		case 0x1C: mbc = MbcType::MBC5; rumble = true; return true;
 		case 0x1D: mbc = MbcType::MBC5; rumble = true; return true;
 		case 0x1E: mbc = MbcType::MBC5; rumble = true; battery = true; return true;
-		case 0x20: mbc = MbcType::MBC6; return true;
+		case 0x20: mbc = MbcType::MBC6; battery = true; return true;
 		case 0x22: mbc = MbcType::MBC7; rumble = true; battery = true; return true;
 		case 0xFD: mbc = MbcType::TAMA5; battery = true; rtc = true; return true;
 		case 0xFE: mbc = MbcType::HuC3; battery = true; rtc = true; return true;

--- a/sgb/gb_mbc.cpp
+++ b/sgb/gb_mbc.cpp
@@ -6,8 +6,8 @@
 
 // Memory Bank Controllers. MBC1, MBC3, MBC5 cover ~95% of commercial
 // GB carts; MBC2, HuC1, HuC3, MMM01, and Sachen MMC1 are also
-// handled, as is MBC7 (accelerometer + 93LC56 EEPROM). MBC6 remains
-// stubbed (read-only no-MBC) for now.
+// handled, as are MBC6 (dual half-bank windows + flash) and MBC7
+// (accelerometer + 93LC56 EEPROM).
 //
 // Register meanings per Pan Docs:
 //
@@ -141,6 +141,13 @@ void MbcReset(MbcState &s)
 		s.rtc_regs[1] = 0xFF;
 		s.rtc_regs[2] = 0xFF;
 		s.rtc_select  = 0x01;
+	}
+	if (s.type == MbcType::MBC6)
+	{
+		s.rom_bank           = 2;
+		s.mmm01_rom_bank_low = 3;
+		s.ram_bank           = 0;
+		s.mmm01_rom_bank_mid = 1;
 	}
 }
 
@@ -465,10 +472,27 @@ void Mbc7EepromClock(Cart &c, uint8_t value)
 	s.rtc_select = static_cast<uint8_t>((do_bit ? 0x01 : 0) | (di ? 0x02 : 0) | (clk ? 0x40 : 0) | (cs ? 0x80 : 0));
 }
 
+uint8_t Mbc6Read(const MbcState &s, const std::vector<uint8_t> &rom, const std::vector<uint8_t> &sram, uint16_t addr)
+{
+	if (addr < 0x4000)
+		return static_cast<uint8_t>(ReadRom(rom, addr));
+	if (addr < 0x6000)
+		return s.mbc1_mode ? 0xFF : static_cast<uint8_t>(ReadRom(rom, (s.rom_bank * 0x2000u) + (addr - 0x4000u)));
+	if (addr < 0x8000)
+		return s.mmm01_mbc1_mode ? 0xFF : static_cast<uint8_t>(ReadRom(rom, (s.mmm01_rom_bank_low * 0x2000u) + (addr - 0x6000u)));
+	if (addr >= 0xA000 && addr < 0xB000)
+		return (s.ram_enable && !sram.empty()) ? ReadSram(sram, (s.ram_bank * 0x1000u) + (addr - 0xA000u)) : 0xFF;
+	if (addr >= 0xB000 && addr < 0xC000)
+		return (s.ram_enable && !sram.empty()) ? ReadSram(sram, (s.mmm01_rom_bank_mid * 0x1000u) + (addr - 0xB000u)) : 0xFF;
+	return 0xFF;
+}
+
 } // anonymous
 
 uint8_t MbcRead(MbcState &s, const std::vector<uint8_t> &rom, const std::vector<uint8_t> &sram, uint16_t addr, bool mbc1_multicart)
 {
+	if (s.type == MbcType::MBC6)
+		return Mbc6Read(s, rom, sram, addr);
 	if (s.type == MbcType::M161 && addr < 0x8000)
 	{
 		// One 32 KiB page covers the whole $0000-$7FFF window.
@@ -922,6 +946,47 @@ void MbcWrite(Cart &c, uint16_t addr, uint8_t value)
 		}
 		break;
 
+	case MbcType::MBC6:
+		if (addr < 0x0400)
+		{
+			s.ram_enable = (value == 0x0A);
+		}
+		else if (addr < 0x0800)
+		{
+			s.ram_bank = value;
+		}
+		else if (addr < 0x0C00)
+		{
+			s.mmm01_rom_bank_mid = value;
+		}
+		else if (addr >= 0x2000 && addr < 0x2800)
+		{
+			s.rom_bank = value;
+		}
+		else if (addr >= 0x2800 && addr < 0x3000)
+		{
+			s.mbc1_mode = (value & 0x08) != 0;
+		}
+		else if (addr >= 0x3000 && addr < 0x3800)
+		{
+			s.mmm01_rom_bank_low = value;
+		}
+		else if (addr >= 0x3800 && addr < 0x4000)
+		{
+			s.mmm01_mbc1_mode = (value & 0x08) != 0;
+		}
+		else if (addr >= 0xA000 && addr < 0xB000)
+		{
+			if (s.ram_enable && !c.sram.empty())
+				WriteSram(c, (s.ram_bank * 0x1000u) + (addr - 0xA000u), value);
+		}
+		else if (addr >= 0xB000 && addr < 0xC000)
+		{
+			if (s.ram_enable && !c.sram.empty())
+				WriteSram(c, (s.mmm01_rom_bank_mid * 0x1000u) + (addr - 0xB000u), value);
+		}
+		break;
+
 	case MbcType::MBC7:
 		if (addr < 0x2000)
 		{
@@ -949,7 +1014,6 @@ void MbcWrite(Cart &c, uint16_t addr, uint8_t value)
 		break;
 
 	default:
-		// MBC6: treat as read-only no-MBC.
 		break;
 	}
 }

--- a/sgb/gb_mbc.h
+++ b/sgb/gb_mbc.h
@@ -19,7 +19,7 @@ enum class MbcType : uint8_t
 	MBC2       = 2,
 	MBC3       = 3,
 	MBC5       = 5,
-	MBC6       = 6,  // not yet implemented
+	MBC6       = 6,  // dual half-bank ROM/flash windows + split SRAM (Net de Get)
 	MBC7       = 7,  // accelerometer + 93LC56 serial EEPROM (Kirby Tilt 'n' Tumble)
 	HuC1       = 8,  // MBC1-like, with infrared (RAM<->IR via $0000-$1FFF)
 	HuC3       = 9,  // MBC-like, with RTC command interface + IR


### PR DESCRIPTION
## Problem

*Net de Get - Minigame @ 100 (Japan)* (cart type `$20`) hangs at boot, cycling a WRAM-clear loop at `$0344`. The cart is **MBC6** — the only game that uses it — which was stubbed read-only no-MBC, so ROM banking was dead and the game couldn't fetch its real code.

## Fix

Implement MBC6 in `sgb/gb_mbc.cpp` + `sgb/gb_cart.cpp`, faithful to mGBA's `_GBMBC6`. MBC6 is unusual: **two independent ROM/flash windows, each an 8 KB *half*-bank**, plus split 4 KB SRAM windows.

- `$0000-$3FFF` — fixed ROM bank 0
- `$4000-$5FFF` — ROM/flash half-bank A; `$6000-$7FFF` — half-bank B
- `$A000-$AFFF` — SRAM half-bank 0; `$B000-$BFFF` — SRAM half-bank 1
- Registers (decoded by address; mGBA uses `addr>>10`): `$0000-$03FF` RAM enable (`$0A`); `$0400`/`$0800` SRAM half-bank A/B; `$2000`/`$3000` ROM half-bank A/B; `$2800`/`$3800` flash-select A/B (bit 3).

**Flash** (the long-dead download feature) is not programmable — mGBA stubs it too — so flash-select reads return blank `$FF`, which is exactly what boots the game; no flash region is allocated. SRAM is the header's 32 KB, and cart type `$20` now sets battery so it persists.

### Savestate-safe

`MbcState` is blob-serialized by `sizeof`, so this adds **no new fields** — it reuses `rom_bank`, `ram_bank`, `mmm01_rom_bank_low/mid`, `mbc1_mode`, `mmm01_mbc1_mode`, `ram_enable` (same approach as MBC7).
