### PR TITLE
fix(gb): defer PPU-raised STAT IRQ 24 dots + hold first frame after LCD enable

### DIFF
--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -86,7 +86,7 @@ inline uint8_t ApplyPalette(uint8_t palette, uint8_t color_idx)
 	return static_cast<uint8_t>((palette >> (color_idx * 2)) & 0x03);
 }
 
-void RecomputeStatLine(Ppu &p, Memory &mem)
+void RecomputeStatLine(Ppu &p, Memory &mem, bool defer_irq = false)
 {
 	// Rebuild the low 3 bits of STAT (mode + LYC coincidence). With the LCD
 	// off the PPU comparator is frozen, so the coincidence flag latches the
@@ -129,7 +129,15 @@ void RecomputeStatLine(Ppu &p, Memory &mem)
 
 	// Rising edge on the combined line raises LCDSTAT IRQ.
 	if (line_high && !p.stat_line_high)
-		mem.if_ = static_cast<uint8_t>(mem.if_ | IRQ_LCDSTAT);
+	{
+		if (defer_irq)
+		{
+			if (p.stat_irq_delay == 0)
+				p.stat_irq_delay = 24;
+		}
+		else
+			mem.if_ = static_cast<uint8_t>(mem.if_ | IRQ_LCDSTAT);
+	}
 	p.stat_line_high = line_high;
 }
 
@@ -143,7 +151,7 @@ void RecomputeStatLine(Ppu &p, Memory &mem)
 inline void RelatchLyc(Ppu &p, Memory &mem)
 {
 	p.lyc_relatch = true;
-	RecomputeStatLine(p, mem);
+	RecomputeStatLine(p, mem, true);
 	p.lyc_relatch = false;
 }
 
@@ -428,10 +436,13 @@ void RenderPixelCgb(Ppu &p, int x)
 
 	p.scanline_bg_raw[x] = bg.color;
 	p.scanline_raw[x]    = bg.color;
-	line[x]              = bg.color;
-	lay[x]               = win_active_here ? GB_PIXEL_WINDOW : GB_PIXEL_BG;
-	cline[x]             = bg_hidden ? CgbColor(p.bg_pal, 0, 0)
-	                                 : CgbColor(p.bg_pal, bg.pal, bg.color);
+	if (!p.present_hold)
+	{
+		line[x]  = bg.color;
+		lay[x]   = win_active_here ? GB_PIXEL_WINDOW : GB_PIXEL_BG;
+		cline[x] = bg_hidden ? CgbColor(p.bg_pal, 0, 0)
+		                     : CgbColor(p.bg_pal, bg.pal, bg.color);
+	}
 
 	const SpritePixelCgb sp = SampleSpritePixelCgb(p, x);
 	if (p.show_obj && sp.covered)
@@ -441,9 +452,12 @@ void RenderPixelCgb(Ppu &p, int x)
 		if (!bg_wins)
 		{
 			p.scanline_raw[x] = sp.color;
-			line[x]           = sp.color;
-			lay[x]            = GB_PIXEL_OBJ;
-			cline[x]          = CgbColor(p.obj_pal, sp.pal, sp.color);
+			if (!p.present_hold)
+			{
+				line[x]  = sp.color;
+				lay[x]   = GB_PIXEL_OBJ;
+				cline[x] = CgbColor(p.obj_pal, sp.pal, sp.color);
+			}
 		}
 	}
 }
@@ -526,16 +540,22 @@ void RenderPixel(Ppu &p)
 
 	p.scanline_bg_raw[x] = bg_color;
 	p.scanline_raw[x]    = bg_color;
-	line[x]              = ApplyPalette(p.latched_bgp, disp_bg);
-	lay[x]               = bg_layer;
+	if (!p.present_hold)
+	{
+		line[x] = ApplyPalette(p.latched_bgp, disp_bg);
+		lay[x]  = bg_layer;
+	}
 
 	// Sprite resolve — overwrite if visible.
 	const SpritePixel sp = SampleSpritePixel(p, x);
 	if (p.show_obj && sp.covered && (!sp.bg_over || disp_bg == 0))
 	{
 		p.scanline_raw[x] = sp.color;
-		line[x]           = ApplyPalette(sp.palette, sp.color);
-		lay[x]            = GB_PIXEL_OBJ;
+		if (!p.present_hold)
+		{
+			line[x] = ApplyPalette(sp.palette, sp.color);
+			lay[x]  = GB_PIXEL_OBJ;
+		}
 	}
 }
 
