### PR TITLE
fix(gb): FF46 reads boot value $00 on CGB — fixes Doc Cosmos title marquee pop

### DIFF
--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -25,7 +25,7 @@ uint8_t            g_dma_last  = 0xFF;  // 0xFF46 last written byte — register
 
 void SetSerialCallback(SerialByteCallback cb) { g_serial_cb = cb; }
 
-void MemReset(Memory &m)
+void MemReset(Memory &m, bool cgb)
 {
 	std::memset(m.wram, 0, sizeof m.wram);
 	std::memset(m.hram, 0, sizeof m.hram);
@@ -38,7 +38,7 @@ void MemReset(Memory &m)
 	// GB CPU starts. boot_rom_enabled stays false until LoadBootROM sets it.
 	std::memset(m.boot_rom, 0, sizeof m.boot_rom);
 	m.boot_rom_enabled = false;
-	g_dma_last         = 0xFF;
+	g_dma_last         = cgb ? 0x00 : 0xFF;
 
 	m.svbk         = 1;
 	m.key1_armed   = false;

--- a/sgb/gb_memory.h
+++ b/sgb/gb_memory.h
@@ -69,7 +69,7 @@ void    MemWrite(Memory &m, uint16_t addr, uint8_t value);
 uint16_t MemRead16(Memory &m, uint16_t addr);
 void     MemWrite16(Memory &m, uint16_t addr, uint16_t value);
 
-void MemReset(Memory &m);
+void MemReset(Memory &m, bool cgb);
 
 // Transfer one 0x10-byte CGB HDMA block during HBlank. No-op when inactive.
 void MemHdmaHBlank(Memory &m);

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -391,7 +391,7 @@ void Emulator::ColdReset()
 void Emulator::Reset()
 {
 	impl_->cpu.Reset();
-	MemReset(impl_->mem);
+	MemReset(impl_->mem, impl_->cgb_mode && !Settings.SGB_BIOSModeActive);
 	PpuReset(impl_->ppu);
 	ApuReset(impl_->apu);
 	TimerReset(impl_->timer);


### PR DESCRIPTION
## Problem

**Doc Cosmos – The Saga Begins** (CGB-only aftermarket): the bottom title-screen marquee ("BY SIMON JAMESON …") pops one tile to the left and snaps back, repeating every 8 frames.

## Root cause

`$FF46` (OAM DMA) is a readable register — it echoes the last value written — and its **power-on value differs by machine: `$00` on CGB/AGB, `$FF` on DMG/MGB/SGB** (boot ROMs never touch it).

Doc Cosmos reads FF46 in its boot init (`$2246`) as a hardware fingerprint and stores `0` (CGB) or `7` (DMG) to `$D5F8`, which phases its title marquee:

- the ticker (`$077A`) shifts the bottom tilemap row (`$9E20`) one tile when `frame_counter & 7 == $D5F8`
- the raster routine (`$0547`) busy-waits `LY >= $84` and writes `SCX = counter` for the marquee rows (1px/frame crawl)

The tile shift must coincide with the SCX 7→0 wrap — phase **0**, the real-CGB value. Our core booted the FF46 echo at `$FF` for every machine, so the game took the phase-7 path: the tilemap shifted one frame before the SCX wrap → 9px pop left, snap back, every 8 frames.

## Fix

`MemReset(Memory&, bool cgb)` boots `g_dma_last` at `$00` (CGB) / `$FF` (DMG/SGB). Each caller states the machine type explicitly. The echo stays a file-static — savestate format unchanged.