### PR TITLE
GB: Demotronic fixes — wave RAM playback access, double-speed CPU budget, tile-granular SCY

### DIFF
--- a/sgb/gb_apu.cpp
+++ b/sgb/gb_apu.cpp
@@ -595,13 +595,15 @@ int32_t ApuDrain(Apu &a, int16_t *out, int32_t max_samples)
 // Register access
 // ===================================================================
 
-uint8_t ApuRead(Apu &a, uint16_t addr)
+uint8_t ApuRead(Apu &a, uint16_t addr, bool cgb)
 {
-	// Wave RAM is always accessible; CH3 running is a special-case on
-	// DMG (reads from CH3's internal pos) — we return the backing RAM
-	// which is correct when CH3 is off. Real DMG quirks deferred.
+	// Wave RAM while CH3 runs: CGB redirects the access to the byte at
+	// CH3's current playback position; DMG returns $FF (outside the
+	// brief post-fetch window, which batching can't resolve).
 	if (addr >= 0xFF30 && addr <= 0xFF3F)
 	{
+		if (a.ch3.enabled)
+			return cgb ? a.ch3.ram[a.ch3.pos >> 1] : 0xFF;
 		return a.ch3.ram[addr - 0xFF30];
 	}
 
@@ -645,11 +647,18 @@ uint8_t ApuRead(Apu &a, uint16_t addr)
 	return 0xFF;
 }
 
-void ApuWrite(Apu &a, uint16_t addr, uint8_t value)
+void ApuWrite(Apu &a, uint16_t addr, uint8_t value, bool cgb)
 {
-	// Wave RAM writes pass through regardless of master enable.
+	// Wave RAM writes pass through regardless of master enable, but a
+	// running CH3 redirects them to its current byte (CGB) or drops
+	// them (DMG), same as reads.
 	if (addr >= 0xFF30 && addr <= 0xFF3F)
 	{
+		if (a.ch3.enabled)
+		{
+			if (cgb) a.ch3.ram[a.ch3.pos >> 1] = value;
+			return;
+		}
 		a.ch3.ram[addr - 0xFF30] = value;
 		return;
 	}

--- a/sgb/gb_apu.h
+++ b/sgb/gb_apu.h
@@ -149,8 +149,8 @@ struct Apu
 void ApuReset(Apu &a);
 void ApuStep(Apu &a, int32_t tcycles);
 
-uint8_t ApuRead(Apu &a, uint16_t addr);
-void    ApuWrite(Apu &a, uint16_t addr, uint8_t value);
+uint8_t ApuRead(Apu &a, uint16_t addr, bool cgb);
+void    ApuWrite(Apu &a, uint16_t addr, uint8_t value, bool cgb);
 
 int32_t ApuDrain(Apu &a, int16_t *out, int32_t max_samples);
 

--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -262,7 +262,7 @@ static uint8_t ReadIO(Memory &m, uint16_t addr)
 	}
 	if (addr >= 0xFF10 && addr <= 0xFF3F)
 	{
-		return m.apu ? ApuRead(*m.apu, addr) : 0xFF;
+		return m.apu ? ApuRead(*m.apu, addr, m.ppu && m.ppu->cgb) : 0xFF;
 	}
 	if (addr >= 0xFF40 && addr <= 0xFF4B)
 	{
@@ -340,7 +340,7 @@ static void WriteIO(Memory &m, uint16_t addr, uint8_t value)
 	}
 	if (addr >= 0xFF10 && addr <= 0xFF3F)
 	{
-		if (m.apu) ApuWrite(*m.apu, addr, value);
+		if (m.apu) ApuWrite(*m.apu, addr, value, m.ppu && m.ppu->cgb);
 		return;
 	}
 	if (addr >= 0xFF40 && addr <= 0xFF4B)

