### PR TITLE
fix(gb): BGP mid-mode-3 re-latch + mode-3 VRAM blocking

### DIFF
--- a/sgb/gb_memory.cpp
+++ b/sgb/gb_memory.cpp
@@ -21,6 +21,13 @@ namespace SGB {
 namespace {
 SerialByteCallback g_serial_cb = nullptr;
 uint8_t            g_dma_last  = 0xFF;  // 0xFF46 last written byte — register reads echo this.
+bool               g_dma_vram_bypass = false;
+}
+
+inline bool VramBlocked(const Memory &m)
+{
+	return !g_dma_vram_bypass && m.ppu &&
+	       m.ppu->mode == PpuMode::Transfer && (m.ppu->lcdc & 0x80);
 }
 
 void SetSerialCallback(SerialByteCallback cb) { g_serial_cb = cb; }
@@ -104,7 +111,8 @@ uint8_t MemRead(Memory &m, uint16_t addr)
 	}
 	if (addr < 0xA000)
 	{
-		return m.ppu ? m.ppu->vram[(addr - 0x8000) + VramBankBase(m)] : 0xFF;
+		if (!m.ppu || VramBlocked(m)) return 0xFF;
+		return m.ppu->vram[(addr - 0x8000) + VramBankBase(m)];
 	}
 	if (addr < 0xC000)
 	{
@@ -160,6 +168,7 @@ void MemWrite(Memory &m, uint16_t addr, uint8_t value)
 	{
 		if (m.ppu)
 		{
+			if (VramBlocked(m)) return;
 			m.ppu->vram[(addr - 0x8000) + VramBankBase(m)] = value;
 			m.ppu->vram_writes++;
 		}
@@ -361,29 +370,35 @@ static void DoOamDma(Memory &m, uint8_t value)
 {
 	if (!m.ppu) return;
 	const uint16_t src = static_cast<uint16_t>(value << 8);
+	g_dma_vram_bypass = true;
 	for (int i = 0; i < 0xA0; ++i)
 	{
 		m.ppu->oam[i] = MemRead(m, static_cast<uint16_t>(src + i));
 	}
+	g_dma_vram_bypass = false;
 }
 
 static void DoGdma(Memory &m, uint16_t src, uint16_t dst, uint16_t blocks)
 {
 	const uint32_t n = static_cast<uint32_t>(blocks) * 0x10u;
+	g_dma_vram_bypass = true;
 	for (uint32_t i = 0; i < n; ++i)
 	{
 		const uint8_t b = MemRead(m, static_cast<uint16_t>(src + i));
 		MemWrite(m, static_cast<uint16_t>(0x8000 + ((dst + i) & 0x1FFF)), b);
 	}
+	g_dma_vram_bypass = false;
 }
 
 static void HdmaTransferBlock(Memory &m)
 {
+	g_dma_vram_bypass = true;
 	for (uint32_t i = 0; i < 0x10; ++i)
 	{
 		const uint8_t b = MemRead(m, static_cast<uint16_t>(m.hdma_src + i));
 		MemWrite(m, static_cast<uint16_t>(0x8000 + ((m.hdma_dst + i) & 0x1FFF)), b);
 	}
+	g_dma_vram_bypass = false;
 	m.hdma_src = static_cast<uint16_t>(m.hdma_src + 0x10);
 	m.hdma_dst = static_cast<uint16_t>(m.hdma_dst + 0x10);
 	m.hdma1 = static_cast<uint8_t>(m.hdma_src >> 8);

--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -37,17 +37,16 @@
 // emits ONE pixel per dot (RenderPixel), re-sampling LCDC/SCX/SCY/OBP0/
 // OBP1/WY at each pixel — this catches mid-LY register writes that some
 // games use for parallax (Animaniacs cloud strip), palette effects, and
-// partial-line scroll. WX and BGP are exceptions: both are latched at
-// mode 2 → 3 and held for the line, so STAT-handler-driven mid-mode-3
-// writes apply to the NEXT line. This matches the 8-dot tile-boundary
-// granularity real DMG uses for window engage (rather than per-pixel).
-// Without WX latching, games that toggle WX from a STAT IRQ to engage/
-// disengage the window for a dialog overlay (One Piece - Maboroshi no
-// Grand Line) tear the boundary scanlines. Without BGP latching, games
-// with per-scanline BGP raster effects where the handler runs long
-// (Initial D Gaiden racing speedometer top border) split the next
-// scanline — early pixels with the previous line's BGP, late pixels
-// with the new value.
+// partial-line scroll. WX is an exception: it is latched at mode 2 → 3
+// and held for the line, so STAT-handler-driven mid-mode-3 writes apply
+// to the NEXT line. This matches the 8-dot tile-boundary granularity
+// real DMG uses for window engage (rather than per-pixel). Without WX
+// latching, games that toggle WX from a STAT IRQ to engage/disengage
+// the window for a dialog overlay (One Piece - Maboroshi no Grand Line)
+// tear the boundary scanlines. BGP is also latched at mode 2 → 3 but a
+// write landing during mode 3 re-latches immediately (applies from the
+// current pixel on) — see Ppu::latched_bgp for the Initial D Gaiden /
+// RoboCop trade-off this resolves.
 //
 // OBJ-over-BG priority: the per-pixel BG raw value (scanline_bg_raw) is
 // tracked alongside the palette-mapped framebuffer so SampleSpritePixel
@@ -968,7 +967,11 @@ void PpuWriteReg(Ppu &p, Memory &mem, uint16_t addr, uint8_t value)
 		case 0xFF43: p.scx = value; break;
 		case 0xFF44: p.ly  = 0; RecomputeStatLine(p, mem); break;
 		case 0xFF45: p.lyc = value; RecomputeStatLine(p, mem); break;
-		case 0xFF47: p.bgp  = value; break;
+		case 0xFF47:
+			p.bgp = value;
+			if (p.mode == PpuMode::Transfer)
+				p.latched_bgp = value;
+			break;
 		case 0xFF48: p.obp0 = value; break;
 		case 0xFF49: p.obp1 = value; break;
 		case 0xFF4A: p.wy = value;   break;

--- a/sgb/gb_ppu.h
+++ b/sgb/gb_ppu.h
@@ -102,11 +102,15 @@ struct Ppu
 	// previous line's BGP, pixels after used the new one. Latching at
 	// the mode 2 → 3 boundary gives each line a single BGP for its
 	// entire mode 3, matching how real DMG sources palette for the
-	// majority of games. $FF47 reads still return live p.bgp. TRADE-OFF:
-	// games that intentionally change BGP mid-mode-3 for a horizontal
-	// gradient (Animaniacs cloud strip, Balloon Kid title) will see one
-	// BGP per line instead of the per-pixel sweep — revisit if those
-	// regress.
+	// majority of games. $FF47 reads still return live p.bgp.
+	// A BGP write that lands DURING mode 3 re-latches immediately, so it
+	// applies from the current pixel onward — real DMG applies BGP
+	// per-pixel, and RoboCop's level-intro venetian blind depends on it
+	// (its STAT handler alternates BGP $FF/$4B per scanline with the
+	// write landing mid-mode-3; without the re-latch the blind renders
+	// as a plain top-to-bottom reveal). Initial D stays protected: its
+	// overrun write lands in the fetcher-setup dots before pixel 0
+	// emits, so the re-latch still covers the whole line.
 	uint8_t   latched_bgp = 0;
 
 	// Monotonic GB t-cycle counter — advanced by PpuStep. Used by


### PR DESCRIPTION
## Summary

RoboCop (USA)'s level intro reveals the background through a per-scanline **BGP venetian blind**: its STAT handler alternates `BGP` between `$FF` (blackout) and `$4B` (inverted) every scanline, with the writes landing mid-mode-3. Verified against SameBoy with an LY/mode-stamped IO-write trace; Mesen shows the same interlaced reveal.

Two hardware behaviors were missing:

### 1. BGP writes landing during mode 3 now re-latch immediately (`gb_ppu.cpp`, `gb_ppu.h`)
`latched_bgp` (taken at the mode 2→3 boundary) deferred mid-mode-3 writes to the next line, where the handler's next write overwrote them before the latch — the blind flattened into a plain top-to-bottom reveal. A `$FF47` write during mode 3 now applies from the current pixel onward, matching real DMG per-pixel BGP. Initial D Gaiden (the game the latch was added for) stays protected: its handler-overrun write lands in the fetcher-setup dots before pixel 0 emits, so the re-latch still covers the whole line.

### 2. Mode-3 VRAM inaccessibility (`gb_memory.cpp`)
CPU reads of `$8000-$9FFF` during mode 3 with the LCD on return `$FF`; writes are dropped. OAM-DMA / GDMA / HDMA copy loops bypass the gate so the existing HDMA behaviors (Little Mermaid II, NASCAR 2000) are untouched. RoboCop bulk-copies its tileset unsynced behind a faded-out screen — blocked-write counts (1557 writes/frame, 770 blocked, same 12-frame window).