@@ -580,6 +600,8 @@ void PpuReset(Ppu &p)
 	p.window_line   = 0;
 	p.stat_line_high = false;
 	p.vblank_irq_delay = 0;
+	p.stat_irq_delay = 0;
+	p.present_hold  = false;
 	p.frame_ready   = false;
 	p.t_cycles      = 0;
 	p.draw_x        = 0;
@@ -612,6 +634,13 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 		--p.vblank_irq_delay;
 		if (p.vblank_irq_delay == 0)
 			mem.if_ = static_cast<uint8_t>(mem.if_ | IRQ_VBLANK);
+	}
+
+	if (p.stat_irq_delay > 0)
+	{
+		--p.stat_irq_delay;
+		if (p.stat_irq_delay == 0)
+			mem.if_ = static_cast<uint8_t>(mem.if_ | IRQ_LCDSTAT);
 	}
 
 	switch (p.mode)
@@ -690,16 +719,22 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 				const int x = static_cast<int>(p.draw_x);
 				p.scanline_bg_raw[x] = 0;
 				p.scanline_raw[x]    = 0;
-				p.framebuffer[p.ly * GB_SCREEN_WIDTH + x] =
-					ApplyPalette(p.latched_bgp, 0);
-				p.layer[p.ly * GB_SCREEN_WIDTH + x] = GB_PIXEL_BG;   // blank BG
+				if (!p.present_hold)
+				{
+					p.framebuffer[p.ly * GB_SCREEN_WIDTH + x] =
+						ApplyPalette(p.latched_bgp, 0);
+					p.layer[p.ly * GB_SCREEN_WIDTH + x] = GB_PIXEL_BG;   // blank BG
+				}
 				const SpritePixel sp = SampleSpritePixel(p, x);
 				if (p.show_obj && sp.covered)
 				{
 					p.scanline_raw[x] = sp.color;
-					p.framebuffer[p.ly * GB_SCREEN_WIDTH + x] =
-						ApplyPalette(sp.palette, sp.color);
-					p.layer[p.ly * GB_SCREEN_WIDTH + x] = GB_PIXEL_OBJ;
+					if (!p.present_hold)
+					{
+						p.framebuffer[p.ly * GB_SCREEN_WIDTH + x] =
+							ApplyPalette(sp.palette, sp.color);
+						p.layer[p.ly * GB_SCREEN_WIDTH + x] = GB_PIXEL_OBJ;
+					}
 				}
 			}
 			++p.draw_x;
@@ -729,6 +764,7 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 			{
 				p.mode          = PpuMode::VBlank;
 				p.frame_ready   = true;
+				p.present_hold  = false;
 				p.window_line   = 0;
 				p.window_active = false;
 				p.wy_triggered  = false;
@@ -787,7 +823,7 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 	}
 
 	if (transitioned)
-		RecomputeStatLine(p, mem);
+		RecomputeStatLine(p, mem, true);
 }
 
 void PpuStep(Ppu &p, Memory &mem, int32_t tcycles)
@@ -815,6 +851,7 @@ void PpuStep(Ppu &p, Memory &mem, int32_t tcycles)
 		p.window_line    = 0;
 		p.stat_line_high = false;
 		p.vblank_irq_delay = 0;
+		p.stat_irq_delay = 0;
 		p.draw_x         = 0;
 		p.window_active  = false;
 		p.wy_triggered   = false;
@@ -870,6 +907,7 @@ void PpuWriteReg(Ppu &p, Memory &mem, uint16_t addr, uint8_t value)
 				p.mode        = PpuMode::OamScan;
 				p.mode_clock  = 0;
 				p.window_line = 0;
+				p.present_hold = p.hold_present_on_enable;
 			}
 			if (is_on) RecomputeStatLine(p, mem);
 			break;

--- a/sgb/gb_ppu.h
+++ b/sgb/gb_ppu.h
@@ -160,6 +160,13 @@ struct Ppu
 	// "wait until LY=$90" busy loop at $078A to capture LY=144 into A.
 	uint8_t  vblank_irq_delay = 0;
 
