### PR TITLE
GB/GBC audio + video fixes: APU dynamic-rate control, 3D Pocket Pool auto frame-blend

### DIFF
--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -115,6 +115,7 @@ struct Emulator::Impl
 	// both re-derive after load.
 	int64_t     ds_extra   = -1;
 	int32_t     apu_ds_rem = 0;
+	double      drc_integ  = 0.0;
 
 	// 256×224 composite staging buffer — heap-resident to keep a
 	// ~112 KB allocation off the stack of whatever thread drives
@@ -406,6 +407,7 @@ void Emulator::Reset()
 	impl_->handoff_frames        = 0;
 	impl_->ds_extra              = -1;
 	impl_->apu_ds_rem            = 0;
+	impl_->drc_integ             = 0.0;
 	std::memset(&impl_->icd2, 0, sizeof impl_->icd2);
 	// 4-bank LCD ring starts at $00 (matches Mesen2 SuperGameboy::Reset).
 	// $7000-$700F latch buffer starts as $FF so reads before the first
@@ -981,6 +983,23 @@ void Emulator::RunFrame()
 		RunCycles(456);
 		safety -= 456;
 	}
+
+	// Frame-locking pins GB time to the host's frame cadence, not the GB's
+	// authentic 59.73 Hz, so APU sample production drifts from the host's
+	// fixed-rate drain; lock production to the drain by steering the APU's
+	// effective clock until the ring buffer fill holds at its setpoint.
+	const uint32_t head = impl_->apu.sample_head;
+	const uint32_t tail = impl_->apu.sample_tail;
+	const uint32_t fill = (head >= tail) ? (head - tail)
+	                                     : (APU_SAMPLE_BUF_SIZE - tail + head);
+	const double err = static_cast<double>(fill) / APU_SAMPLE_BUF_SIZE - 0.125;
+	impl_->drc_integ += 5e-5 * err;
+	if (impl_->drc_integ >  0.03) impl_->drc_integ =  0.03;
+	if (impl_->drc_integ < -0.03) impl_->drc_integ = -0.03;
+	double corr = 0.02 * err + impl_->drc_integ;
+	if (corr >  0.03) corr =  0.03;
+	if (corr < -0.03) corr = -0.03;
+	ApuSetClockHz(impl_->apu, static_cast<int32_t>(base_hz * (1.0 + corr) + 0.5));
 }
 
 // ===================================================================
@@ -2122,6 +2141,7 @@ bool Emulator::StateLoad(const uint8_t *buffer, size_t size)
 	impl_->cart.sram_dirty = false;
 	impl_->ds_extra        = -1;
 	impl_->apu_ds_rem      = 0;
+	impl_->drc_integ       = 0.0;
 
 	// Reset only the sub-sample integration accumulator. The ring buffer
 	// is not serialized but also not wiped — it stays at its current

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -641,6 +641,7 @@ static void IcdStageNextSynth(Emulator::Impl::Icd2 &icd)
 namespace {
 struct GBAutoBlendEntry { const char *title; GBBlendMode mode; GBBlendLayer layer; };
 const GBAutoBlendEntry kGBAutoBlend[] = {
+	{ "3DPOCKTPOOLBVPP",  GB_BLEND_SIMPLE, GB_BLEND_LAYER_ALL        },  // 3D Pocket Pool — 2-phase multiplex of balls (OBJ) and shadows (BG), so layer must be ALL
 	{ "CASTLEVANIA2 BEL", GB_BLEND_SIMPLE, GB_BLEND_LAYER_BACKGROUND },  // Castlevania II: Belmont's Revenge (16-byte title)
 	{ "ZAS",              GB_BLEND_SIMPLE, GB_BLEND_LAYER_BACKGROUND },  // Chikyuu Kaihou Gun ZAS
 	{ "ZELDA",            GB_BLEND_SIMPLE, GB_BLEND_LAYER_ALL        },  // Zelda: Link's Awakening (DX)


### PR DESCRIPTION
## fix(gb): audio dynamic-rate control — lock sample production to host pacing

BIOS-less `RunFrame` is frame-locked (exactly one 70224-cycle GB frame per host frame), so GB time runs at the host's cadence (SNES throttle 60.0988 fps, vsync, etc.) while `ApuSetClockHz` paced samples assuming the authentic hardware clock. The mismatch is structural:

- **CGB carts** (clock 4194304): +0.62% overproduction → the 16K sample ring pins full after ~55s, then sheds ~300 samples/s as waveform splices, with audio latency stuck at +341ms. Worst audible on wave-RAM PCM streamers — 3D Pocket Pool's entire soundtrack is CH3 streaming (16 wave bytes rewritten + retrigger ~7×/frame).
- **DMG carts** (default SGB1 run mode, clock 4295455): −1.8% underproduction → XAudio2 starvation stutter.

Fix: a small PI controller at the end of `RunFrame` steers the APU's effective clock so the ring fill holds at a 43ms setpoint, matching production to whatever the host actually drains. Settles in ~3s, ripple ±0.6 cents. The integrator lives in `Impl` (reset on `Reset`/`StateLoad`, like `ds_extra`) — no `Apu` fields added, savestates unaffected.

Validated with a harness host-pacing simulation: at 60.0988fps the ring was pinned for 3607/6000 frames without the fix, 0 with it (correction converges to the predicted +0.65%); an underproducing 58.7fps host converges to −1.81% with no starvation.

## fix(gb): 3D Pocket Pool auto frame-blend — Simple, layer All

The in-game "flashing" is the game's own rendering: it 2-phase-multiplexes the picture at 30Hz (balls/HUD markers as alternating OBJ subsets — 15 balls exceed the per-line sprite limit — and ball shadows redrawn into BG tiles every other frame), relying on GBC LCD ghosting to fuse the phases.

Added the title to the `kGBAutoBlend` table (Simple Blend, layer **All**) so it blends out of the box with the default Auto setting. Layer must be All: per-pixel layer-map analysis shows the flicker spans OBJ↔OBJ (322 px), BG↔BG (249 px) and OBJ↔BG (260 px), so sprites- or background-selective blending each leave residue (shadows keep flickering under a sprites-layer blend). With a 50/50 blend of adjacent frames the output is pixel-stable (raw adjacent frames differ by ~600 px, blended pairs by 0).