### PR TITLE
fix(gb): HBLANK HDMA armed while LCD off must copy one block immediately

### DIFF
--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -415,8 +415,12 @@ static void HdmaTrigger(Memory &m, uint8_t value)
 		m.hdma_len    = blocks;
 		m.hdma_active = true;
 		m.hdma5       = static_cast<uint8_t>(value & 0x7F);
-		if (m.ppu && (m.ppu->lcdc & 0x80) &&
-		    m.ppu->mode == PpuMode::HBlank && !m.hdma_hblank_latch)
+		if (m.ppu && !(m.ppu->lcdc & 0x80))
+		{
+			HdmaTransferBlock(m);
+		}
+		else if (m.ppu && m.ppu->mode == PpuMode::HBlank &&
+		         !m.hdma_hblank_latch)
 		{
 			HdmaTransferBlock(m);
 			m.hdma_hblank_latch = true;
@@ -446,6 +450,12 @@ void MemHdmaHBlank(Memory &m)
 	if (!m.hdma_active) return;
 	HdmaTransferBlock(m);
 	m.hdma_hblank_latch = true;
+}
+
+void MemHdmaLcdOff(Memory &m)
+{
+	if (!m.hdma_active) return;
+	HdmaTransferBlock(m);
 }
 
 } // namespace SGB

--- a/sgb/gb_memory.h
+++ b/sgb/gb_memory.h
@@ -74,6 +74,10 @@ void MemReset(Memory &m);
 // Transfer one 0x10-byte CGB HDMA block during HBlank. No-op when inactive.
 void MemHdmaHBlank(Memory &m);
 
+// LCD turned off outside HBlank with an HBlank HDMA armed: the off edge
+// counts as entering HBlank, so one pending block fires (SameBoy GB_lcd_off).
+void MemHdmaLcdOff(Memory &m);
+
 // Callback fires each time the CPU initiates a serial transfer (write
 // 0x80/0x81 to 0xFF02). The byte passed is whatever was in 0xFF01 at
 // the moment. Used by the test harness to capture Blargg output; P6a

--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -858,6 +858,8 @@ void PpuWriteReg(Ppu &p, Memory &mem, uint16_t addr, uint8_t value)
 			const bool was_on = (p.lcdc & 0x80) != 0;
 			p.lcdc = value;
 			const bool is_on  = (p.lcdc & 0x80) != 0;
+			if (was_on && !is_on && p.cgb && p.mode != PpuMode::HBlank)
+				MemHdmaLcdOff(mem);
 			// LCD turn-on resets to line 0 / mode 2.
 			if (!was_on && is_on)
 			{


### PR DESCRIPTION
## Problem

**Worms Armageddon (USA) (GBC)** freezes when launching **Quickstart**. The loader disables the LCD, arms a 1-block HBLANK HDMA ($C1A0 → VRAM), then spins at $107E polling HDMA5 until bit 7 reads 1:

```
107C: LDH ($FF55),A   ; HDMA5 = $80 → HBLANK HDMA, 1 block
107E: LDH A,($FF55)   ; ← stuck here forever
1080: BIT 7,A
1082: JR Z,$107E
```

With the LCD off the PPU never enters HBlank, so `MemHdmaHBlank` never fires, the block never transfers, and bit 7 never sets.

## Hardware rule

Starting an HBLANK HDMA during mode 0 **or with the LCD disabled** copies the first block immediately (Pan Docs; SameBoy `memory.c` `GB_IO_HDMA5` triggers on STAT mode==0, and `GB_lcd_off` parks STAT to mode 0). Symmetrically, turning the LCD off outside HBlank with an HBLANK HDMA armed fires one pending block on the off edge (SameBoy `GB_lcd_off`).

## Fix (3 files)

- `sgb/gb_memory.cpp` — `HdmaTrigger`: LCD off → transfer one block immediately. Deliberately not gated on `hdma_hblank_latch`, which sits stale-true between H-blanks and would wrongly suppress the first block after an LCD-off following a serviced H-blank.
- `sgb/gb_memory.cpp/.h` — new `MemHdmaLcdOff`: one pending block on the LCD-off edge.
- `sgb/gb_ppu.cpp` — call it from the $FF40 write handler on a 1→0 LCDC.7 edge, CGB only, when not already in HBlank.