+	// STAT counterpart of vblank_irq_delay (PPU-originated edges only).
+	uint8_t  stat_irq_delay = 0;
+
+	// Real panels never display the first frame after LCD enable — hold the prior one.
+	bool     hold_present_on_enable = true;
+	bool     present_hold = false;
+
 	uint8_t  framebuffer[GB_SCREEN_WIDTH * GB_SCREEN_HEIGHT];
 
 	// Per-frame raw 2-bit BG/window/sprite indices (pre-BGP/OBP). The

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -442,6 +442,8 @@ void Emulator::Reset()
 	impl_->fb.pitch  = GB_SCREEN_WIDTH;
 
 	impl_->ppu.cgb = impl_->cgb_mode && !Settings.SGB_BIOSModeActive;
+	impl_->ppu.hold_present_on_enable = !Settings.SGB_BIOSModeActive &&
+		(impl_->cgb_mode || impl_->run_mode == RunMode::DMG);
 
 	// Apply run-mode specific post-boot register values. The SGB BIOS
 	// hands control to the cart with slightly different register state
@@ -1072,6 +1074,8 @@ void Emulator::RunCycles(int32_t tcycles)
 	// bank-1 attributes, no CGB palettes); rendering it as CGB would read
 	// garbage. Gate the color path off whenever the BIOS is driving.
 	impl_->ppu.cgb = impl_->cgb_mode && !Settings.SGB_BIOSModeActive;
+	impl_->ppu.hold_present_on_enable = !Settings.SGB_BIOSModeActive &&
+		(impl_->cgb_mode || impl_->run_mode == RunMode::DMG);
 
 	// MMM01 multicart just locked into game-mode — inject the SGB
 	// default ("Mario") palette packets so the picked sub-game gets
@@ -2136,6 +2140,8 @@ bool Emulator::StateLoad(const uint8_t *buffer, size_t size)
 	impl_->fb.pitch  = GB_SCREEN_WIDTH;
 
 	impl_->ppu.cgb = impl_->cgb_mode && !Settings.SGB_BIOSModeActive;
+	impl_->ppu.hold_present_on_enable = !Settings.SGB_BIOSModeActive &&
+		(impl_->cgb_mode || impl_->run_mode == RunMode::DMG);
 
 	// Reseed the SGB-bridge mirrors on Joypad from icd2 — these are
 	// not serialized (see VisitState), so a load with the BIOS not


### PR DESCRIPTION
## Problem

**RoboCop vs. The Terminator (USA)** flashes the bottom half of the screen for one frame as the "Detroit: On Patrol" intro fades to black, and flashes a full screen of striped garbage tiles for one frame at the legal-text → black transition.

## Root causes

**Half-screen flash.** The fade is an LYC-driven BGP raster band (black above LYC-top, visible band, black below LYC-bottom) that converges to line $47. On the degenerate final frame both LYC edges collide; the game's STAT handler spins a ~300 T delay, reads LY, and deliberately skips the un-blank writes when LY > $47 — a defensive guard for exactly this frame. On real DMG the rise→read chain (~500 T) lands the read on the next line, so the guard trips and the frame stays black. Our CPU executes instructions atomically against a PPU that has already advanced, so it observes PPU-raised IF bits one instruction-budget (~24 dots) early — the read landed at the tail of the LYC line itself, the guard passed, and BGP got un-blanked for the bottom half of one frame. This is the same skew `vblank_irq_delay` already compensates for VBlank (Altered Space); STAT never got the counterpart.

**Stripes flash.** The game disables the LCD during VBlank, rewrites VRAM, and re-enables it. Real panels never display the first frame after LCDC.7 0→1 (SameBoy models this as `GB_FRAMESKIP_LCD_TURNED_ON`); we rendered and presented that half-loaded frame.

## Fix

- `stat_irq_delay`: PPU-originated STAT rising edges (mode transitions, LYC comparator) defer `IF.LCDSTAT` by 24 dots, mirroring `vblank_irq_delay`. Edges raised by CPU register writes (FF40/41/44/45, STAT-write quirk) stay immediate — those are already synchronous with instruction retirement.
- `present_hold`: the first frame after LCD enable renders normally but skips the framebuffer/layer/color_fb stores, so the prior frame holds for that one frame. Capture-side buffers (`scanline_raw`, `raw_framebuffer`, SGB scanline capture) stay live. Disabled in SGB modes via `hold_present_on_enable` — the ICD2 stream sees every frame on real SGB, and BIOS border capture reads framebuffer lines.

Both fields are transient (≤1 frame) and unserialized, matching `vblank_irq_delay`.