--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -153,7 +153,7 @@ inline uint8_t SampleBgPixel(const Ppu &p, int x)
 {
 	const uint16_t map_base  = (p.lcdc & 0x08) ? 0x1C00 : 0x1800;
 	const bool     tiles_un  = (p.lcdc & 0x10) != 0;
-	const uint8_t  bg_y      = static_cast<uint8_t>(p.ly + p.scy);
+	const uint8_t  bg_y      = static_cast<uint8_t>(p.ly + p.fetch_scy);
 	const uint32_t tile_row  = bg_y >> 3;
 	const uint32_t fine_y    = bg_y & 7;
 	const uint8_t  bg_x      = static_cast<uint8_t>(x + p.scx);
@@ -324,7 +324,7 @@ inline BgPixelCgb SampleBgPixelCgb(const Ppu &p, int x, bool window)
 	else
 	{
 		map_base = (p.lcdc & 0x08) ? 0x1C00 : 0x1800;
-		const uint8_t bg_y = static_cast<uint8_t>(p.ly + p.scy);
+		const uint8_t bg_y = static_cast<uint8_t>(p.ly + p.fetch_scy);
 		tile_row = bg_y >> 3;
 		fine_y   = bg_y & 7;
 		const uint8_t bg_x = static_cast<uint8_t>(x + p.scx);
@@ -653,6 +653,7 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 			// single BGP for its entire mode 3.
 			p.latched_wx  = p.wx;
 			p.latched_bgp = p.bgp;
+			p.fetch_scy   = p.scy;
 			// Arm the window WY-trigger once LY == WY while it's enabled. Sampled
 			// after this line's LYC/STAT handler ran in mode 2, so a window kept
 			// disabled across the WY line never arms.
@@ -676,6 +677,8 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 			MODE3_SETUP_DOTS + p.mode3_sprite_stall;
 		if (p.mode_clock > pixel_start_dot && p.draw_x < GB_SCREEN_WIDTH)
 		{
+			if (((p.draw_x + p.scx) & 7) == 0)
+				p.fetch_scy = p.scy;
 			if (p.cgb || (p.lcdc & 0x01))
 			{
 				RenderPixel(p);

--- a/sgb/gb_ppu.h
+++ b/sgb/gb_ppu.h
@@ -85,6 +85,14 @@ struct Ppu
 	// still return the live p.wx.
 	uint8_t   latched_wx = 0;
 
+	// SCY as sampled by the BG fetcher. Real hardware reads SCY at each
+	// tile fetch (8-pixel granularity), so a mid-scanline SCY write takes
+	// effect at the next tile, never mid-tile. Latched at mode 2 → 3 and
+	// re-latched at every BG tile boundary during pixel emission
+	// (Demotronic's per-column SCY waves). Transient — recomputed every
+	// line, not serialized.
+	uint8_t   fetch_scy = 0;
+
 	// BGP snapshot taken at mode 2 → 3 — same rationale as latched_wx.
 	// Initial D Gaiden's per-scanline raster effect handler can extend
 	// into the next line's mode 2 / early mode 3 (handler is ~55 m-cycles,

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -102,6 +102,20 @@ struct Emulator::Impl
 	PacketState sgb_pkt;
 	SgbState    sgb_state;
 
+	// CGB double-speed CPU-vs-PPU clock ledger. ds_extra is the CPU's
+	// accumulated extra T-cycle budget from double-speed dots; it must
+	// persist across RunCycles calls — re-deriving it from
+	// cpu.t_cycles - ppu.t_cycles each call forgives whatever lag
+	// (≤ kMaxOpcodeTCycles) the CPU ended the previous call with, which
+	// bleeds ~2% of CPU throughput in double-speed and desyncs
+	// cycle-counted raster loops (Demotronic's mid-scanline SCY waves).
+	// -1 = re-derive at next RunCycles (fresh reset / savestate load).
+	// apu_ds_rem is the odd-cycle carry of the CPU→APU clock halving in
+	// double-speed, persisted for the same reason. Neither is serialized;
+	// both re-derive after load.
+	int64_t     ds_extra   = -1;
+	int32_t     apu_ds_rem = 0;
+
 	// 256×224 composite staging buffer — heap-resident to keep a
 	// ~112 KB allocation off the stack of whatever thread drives
 	// S9xMainLoop (snes9x's per-thread stacks aren't always large).
@@ -390,6 +404,8 @@ void Emulator::Reset()
 	impl_->boot_handoff_captured = false;
 	impl_->boot_handoff_regs     = {};
 	impl_->handoff_frames        = 0;
+	impl_->ds_extra              = -1;
+	impl_->apu_ds_rem            = 0;
 	std::memset(&impl_->icd2, 0, sizeof impl_->icd2);
 	// 4-bank LCD ring starts at $00 (matches Mesen2 SuperGameboy::Reset).
 	// $7000-$700F latch buffer starts as $FF so reads before the first
@@ -1096,10 +1112,15 @@ void Emulator::RunCycles(int32_t tcycles)
 	// CGB double-speed: the CPU runs twice per PPU dot. ds_extra is the
 	// accumulated lead of the CPU clock over the PPU clock; it is 0 whenever
 	// double-speed has never engaged, so the DMG/SGB gate is byte-identical.
+	// It lives in Impl and persists across calls — see the field comment.
 	const int64_t target_t = impl_->ppu.t_cycles + tcycles;
-	int64_t ds_extra = impl_->cpu.State().t_cycles - impl_->ppu.t_cycles;
-	if (ds_extra < 0) ds_extra = 0;
-	int32_t apu_rem = 0;
+	if (impl_->ds_extra < 0)
+	{
+		impl_->ds_extra = impl_->cpu.State().t_cycles - impl_->ppu.t_cycles;
+		if (impl_->ds_extra < 0) impl_->ds_extra = 0;
+	}
+	int64_t &ds_extra = impl_->ds_extra;
+	int32_t &apu_rem  = impl_->apu_ds_rem;
 	while (impl_->ppu.t_cycles < target_t)
 	{
 		PpuStep(impl_->ppu, impl_->mem, 1);
@@ -2095,6 +2116,8 @@ bool Emulator::StateLoad(const uint8_t *buffer, size_t size)
 	impl_->mem.cart   = &impl_->cart;
 
 	impl_->cart.sram_dirty = false;
+	impl_->ds_extra        = -1;
+	impl_->apu_ds_rem      = 0;
 
 	// Reset only the sub-sample integration accumulator. The ring buffer
 	// is not serialized but also not wiped — it stays at its current


### PR DESCRIPTION
## Summary

Three GB-core accuracy fixes, found via the **Demotronic** GBC demo (mb-dtrnc.gbc), which both detects emulators at boot and stresses cycle-exact raster timing. All three stages of the demo now pass: hardware check ("OH BOY!"), and the mid-scanline SCY letter-wave effect renders correctly (verified against Mesen and SameBoy).

### 1. Wave RAM access while CH3 is playing (`gb_apu.cpp`)

The demo's boot protection copies 16 header bytes into wave RAM, triggers CH3, then reads $FF30-$3F back **while the channel plays**. Real hardware never returns the stored bytes (CGB redirects the access to the byte at CH3's current playback position; DMG returns $FF / drops writes) — transparent readback is an emulator tell, and the demo showed "NO BOY! NO DEMO!".

`ApuRead`/`ApuWrite` now take a `cgb` flag: while `ch3.enabled`, accesses hit `ram[pos >> 1]` on CGB and read $FF / are dropped on DMG. Channel off → backing RAM as before. No struct fields added (savestate-safe).

### 2. Persistent double-speed CPU budget ledger (`sgb.cpp`)

`Emulator::RunCycles` re-derived `ds_extra = cpu.t_cycles - ppu.t_cycles` on **every call**, re-baselining the CPU budget to wherever the CPU currently lagged (≤ 24 T). Every slice boundary forgave that lag → **~2% CPU underclock in CGB double-speed** (worse with smaller slices). Demotronic's cycle-counted copper loop (exactly 456 dots/scanline of SCY writes — our CPU executed it in exactly 912 T, verified per-instruction) drifted +8 dots/scanline against the PPU, sliding its mid-scanline SCY burst out of the visible pixels: flat rows + smear instead of the 3D wave.

`ds_extra` (plus the CPU→APU odd-cycle carry in double-speed) now persists in `Impl`, derived once (-1 sentinel), reset on `Reset()` and savestate load. Affects every CGB double-speed game: full 2× CPU throughput.

### 3. Tile-granular SCY sampling (`gb_ppu.cpp/.h`)

The renderer sampled live `p.scy` per **pixel**; the hardware BG fetcher samples it per **tile fetch** (8-pixel granularity). Mid-scanline SCY writes were tearing tiles mid-glyph. New transient `fetch_scy` latches at mode 2→3 and re-latches at each BG tile boundary; both DMG and CGB BG sample paths use it. Not serialized — savestates unaffected.

## Verification

- Demotronic: boot check passes (type 2 = real CGB), letters part renders intact glyphs on smooth 3D arcs matching Mesen/SameBoy ground truth (headless framebuffer dumps).
- **108-ROM signature sweep**: wave RAM fix — zero diffs; timing fixes — 12 diffs, every one eyeballed: CGB double-speed games show pure animation-phase shifts from the corrected CPU speed (e.g. Men in Black's intro progresses further in the same frame count); Killer Instinct (DMG) differs by 3 px on the bottom scanline for ~7 transition frames (mid-line SCY now lands at tile boundaries, as hardware does). No corruption.