### PR TITLE
feat(cheats): cheat search and editor for BIOS-less GB/GBC/SGB games

### DIFF
--- a/cheats.cpp
+++ b/cheats.cpp
@@ -37,17 +37,56 @@
 	 (s) == S9X_24_BITS ? (((int32) ((*((m) + (o)) + (*((m) + (o) + 1) << 8) + (*((m) + (o) + 2) << 16)) << 8)) >> 8): \
                            ((int32)  (*((m) + (o)) + (*((m) + (o) + 1) << 8) + (*((m) + (o) + 2) << 16) + (*((m) + (o) + 3) << 24))))
 
+static void S9xSetBitRange (uint32 *bits, int start, int count)
+{
+	// start is 32-aligned for all three regions (0x00000/0x20000/0x30000)
+	int full = count >> 5;
+	if (full)
+		memset(bits + (start >> 5), 0xff, full * sizeof(uint32));
+
+	int rem = count & 31;
+	if (rem)
+		bits[(start >> 5) + full] = (1u << rem) - 1;
+}
+
 void S9xStartCheatSearch (SCheatData *d)
 {
-	memmove(d->CWRAM, d->RAM, 0x20000);
-	memmove(d->CSRAM, d->SRAM, 0x80000);
-	memmove(d->CIRAM, &d->FillRAM[0x3000], 0x2000);
-	memset((char *) d->ALL_BITS, 0xff, 0x32000 >> 3);
+	if (d->RAM && d->ram_size)
+		memmove(d->CWRAM, d->RAM, d->ram_size);
+	if (d->SRAM && d->sram_size)
+		memmove(d->CSRAM, d->SRAM, d->sram_size);
+	if (d->IRAM && d->iram_size)
+		memmove(d->CIRAM, d->IRAM, d->iram_size);
+
+	memset((char *) d->ALL_BITS, 0, 0x32000 >> 3);
+	S9xSetBitRange(d->ALL_BITS, 0x00000, d->RAM  ? d->ram_size  : 0);
+	S9xSetBitRange(d->ALL_BITS, 0x20000, d->SRAM ? d->sram_size : 0);
+	S9xSetBitRange(d->ALL_BITS, 0x30000, d->IRAM ? d->iram_size : 0);
+}
+
+static void S9xClearTrailingBits (SCheatData *d, int l)
+{
+	int	i;
+	int	ram_n  = (int) d->ram_size;
+	int	sram_n = (int) d->sram_size;
+	int	iram_n = (int) d->iram_size;
+
+	for (i = ram_n - l < 0 ? 0 : ram_n - l; i < ram_n; i++)
+		BIT_CLEAR(d->WRAM_BITS, i);
+
+	for (i = sram_n - l < 0 ? 0 : sram_n - l; i < sram_n; i++)
+		BIT_CLEAR(d->SRAM_BITS, i);
+
+	for (i = iram_n - l < 0 ? 0 : iram_n - l; i < iram_n; i++)
+		BIT_CLEAR(d->IRAM_BITS, i);
 }
 
 void S9xSearchForChange (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataSize size, bool8 is_signed, bool8 update)
 {
 	int	l, i;
+	int	ram_n  = (int) d->ram_size;
+	int	sram_n = (int) d->sram_size;
+	int	iram_n = (int) d->iram_size;
 
 	switch (size)
 	{
@@ -60,7 +99,7 @@ void S9xSearchForChange (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatData
 
 	if (is_signed)
 	{
-		for (i = 0; i < 0x20000 - l; i++)
+		for (i = 0; i < ram_n - l; i++)
 		{
 			if (TEST_BIT(d->WRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTDS(size, d->RAM, i), _S9XCHTDS(size, d->CWRAM, i)))
 			{
@@ -71,7 +110,7 @@ void S9xSearchForChange (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatData
 				BIT_CLEAR(d->WRAM_BITS, i);
 		}
 
-		for (i = 0; i < 0x10000 - l; i++)
+		for (i = 0; i < sram_n - l; i++)
 		{
 			if (TEST_BIT(d->SRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTDS(size, d->SRAM, i), _S9XCHTDS(size, d->CSRAM, i)))
 			{
@@ -82,12 +121,12 @@ void S9xSearchForChange (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatData
 				BIT_CLEAR(d->SRAM_BITS, i);
 		}
 
-		for (i = 0; i < 0x2000 - l; i++)
+		for (i = 0; i < iram_n - l; i++)
 		{
-			if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTDS(size, d->FillRAM + 0x3000, i), _S9XCHTDS(size, d->CIRAM, i)))
+			if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTDS(size, d->IRAM, i), _S9XCHTDS(size, d->CIRAM, i)))
 			{
 				if (update)
-					d->CIRAM[i] = d->FillRAM[i + 0x3000];
+					d->CIRAM[i] = d->IRAM[i];
 			}
 			else
 				BIT_CLEAR(d->IRAM_BITS, i);
@@ -95,7 +134,7 @@ void S9xSearchForChange (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatData
 	}
 	else
 	{
-		for (i = 0; i < 0x20000 - l; i++)
+		for (i = 0; i < ram_n - l; i++)
 		{
 			if (TEST_BIT(d->WRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTD(size, d->RAM, i), _S9XCHTD(size, d->CWRAM, i)))
 			{
@@ -106,7 +145,7 @@ void S9xSearchForChange (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatData
 				BIT_CLEAR(d->WRAM_BITS, i);
 		}
 
-		for (i = 0; i < 0x10000 - l; i++)
+		for (i = 0; i < sram_n - l; i++)
 		{
 			if (TEST_BIT(d->SRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTD(size, d->SRAM, i), _S9XCHTD(size, d->CSRAM, i)))
 			{
@@ -117,28 +156,27 @@ void S9xSearchForChange (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatData
 				BIT_CLEAR(d->SRAM_BITS, i);
 		}
 
-		for (i = 0; i < 0x2000 - l; i++)
+		for (i = 0; i < iram_n - l; i++)
 		{
-			if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTD(size, d->FillRAM + 0x3000, i), _S9XCHTD(size, d->CIRAM, i)))
+			if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTD(size, d->IRAM, i), _S9XCHTD(size, d->CIRAM, i)))
 			{
 				if (update)
-					d->CIRAM[i] = d->FillRAM[i + 0x3000];
+					d->CIRAM[i] = d->IRAM[i];
 			}
 			else
 				BIT_CLEAR(d->IRAM_BITS, i);
 		}
 	}
 
-	for (i = 0x20000 - l; i < 0x20000; i++)
-		BIT_CLEAR(d->WRAM_BITS, i);
-
-	for (i = 0x10000 - l; i < 0x10000; i++)
-		BIT_CLEAR(d->SRAM_BITS, i);
+	S9xClearTrailingBits(d, l);
 }
 
 void S9xSearchForValue (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataSize size, uint32 value, bool8 is_signed, bool8 update)
 {
-	int l, i;
+	int	l, i;
+	int	ram_n  = (int) d->ram_size;
+	int	sram_n = (int) d->sram_size;
+	int	iram_n = (int) d->iram_size;
 
 	switch (size)
 	{
@@ -151,7 +189,7 @@ void S9xSearchForValue (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataS
 
 	if (is_signed)
 	{
-		for (i = 0; i < 0x20000 - l; i++)
+		for (i = 0; i < ram_n - l; i++)
 		{
 			if (TEST_BIT(d->WRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTDS(size, d->RAM, i), (int32) value))
 			{
@@ -162,7 +200,7 @@ void S9xSearchForValue (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataS
 				BIT_CLEAR(d->WRAM_BITS, i);
 		}
 
-		for (i = 0; i < 0x10000 - l; i++)
+		for (i = 0; i < sram_n - l; i++)
 		{
 			if (TEST_BIT(d->SRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTDS(size, d->SRAM, i), (int32) value))
 			{
@@ -173,12 +211,12 @@ void S9xSearchForValue (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataS
 				BIT_CLEAR(d->SRAM_BITS, i);
 		}
 
-		for (i = 0; i < 0x2000 - l; i++)
+		for (i = 0; i < iram_n - l; i++)
 		{
-			if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTDS(size, d->FillRAM + 0x3000, i), (int32) value))
+			if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTDS(size, d->IRAM, i), (int32) value))
 			{
 				if (update)
-					d->CIRAM[i] = d->FillRAM[i + 0x3000];
+					d->CIRAM[i] = d->IRAM[i];
 			}
 			else
 				BIT_CLEAR(d->IRAM_BITS, i);
@@ -186,7 +224,7 @@ void S9xSearchForValue (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataS
 	}
 	else
 	{
-		for (i = 0; i < 0x20000 - l; i++)
+		for (i = 0; i < ram_n - l; i++)
 		{
 			if (TEST_BIT(d->WRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTD(size, d->RAM, i), value))
 			{
@@ -197,7 +235,7 @@ void S9xSearchForValue (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataS
 				BIT_CLEAR(d->WRAM_BITS, i);
 		}
 
-		for (i = 0; i < 0x10000 - l; i++)
+		for (i = 0; i < sram_n - l; i++)
 		{
 			if (TEST_BIT(d->SRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTD(size, d->SRAM, i), value))
 			{
@@ -208,28 +246,27 @@ void S9xSearchForValue (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataS
 				BIT_CLEAR(d->SRAM_BITS, i);
 		}
 
-		for (i = 0; i < 0x2000 - l; i++)
+		for (i = 0; i < iram_n - l; i++)
 		{
-			if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTD(size, d->FillRAM + 0x3000, i), value))
+			if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, _S9XCHTD(size, d->IRAM, i), value))
 			{
 				if (update)
-					d->CIRAM[i] = d->FillRAM[i + 0x3000];
+					d->CIRAM[i] = d->IRAM[i];
 			}
 			else
 				BIT_CLEAR(d->IRAM_BITS, i);
 		}
 	}
 
-	for (i = 0x20000 - l; i < 0x20000; i++)
-		BIT_CLEAR(d->WRAM_BITS, i);
-
-	for (i = 0x10000 - l; i < 0x10000; i++)
-		BIT_CLEAR(d->SRAM_BITS, i);
+	S9xClearTrailingBits(d, l);
 }
 
 void S9xSearchForAddress (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDataSize size, uint32 value, bool8 update)
 {
 	int	l, i;
+	int	ram_n  = (int) d->ram_size;
+	int	sram_n = (int) d->sram_size;
+	int	iram_n = (int) d->iram_size;
 
 	switch (size)
 	{
@@ -240,7 +277,7 @@ void S9xSearchForAddress (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDat
 		case S9X_32_BITS:	l = 3; break;
 	}
 
-	for (i = 0; i < 0x20000 - l; i++)
+	for (i = 0; i < ram_n - l; i++)
 	{
 		if (TEST_BIT(d->WRAM_BITS, i) && _S9XCHTC(cmp, i, (int32) value))
 		{
@@ -251,7 +288,7 @@ void S9xSearchForAddress (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDat
 			BIT_CLEAR(d->WRAM_BITS, i);
 	}
 
-	for (i = 0; i < 0x10000 - l; i++)
+	for (i = 0; i < sram_n - l; i++)
 	{
 		if (TEST_BIT(d->SRAM_BITS, i) && _S9XCHTC(cmp, i + 0x20000, (int32) value))
 		{
@@ -262,43 +299,39 @@ void S9xSearchForAddress (SCheatData *d, S9xCheatComparisonType cmp, S9xCheatDat
 			BIT_CLEAR(d->SRAM_BITS, i);
 	}
 
-	for (i = 0; i < 0x2000 - l; i++)
+	for (i = 0; i < iram_n - l; i++)
 	{
 		if (TEST_BIT(d->IRAM_BITS, i) && _S9XCHTC(cmp, i + 0x30000, (int32) value))
 		{
 			if (update)
-				d->CIRAM[i] = d->FillRAM[i + 0x3000];
+				d->CIRAM[i] = d->IRAM[i];
 		}
 		else
 			BIT_CLEAR(d->IRAM_BITS, i);
 	}
 
-	for (i = 0x20000 - l; i < 0x20000; i++)
-		BIT_CLEAR(d->WRAM_BITS, i);
-
-	for (i = 0x10000 - l; i < 0x10000; i++)
-		BIT_CLEAR(d->SRAM_BITS, i);
+	S9xClearTrailingBits(d, l);
 }
 
 void S9xOutputCheatSearchResults (SCheatData *d)
 {
 	int	i;
 
-	for (i = 0; i < 0x20000; i++)
+	for (i = 0; i < (int) d->ram_size; i++)
 	{
 		if (TEST_BIT(d->WRAM_BITS, i))
 			printf("WRAM: %05x: %02x\n", i, d->RAM[i]);
 	}
 
-	for (i = 0; i < 0x10000; i++)
+	for (i = 0; i < (int) d->sram_size; i++)
 	{
 		if (TEST_BIT(d->SRAM_BITS, i))
 			printf("SRAM: %04x: %02x\n", i, d->SRAM[i]);
 	}
 
-	for (i = 0; i < 0x2000; i++)
+	for (i = 0; i < (int) d->iram_size; i++)
 	{
 		if (TEST_BIT(d->IRAM_BITS, i))
-			printf("IRAM: %05x: %02x\n", i, d->FillRAM[i + 0x3000]);
+			printf("IRAM: %05x: %02x\n", i, d->IRAM[i]);
 	}
 }

--- a/cheats.h
+++ b/cheats.h
@@ -41,6 +41,11 @@ struct SCheatData
 	uint8_t	*RAM;
 	uint8_t	*FillRAM;
 	uint8_t	*SRAM;
+	uint8_t	*IRAM;
+	uint32_t	ram_size;
+	uint32_t	sram_size;
+	uint32_t	iram_size;
+	bool8	gb_mode;
 	uint32_t	ALL_BITS[0x32000 >> 5];
 	uint8_t	CWatchRAM[0x32000];
 };
@@ -93,6 +98,9 @@ void S9xCheatsEnable(void);
 std::string S9xCheatValidate(const std::string &cheat);
 
 uint32_t S9xCheatFlatToSNES(uint32_t flat_addr);
+bool S9xCheatsGBMode(void);
+uint32_t S9xCheatFlatToAddress(uint32_t flat_addr);
+int32_t S9xCheatGBToFlat(uint32_t gb_addr);
 
 void S9xInitCheatData (void);
 void S9xInitWatchedAddress (void);

--- a/cheats2.cpp
+++ b/cheats2.cpp
@@ -8,10 +8,19 @@
 #include "cheats.h"
 #include "snes9x.h"
 #include "memmap.h"
+#include "sgb/sgb.h"
 #include <cassert>
+
+bool S9xCheatsGBMode(void)
+{
+    return Settings.SuperGameBoy && !Settings.SGB_BIOSModeActive;
+}
 
 static inline uint8 S9xGetByteFree(uint32 Address)
 {
+    if (S9xCheatsGBMode())
+        return S9xSGBCheatRead(Address);
+
     int block = (Address & 0xffffff) >> MEMMAP_SHIFT;
     uint8 *GetAddress = Memory.Map[block];
     uint8 byte;
@@ -104,6 +113,12 @@ static inline uint8 S9xGetByteFree(uint32 Address)
 
 static inline void S9xSetByteFree(uint8 Byte, uint32 Address)
 {
+    if (S9xCheatsGBMode())
+    {
+        S9xSGBCheatWrite(Address, Byte);
+        return;
+    }
+
     int block = (Address & 0xffffff) >> MEMMAP_SHIFT;
     uint8 *SetAddress = Memory.Map[block];
 
@@ -204,9 +219,28 @@ void S9xInitWatchedAddress(void)
 
 void S9xInitCheatData(void)
 {
-    Cheat.RAM = Memory.RAM;
-    Cheat.SRAM = Memory.SRAM;
-    Cheat.FillRAM = Memory.FillRAM;
+    Cheat.gb_mode = S9xCheatsGBMode();
+
+    if (Cheat.gb_mode)
+    {
+        unsigned int wram_size = 0, sram_size = 0, hram_size = 0;
+        Cheat.RAM       = S9xSGBCheatWRAMPtr(&wram_size);
+        Cheat.SRAM      = S9xSGBCheatSRAMPtr(&sram_size);
+        Cheat.IRAM      = S9xSGBCheatHRAMPtr(&hram_size);
+        Cheat.FillRAM   = Memory.FillRAM;
+        Cheat.ram_size  = wram_size;
+        Cheat.sram_size = sram_size > 0x10000 ? 0x10000 : sram_size;
+        Cheat.iram_size = hram_size;
+        return;
+    }
+
+    Cheat.RAM       = Memory.RAM;
+    Cheat.SRAM      = Memory.SRAM;
+    Cheat.FillRAM   = Memory.FillRAM;
+    Cheat.IRAM      = Memory.FillRAM + 0x3000;
+    Cheat.ram_size  = 0x20000;
+    Cheat.sram_size = 0x10000;
+    Cheat.iram_size = 0x2000;
 }
 
 uint32_t S9xCheatFlatToSNES(uint32_t flat_addr)
@@ -249,6 +283,49 @@ uint32_t S9xCheatFlatToSNES(uint32_t flat_addr)
         // (used by the watch system's internal encoding)
         return flat_addr + 0x7E0000;
     }
+}
+
+static uint32_t S9xCheatFlatToGB(uint32_t flat_addr)
+{
+    if (flat_addr < 0x20000)
+    {
+        if (flat_addr < 0x2000)
+            return 0xC000 + flat_addr;
+        return 0x10000 + (flat_addr - 0x2000);
+    }
+    else if (flat_addr < 0x30000)
+    {
+        uint32_t sram_off = flat_addr - 0x20000;
+        if (sram_off < 0x2000)
+            return 0xA000 + sram_off;
+        return 0x16000 + (sram_off - 0x2000);
+    }
+
+    return 0xFF80 + (flat_addr - 0x30000);
+}
+
+int32_t S9xCheatGBToFlat(uint32_t gb_addr)
+{
+    if (gb_addr >= 0xC000 && gb_addr < 0xE000)
+        return gb_addr - 0xC000;
+    if (gb_addr >= 0xE000 && gb_addr < 0xFE00)   // Echo RAM
+        return gb_addr - 0xE000;
+    if (gb_addr >= 0x10000 && gb_addr < 0x16000)
+        return 0x2000 + (gb_addr - 0x10000);
+    if (gb_addr >= 0xA000 && gb_addr < 0xC000)
+        return 0x20000 + (gb_addr - 0xA000);
+    if (gb_addr >= 0x16000 && gb_addr < 0x24000)
+        return 0x22000 + (gb_addr - 0x16000);
+    if (gb_addr >= 0xFF80 && gb_addr < 0xFFFF)
+        return 0x30000 + (gb_addr - 0xFF80);
+    return -1;
+}
+
+uint32_t S9xCheatFlatToAddress(uint32_t flat_addr)
+{
+    if (S9xCheatsGBMode())
+        return S9xCheatFlatToGB(flat_addr);
+    return S9xCheatFlatToSNES(flat_addr);
 }
 
 static inline std::string trim(const std::string &&string)
@@ -462,6 +539,126 @@ bool S9xGameGenieToRaw(const std::string &code, uint32 &address, uint8 &byte)
     return true;
 }
 
+// GB GameShark TTVVAAAA: TT 00/01 = 8-bit RAM write, 8x = SRAM bank x,
+// 9x = CGB WRAM bank x; AAAA is little-endian.
+static bool S9xGBGameSharkToRaw(const std::string &code, uint32 &address, uint8 &byte)
+{
+    if (code.length() != 8 || !is_all_hex(code))
+        return false;
+
+    uint32 data = std::strtoul(code.c_str(), nullptr, 16);
+    uint8  type = data >> 24;
+    uint8  value = (data >> 16) & 0xFF;
+    uint32 addr = ((data & 0xFF) << 8) | ((data >> 8) & 0xFF);
+
+    if (type == 0x00 || type == 0x01)
+    {
+        if (addr < 0x8000)
+            return false;
+    }
+    else if ((type & 0xF0) == 0x80)
+    {
+        if (addr < 0xA000 || addr >= 0xC000)
+            return false;
+        uint8 bank = type & 0x0F;
+        if (bank >= 1)
+            addr = 0x16000 + (bank - 1) * 0x2000 + (addr - 0xA000);
+    }
+    else if ((type & 0xF0) == 0x90)
+    {
+        if (addr < 0xD000 || addr >= 0xE000)
+            return false;
+        uint8 bank = type & 0x07;
+        if (bank >= 2)
+            addr = 0x10000 + (bank - 2) * 0x1000 + (addr - 0xD000);
+    }
+    else
+        return false;
+
+    address = addr;
+    byte = value;
+
+    return true;
+}
+
+// GB Game Genie ABC-DEF[-GHI]: value = AB, address = (F^$F)CDE,
+// compare = GI rotated right 2 then XOR $BA (H is a check digit).
+// ROM patches: bank-0 addresses patch one site; banked addresses
+// (0x4000-0x7FFF) expand to every 16K bank, filtered by the compare
+// byte when present.
+static bool S9xGBGameGenieToCheats(const std::string &code, std::vector<SCheat> &cheats)
+{
+    bool has_compare = false;
+
+    if (code.length() == 11 && code[3] == '-' && code[7] == '-' &&
+        is_all_hex(code.substr(0, 3)) && is_all_hex(code.substr(4, 3)) &&
+        is_all_hex(code.substr(8, 3)))
+        has_compare = true;
+    else if (!(code.length() == 7 && code[3] == '-' &&
+               is_all_hex(code.substr(0, 3)) && is_all_hex(code.substr(4, 3))))
+        return false;
+
+    auto hex = [](char ch) -> uint32 {
+        if (ch >= '0' && ch <= '9') return ch - '0';
+        if (ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
+        return ch - 'A' + 10;
+    };
+
+    uint8  value = (hex(code[0]) << 4) | hex(code[1]);
+    uint32 address = (hex(code[2]) << 8) | (hex(code[4]) << 4) | hex(code[5]) |
+                     ((hex(code[6]) ^ 0xF) << 12);
+    uint8  compare = 0;
+
+    if (address >= 0x8000)
+        return false;
+
+    if (has_compare)
+    {
+        compare = (hex(code[8]) << 4) | hex(code[10]);
+        compare = ((compare >> 2) | (compare << 6)) & 0xFF;
+        compare ^= 0xBA;
+    }
+
+    unsigned int rom_size = 0;
+    const unsigned char *rom = S9xSGBCheatROMPtr(&rom_size);
+    if (!rom || !rom_size)
+        return false;
+
+    SCheat c;
+    c.enabled     = false;
+    c.conditional = false;
+    c.cond_true   = false;
+    c.cond_byte   = 0;
+    c.saved_byte  = 0;
+    c.byte        = value;
+
+    if (address < 0x4000)
+    {
+        if (address >= rom_size)
+            return false;
+        if (has_compare)
+        {
+            c.conditional = true;
+            c.cond_byte = compare;
+        }
+        c.address = 0x01000000 | address;
+        cheats.push_back(c);
+        return true;
+    }
+
+    size_t before = cheats.size();
+    for (uint32 bank = 0; bank * 0x4000 + 0x4000 <= rom_size; bank++)
+    {
+        uint32 ofs = bank * 0x4000 + (address - 0x4000);
+        if (has_compare && rom[ofs] != compare)
+            continue;
+        c.address = 0x01000000 | ofs;
+        cheats.push_back(c);
+    }
+
+    return cheats.size() > before;
+}
+
 SCheat S9xTextToCheat(const std::string &text)
 {
     SCheat c;
@@ -471,11 +668,15 @@ SCheat S9xTextToCheat(const std::string &text)
     c.enabled     = false;
     c.conditional = false;
 
-    if (S9xGameGenieToRaw(text, c.address, c.byte))
+    if (S9xCheatsGBMode() && S9xGBGameSharkToRaw(text, c.address, c.byte))
     {
         byte = c.byte;
     }
-    else if (S9xProActionReplayToRaw(text, c.address, c.byte))
+    else if (!S9xCheatsGBMode() && S9xGameGenieToRaw(text, c.address, c.byte))
+    {
+        byte = c.byte;
+    }
+    else if (!S9xCheatsGBMode() && S9xProActionReplayToRaw(text, c.address, c.byte))
     {
         byte = c.byte;
     }
@@ -547,6 +748,9 @@ SCheatGroup S9xCreateCheatGroup(const std::string &name, const std::string &chea
     auto cheats = split_string(cheat, '+');
     for (const auto &c : cheats)
     {
+        if (S9xCheatsGBMode() && S9xGBGameGenieToCheats(c, g.cheat))
+            continue;
+
         SCheat new_cheat = S9xTextToCheat(c);
         if (new_cheat.address)
             g.cheat.push_back(new_cheat);

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -1640,6 +1640,7 @@ bool8 CMemory::LoadROM (const char *filename)
 
         // BIOS-less fallback — the legacy path that runs our GB core directly
         // in S9xMainLoop, gated on Settings.SuperGameBoy.
+        S9xDeleteCheats();
         if (Settings.SuperGameBoy) S9xSGBDeinit();
         if (Settings.SGB_BIOSModeActive) Settings.SGB_BIOSModeActive = FALSE;
         Settings.SuperGameBoy      = TRUE;
@@ -1655,6 +1656,7 @@ bool8 CMemory::LoadROM (const char *filename)
         S9xSGBSetAudioRate(Settings.SoundPlaybackRate);
         S9xInitCheatData();
         ROMFilename = filename;
+        S9xLoadCheatFile(S9xGetFilename(".cht", CHEAT_DIR).c_str());
         EmitSGBLoadBanner(filename, 0);
         return TRUE;
     }
@@ -1715,6 +1717,7 @@ bool8 CMemory::LoadROM (const char *filename)
             }
 
             // BIOS-less fallback (legacy path).
+            S9xDeleteCheats();
             if (Settings.SGB_BIOSModeActive) Settings.SGB_BIOSModeActive = FALSE;
             Settings.SuperGameBoy      = TRUE;
             Settings.GameBoyRunMode    = gbCgb ? 0 : 1;
@@ -1729,6 +1732,7 @@ bool8 CMemory::LoadROM (const char *filename)
             S9xSGBSetAudioRate(Settings.SoundPlaybackRate);
             S9xInitCheatData();
             ROMFilename = filename;
+            S9xLoadCheatFile(S9xGetFilename(".cht", CHEAT_DIR).c_str());
             EmitSGBLoadBanner(filename, 0);
             return TRUE;
         }

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -918,10 +918,10 @@ uint8_t Emulator::PeekRAByte(uint32_t addr) const
 	}
 
 	// Extended bank window 0x10000-0x33FFF.
-	//   0x10000-0x15FFF — GBC system RAM banks 2-7. We don't yet emulate
-	//                     CGB extra WRAM banks; return 0.
+	//   0x10000-0x15FFF — GBC system RAM banks 2-7.
 	//   0x16000-0x33FFF — Cartridge SRAM banks 1-15 (each 0x2000 bytes).
-	if (addr < 0x16000) return 0;
+	if (addr < 0x16000)
+		return impl_->mem.wram[0x2000 + (addr - 0x10000)];
 	if (addr < 0x34000)
 	{
 		const uint32_t off = addr - 0x16000;
@@ -933,6 +933,140 @@ uint8_t Emulator::PeekRAByte(uint32_t addr) const
 		return 0;
 	}
 	return 0;
+}
+
+uint8_t Emulator::CheatRead(uint32_t addr) const
+{
+	if (!impl_->has_rom) return 0;
+
+	if (addr & 0x01000000)
+	{
+		const uint32_t ofs = addr & 0x00FFFFFF;
+		return ofs < impl_->cart.rom.size() ? impl_->cart.rom[ofs] : 0;
+	}
+
+	if (addr < 0x10000)
+	{
+		const uint16_t a = static_cast<uint16_t>(addr);
+		if (a < 0x8000)
+			return MbcRead(const_cast<MbcState &>(impl_->cart.mbc),
+			               impl_->cart.rom, impl_->cart.sram, a, impl_->cart.mbc1_multicart);
+		if (a < 0xA000)        // VRAM — not exposed
+			return 0;
+		if (a < 0xC000)        // Cart SRAM bank 0, fixed, ignores RAM-enable
+		{
+			const uint32_t ofs = a - 0xA000;
+			return ofs < impl_->cart.sram.size() ? impl_->cart.sram[ofs] : 0;
+		}
+		if (a < 0xE000)
+			return impl_->mem.wram[a - 0xC000];
+		if (a < 0xFE00)        // Echo RAM
+			return impl_->mem.wram[a - 0xE000];
+		if (a >= 0xFF80 && a < 0xFFFF)
+			return impl_->mem.hram[a - 0xFF80];
+		return 0;
+	}
+
+	if (addr < 0x16000)        // CGB WRAM banks 2-7
+		return impl_->mem.wram[0x2000 + (addr - 0x10000)];
+	if (addr < 0x34000)        // Cart SRAM banks 1-15
+	{
+		const uint32_t ofs = 0x2000 + (addr - 0x16000);
+		return ofs < impl_->cart.sram.size() ? impl_->cart.sram[ofs] : 0;
+	}
+	return 0;
+}
+
+void Emulator::CheatWrite(uint32_t addr, uint8_t value)
+{
+	if (!impl_->has_rom) return;
+
+	if (addr & 0x01000000)
+	{
+		const uint32_t ofs = addr & 0x00FFFFFF;
+		if (ofs < impl_->cart.rom.size())
+			impl_->cart.rom[ofs] = value;
+		return;
+	}
+
+	if (addr < 0x10000)
+	{
+		const uint16_t a = static_cast<uint16_t>(addr);
+		if (a < 0x4000)        // ROM bank 0 patch
+		{
+			if (a < impl_->cart.rom.size())
+				impl_->cart.rom[a] = value;
+			return;
+		}
+		if (a < 0xA000)        // Switchable ROM / VRAM — not writable here
+			return;
+		if (a < 0xC000)        // Cart SRAM bank 0
+		{
+			const uint32_t ofs = a - 0xA000;
+			if (ofs < impl_->cart.sram.size())
+			{
+				impl_->cart.sram[ofs] = value;
+				impl_->cart.sram_dirty = true;
+			}
+			return;
+		}
+		if (a < 0xE000)
+		{
+			impl_->mem.wram[a - 0xC000] = value;
+			return;
+		}
+		if (a < 0xFE00)        // Echo RAM
+		{
+			impl_->mem.wram[a - 0xE000] = value;
+			return;
+		}
+		if (a >= 0xFF80 && a < 0xFFFF)
+			impl_->mem.hram[a - 0xFF80] = value;
+		return;
+	}
+
+	if (addr < 0x16000)
+	{
+		impl_->mem.wram[0x2000 + (addr - 0x10000)] = value;
+		return;
+	}
+	if (addr < 0x34000)
+	{
+		const uint32_t ofs = 0x2000 + (addr - 0x16000);
+		if (ofs < impl_->cart.sram.size())
+		{
+			impl_->cart.sram[ofs] = value;
+			impl_->cart.sram_dirty = true;
+		}
+	}
+}
+
+uint8_t *Emulator::CheatWRAM(uint32_t *size) const
+{
+	if (!impl_->has_rom) { *size = 0; return nullptr; }
+	*size = impl_->cgb_mode ? 0x8000 : 0x2000;
+	return impl_->mem.wram;
+}
+
+uint8_t *Emulator::CheatSRAM(uint32_t *size) const
+{
+	if (!impl_->has_rom || impl_->cart.sram.empty()) { *size = 0; return nullptr; }
+	*size = static_cast<uint32_t>(impl_->cart.sram.size());
+	return impl_->cart.sram.data();
+}
+
+uint8_t *Emulator::CheatHRAM(uint32_t *size) const
+{
+	if (!impl_->has_rom) { *size = 0; return nullptr; }
+	*size = sizeof(impl_->mem.hram);
+	return impl_->mem.hram;
+}
+
+const uint8_t *Emulator::CheatROM(uint32_t *size) const
+{
+	if (!impl_->has_rom || impl_->cart.rom.empty()) { *size = 0; return nullptr; }
+	*size = static_cast<uint32_t>(impl_->cart.rom.size());
+	return impl_->cart.rom.data();
 }
 
 void Emulator::SetRunMode(RunMode m)
@@ -2550,4 +2684,46 @@ bool S9xSGBGetROMBytes(const unsigned char **out_data, size_t *out_size)
 unsigned char S9xSGBPeekRAByte(unsigned int addr)
 {
 	return SGB::Instance().PeekRAByte(addr);
+}
+
+unsigned char S9xSGBCheatRead(unsigned int addr)
+{
+	return SGB::Instance().CheatRead(addr);
+}
+
+void S9xSGBCheatWrite(unsigned int addr, unsigned char value)
+{
+	SGB::Instance().CheatWrite(addr, value);
+}
+
+unsigned char *S9xSGBCheatWRAMPtr(unsigned int *size)
+{
+	uint32_t n = 0;
+	unsigned char *p = SGB::Instance().CheatWRAM(&n);
+	*size = n;
+	return p;
+}
+
+unsigned char *S9xSGBCheatSRAMPtr(unsigned int *size)
+{
+	uint32_t n = 0;
+	unsigned char *p = SGB::Instance().CheatSRAM(&n);
+	*size = n;
+	return p;
+}
+
+unsigned char *S9xSGBCheatHRAMPtr(unsigned int *size)
+{
+	uint32_t n = 0;
+	unsigned char *p = SGB::Instance().CheatHRAM(&n);
+	*size = n;
+	return p;
+}
+
+const unsigned char *S9xSGBCheatROMPtr(unsigned int *size)
+{
+	uint32_t n = 0;
+	const unsigned char *p = SGB::Instance().CheatROM(&n);
+	*size = n;
+	return p;
 }

--- a/sgb/sgb.h
+++ b/sgb/sgb.h
@@ -109,6 +109,21 @@ public:
 	// out-of-range addresses.
 	uint8_t        PeekRAByte(uint32_t addr) const;
 
+	// Cheat-engine memory access. PeekRAByte's address layout, except
+	// 0xA000-0xBFFF is cart SRAM bank 0 fixed (ignores the MBC RAM-enable
+	// gate) and 0x01000000|offset addresses the cart ROM image by
+	// physical byte offset (Game Genie ROM patches). Writes outside
+	// writable regions are dropped.
+	uint8_t        CheatRead(uint32_t addr) const;
+	void           CheatWrite(uint32_t addr, uint8_t value);
+
+	// Live region pointers + byte counts for the cheat-search engine;
+	// nullptr / *size=0 when unavailable.
+	uint8_t       *CheatWRAM(uint32_t *size) const;   // 0x2000 DMG / 0x8000 CGB
+	uint8_t       *CheatSRAM(uint32_t *size) const;
+	uint8_t       *CheatHRAM(uint32_t *size) const;   // 0x7F
+	const uint8_t *CheatROM(uint32_t *size) const;
+
 	// Install the 256-byte DMG/SGB GB-side boot ROM. Takes effect on the
 	// next Reset. Call with nullptr/size=0 to clear. Only loaded in
 	// authentic BIOS mode — BIOS-less continues to start at 0x0100.
@@ -448,6 +463,14 @@ bool          S9xSGBGetROMBytes (const unsigned char **out_data, size_t *out_siz
 // 0x10000-0x33FFF for the extended SRAM/CGB-WRAM bank window). Returns
 // 0 for unmapped or out-of-range addresses.
 unsigned char S9xSGBPeekRAByte (unsigned int addr);
+
+// Cheat-engine GB memory access — see Emulator::CheatRead/CheatWrite.
+unsigned char S9xSGBCheatRead (unsigned int addr);
+void          S9xSGBCheatWrite (unsigned int addr, unsigned char value);
+unsigned char *S9xSGBCheatWRAMPtr (unsigned int *size);
+unsigned char *S9xSGBCheatSRAMPtr (unsigned int *size);
+unsigned char *S9xSGBCheatHRAMPtr (unsigned int *size);
+const unsigned char *S9xSGBCheatROMPtr (unsigned int *size);
 
 bool S9xSGBHasBattery(void);
 bool S9xSGBSaveBatteryToPath(const char *path);

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -4558,15 +4558,27 @@ int WINAPI WinMain(
 					if(watches[i].on)
 					{
 						int address = watches[i].address - 0x7E0000;
-						const uint8* source;
+						if(address < 0 || address >= 0x32000)
+							continue;
+						const uint8* source = NULL;
 						if(address < 0x20000)
-							source = Memory.RAM + address ;
+						{
+							if(Cheat.RAM && address + watches[i].size <= (int)Cheat.ram_size)
+								source = Cheat.RAM + address;
+						}
 						else if(address < 0x30000)
-							source = Memory.SRAM + address  - 0x20000;
+						{
+							if(Cheat.SRAM && (address - 0x20000) + watches[i].size <= (int)Cheat.sram_size)
+								source = Cheat.SRAM + address - 0x20000;
+						}
 						else
-							source = Memory.FillRAM + address  - 0x30000;
+						{
+							if(Cheat.IRAM && (address - 0x30000) + watches[i].size <= (int)Cheat.iram_size)
+								source = Cheat.IRAM + address - 0x30000;
+						}
 
-						CopyMemory(Cheat.CWatchRAM + address, source, watches[i].size);
+						if(source)
+							CopyMemory(Cheat.CWatchRAM + address, source, watches[i].size);
 					}
 				}
 			}
@@ -12683,6 +12695,21 @@ static int cheatSortColumn = -1;
 static bool cheatSortAscending = true;
 static std::set<int> cheatMaskedAddrs;
 
+static void FormatCheatSearchAddress(int addr, TCHAR *buf)
+{
+	if (Cheat.gb_mode)
+	{
+		_stprintf(buf, TEXT("%04X"), S9xCheatFlatToAddress(addr));
+		return;
+	}
+	if (addr < 0x20000)
+		_stprintf(buf, TEXT("%06X"), addr + 0x7E0000);
+	else if (addr < 0x30000)
+		_stprintf(buf, TEXT("s%05X"), addr - 0x20000);
+	else
+		_stprintf(buf, TEXT("i%05X"), addr - 0x30000);
+}
+
 static inline int CheatCount(int byteSub)
 {
 	int a, b=0;
@@ -12695,7 +12722,7 @@ static inline int CheatCount(int byteSub)
 	return b;
 }
 
-static int CheatGetValue(int addr, int byteSz, const uint8 *ram, const uint8 *sram, const uint8 *fillram)
+static int CheatGetValue(int addr, int byteSz, const uint8 *ram, const uint8 *sram, const uint8 *iram)
 {
 	int q = 0;
 	for (int r = 0; r <= byteSz; r++)
@@ -12705,19 +12732,35 @@ static int CheatGetValue(int addr, int byteSz, const uint8 *ram, const uint8 *sr
 		else if (addr < 0x30000)
 			q += sram[(addr - 0x20000) + r] << (8 * r);
 		else
-			q += fillram[(addr - 0x30000) + r] << (8 * r);
+			q += iram[(addr - 0x30000) + r] << (8 * r);
 	}
 	return q;
+}
+
+static bool CheatAddrLive(int addr, int byteSz)
+{
+	if (addr < 0x20000)
+		return Cheat.RAM && addr + byteSz < (int)Cheat.ram_size;
+	if (addr < 0x30000)
+		return Cheat.SRAM && (addr - 0x20000) + byteSz < (int)Cheat.sram_size;
+	return Cheat.IRAM && (addr - 0x30000) + byteSz < (int)Cheat.iram_size;
 }
 
 static void CheatSearchBuildIndex(int byteSub)
 {
 	cheatSearchAddrs.clear();
-	for (int a = 0; a < 0x30000 - byteSub; a++)
+	auto scan = [byteSub](int base, int size)
 	{
-		if (TEST_BIT(Cheat.ALL_BITS, a) && cheatMaskedAddrs.find(a) == cheatMaskedAddrs.end())
-			cheatSearchAddrs.push_back(a);
-	}
+		for (int a = base; a < base + size - byteSub; a++)
+		{
+			if (TEST_BIT(Cheat.ALL_BITS, a) && cheatMaskedAddrs.find(a) == cheatMaskedAddrs.end())
+				cheatSearchAddrs.push_back(a);
+		}
+	};
+	scan(0x00000, (int)Cheat.ram_size);
+	scan(0x20000, (int)Cheat.sram_size);
+	if (Cheat.gb_mode)
+		scan(0x30000, (int)Cheat.iram_size);
 }
 
 static std::vector<int> CheatSearchGetSelectedAddresses(HWND hLV)
@@ -12740,8 +12783,8 @@ static void CheatSearchSortIndex(int column, bool ascending, int byteSz)
 			if (column == 0) {
 				va = a; vb = b;
 			} else if (column == 1) {
-				va = CheatGetValue(a, byteSz, Cheat.RAM, Cheat.SRAM, Cheat.FillRAM);
-				vb = CheatGetValue(b, byteSz, Cheat.RAM, Cheat.SRAM, Cheat.FillRAM);
+				va = CheatAddrLive(a, byteSz) ? CheatGetValue(a, byteSz, Cheat.RAM, Cheat.SRAM, Cheat.IRAM) : 0;
+				vb = CheatAddrLive(b, byteSz) ? CheatGetValue(b, byteSz, Cheat.RAM, Cheat.SRAM, Cheat.IRAM) : 0;
 			} else {
 				va = CheatGetValue(a, byteSz, Cheat.CWRAM, Cheat.CSRAM, Cheat.CIRAM);
 				vb = CheatGetValue(b, byteSz, Cheat.CWRAM, Cheat.CSRAM, Cheat.CIRAM);
@@ -12867,13 +12910,7 @@ INT_PTR CALLBACK DlgCheatMask(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 			if (nmlvdi->item.mask & LVIF_TEXT)
 			{
 				static TCHAR buf[16];
-				int addr = cheatMaskedIndex[idx];
-				if (addr < 0x20000)
-					_stprintf(buf, TEXT("%06X"), addr + 0x7E0000);
-				else if (addr < 0x30000)
-					_stprintf(buf, TEXT("s%05X"), addr - 0x20000);
-				else
-					_stprintf(buf, TEXT("i%05X"), addr - 0x30000);
+				FormatCheatSearchAddress(cheatMaskedIndex[idx], buf);
 				nmlvdi->item.pszText = buf;
 			}
 			return TRUE;
@@ -12891,15 +12928,20 @@ INT_PTR CALLBACK DlgCheatMask(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 			if (ScanAddress(buf, address))
 			{
 				int internal;
-				if (address >= 0x7E0000 && address < 0x7E0000 + 0x20000)
+				if (Cheat.gb_mode)
+					internal = S9xCheatGBToFlat(address);
+				else if (address >= 0x7E0000 && address < 0x7E0000 + 0x20000)
 					internal = address - 0x7E0000;
 				else if (address < 0x10000)
 					internal = address + 0x20000;
 				else
 					internal = address + 0x30000;
-				cheatMaskedAddrs.insert(internal);
-				MaskDlgRefresh(hDlg);
-				SetDlgItemText(hDlg, IDC_MASK_ADDRESS, TEXT(""));
+				if (internal >= 0)
+				{
+					cheatMaskedAddrs.insert(internal);
+					MaskDlgRefresh(hDlg);
+					SetDlgItemText(hDlg, IDC_MASK_ADDRESS, TEXT(""));
+				}
 			}
 			return TRUE;
 		}
@@ -13185,19 +13227,16 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 					i = cheatSearchAddrs[idx];
 					if(j=nmlvdi->item.iSubItem==0)
 					{
-						if(i < 0x20000)
-							_stprintf(buf, TEXT("%06X"), i+0x7E0000);
-						else if(i < 0x30000)
-							_stprintf(buf, TEXT("s%05X"), i-0x20000);
-						else
-							_stprintf(buf, TEXT("i%05X"), i-0x30000);
+						FormatCheatSearchAddress(i, buf);
 						nmlvdi->item.pszText=buf;
 						nmlvdi->item.cchTextMax=8;
 					}
 					if(j=nmlvdi->item.iSubItem==1)
 					{
 						int q=0, r=0;
-						if(i < 0x20000)
+						if(!CheatAddrLive(i, bytes))
+							q = 0;
+						else if(i < 0x20000)
 							for(r=0;r<=bytes;r++)
 								q+=(Cheat.RAM[i+r])<<(8*r);
 						else if(i < 0x30000)
@@ -13205,7 +13244,7 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 								q+=(Cheat.SRAM[(i-0x20000)+r])<<(8*r);
 						else
 							for(r=0;r<=bytes;r++)
-								q+=(Cheat.FillRAM[(i-0x30000)+r])<<(8*r);
+								q+=(Cheat.IRAM[(i-0x30000)+r])<<(8*r);
 						//needs to account for size
 						switch(val_type)
 						{
@@ -13360,6 +13399,12 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 
 					int searchNum = 0;
 					ScanAddress(searchstr, searchNum);
+					if (Cheat.gb_mode)
+					{
+						int32_t flat = S9xCheatGBToFlat(searchNum);
+						if (flat >= 0)
+							searchNum = flat;
+					}
 
 					// search through the sorted index
 					for (int n = 0; n < count; n++)
@@ -13517,9 +13562,9 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 						cht.size = cheatSize;
 						cht.format = val_type;
 
-						cht.address = S9xCheatFlatToSNES(addr);
+						cht.address = S9xCheatFlatToAddress(addr);
 
-						cht.new_val = CheatGetValue(addr, bytes, Cheat.RAM, Cheat.SRAM, Cheat.FillRAM);
+						cht.new_val = CheatAddrLive(addr, bytes) ? CheatGetValue(addr, bytes, Cheat.RAM, Cheat.SRAM, Cheat.IRAM) : 0;
 						cht.saved_val = CheatGetValue(addr, bytes, Cheat.CWRAM, Cheat.CSRAM, Cheat.CIRAM);
 
 						DialogBoxParam(g_hInst, MAKEINTRESOURCE(IDD_CHEAT_FROM_SEARCH), hDlg, DlgCheatSearchAdd, (LPARAM)&cht);
@@ -13529,9 +13574,9 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 						// Multiple selection: batch add all cheats directly
 						for (int addr : addrs)
 						{
-							uint32 address = S9xCheatFlatToSNES(addr);
+							uint32 address = S9xCheatFlatToAddress(addr);
 
-							int curVal = CheatGetValue(addr, bytes, Cheat.RAM, Cheat.SRAM, Cheat.FillRAM);
+							int curVal = CheatAddrLive(addr, bytes) ? CheatGetValue(addr, bytes, Cheat.RAM, Cheat.SRAM, Cheat.IRAM) : 0;
 
 							std::string code_string;
 							char code[10];
@@ -13635,7 +13680,9 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 						watches[i].format = val_type;
 						watches[i].address = address;
 						watches[i].buf[0] = '\0';
-						if(address < 0x7E0000 + 0x20000)
+						if(Cheat.gb_mode)
+							sprintf(watches[i].desc, "%04X", S9xCheatFlatToAddress(addrs[n]));
+						else if(address < 0x7E0000 + 0x20000)
 							sprintf(watches[i].desc, "%6X", address);
 						else if(address < 0x7E0000 + 0x30000)
 							sprintf(watches[i].desc, "s%05X", address - 0x7E0000 - 0x20000);
@@ -13657,12 +13704,7 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 					{
 						int addr = cheatSearchAddrs[sel];
 						TCHAR buf[16];
-						if (addr < 0x20000)
-							_stprintf(buf, TEXT("%06X"), addr + 0x7E0000);
-						else if (addr < 0x30000)
-							_stprintf(buf, TEXT("s%05X"), addr - 0x20000);
-						else
-							_stprintf(buf, TEXT("i%05X"), addr - 0x30000);
+						FormatCheatSearchAddress(addr, buf);
 						if (OpenClipboard(hDlg))
 						{
 							EmptyClipboard();
@@ -13761,7 +13803,9 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 								fscanf(file, " address = 0x%x, name = \"%31[^\"]\", size = %d, format = %d\n", &watches[i].address, nameStr, &watches[i].size, &watches[i].format);
 								if(nameStr[0] == '\0' || nameStr[0] == '?')
 								{
-									if(watches[i].address < 0x7E0000 + 0x20000)
+									if(Cheat.gb_mode)
+										sprintf(nameStr, "%04X", S9xCheatFlatToAddress(watches[i].address - 0x7E0000));
+									else if(watches[i].address < 0x7E0000 + 0x20000)
 										sprintf(nameStr, "%06X", watches[i].address);
 									else if(watches[i].address < 0x7E0000 + 0x30000)
 										sprintf(nameStr, "s%05X", watches[i].address - 0x7E0000 - 0x20000);
@@ -13895,7 +13939,13 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 					if(use_entered==2)
 					{
 						ret = ScanAddress(buf, value);
-						value -= 0x7E0000;
+						if (Cheat.gb_mode)
+						{
+							int32_t flat = S9xCheatGBToFlat(value);
+							value = flat >= 0 ? (uint32)flat : 0xFFFFFFFF;
+						}
+						else
+							value -= 0x7E0000;
 						S9xSearchForAddress (&Cheat, comp_type, bytes, value, FALSE);
 					}
 					else
@@ -13940,9 +13990,12 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 				// if non-modal, update "Prev. Value" column after Search
 				if(cheatSearchHWND)
 				{
-					CopyMemory(Cheat.CWRAM, Cheat.RAM, 0x20000);
-					CopyMemory(Cheat.CSRAM, Cheat.SRAM, 0x10000);
-					CopyMemory(Cheat.CIRAM, Cheat.FillRAM, 0x2000);
+					if (Cheat.RAM && Cheat.ram_size)
+						CopyMemory(Cheat.CWRAM, Cheat.RAM, Cheat.ram_size);
+					if (Cheat.SRAM && Cheat.sram_size)
+						CopyMemory(Cheat.CSRAM, Cheat.SRAM, Cheat.sram_size);
+					if (Cheat.IRAM && Cheat.iram_size)
+						CopyMemory(Cheat.CIRAM, Cheat.IRAM, Cheat.iram_size);
 				}
 
 
@@ -13950,9 +14003,12 @@ INT_PTR CALLBACK DlgCheatSearch(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 				return true;
 				break;
 			case IDOK:
-				CopyMemory(Cheat.CWRAM, Cheat.RAM, 0x20000);
-				CopyMemory(Cheat.CSRAM, Cheat.SRAM, 0x10000);
-				CopyMemory(Cheat.CIRAM, Cheat.FillRAM, 0x2000);
+				if (Cheat.RAM && Cheat.ram_size)
+					CopyMemory(Cheat.CWRAM, Cheat.RAM, Cheat.ram_size);
+				if (Cheat.SRAM && Cheat.sram_size)
+					CopyMemory(Cheat.CSRAM, Cheat.SRAM, Cheat.sram_size);
+				if (Cheat.IRAM && Cheat.iram_size)
+					CopyMemory(Cheat.CIRAM, Cheat.IRAM, Cheat.iram_size);
 				/* fall through */
 			case IDCANCEL:
                 if(cheatSearchHWND)
@@ -13984,7 +14040,10 @@ INT_PTR CALLBACK DlgCheatSearchAdd(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lP
 		{
 			TCHAR buf [12];
 			new_cheat=(struct ICheat*)lParam;
-			_stprintf(buf, TEXT("%06X"), new_cheat->address);
+			if (Cheat.gb_mode)
+				_stprintf(buf, TEXT("%04X"), new_cheat->address);
+			else
+				_stprintf(buf, TEXT("%06X"), new_cheat->address);
 			SetDlgItemText(hDlg, IDC_NC_ADDRESS, buf);
 			switch(new_cheat->format)
 			{


### PR DESCRIPTION
## Summary

The cheat engine (cheat search + Game Genie/Pro-Action Replay editor) previously only operated on the SNES bus, so it was useless while a BIOS-less GB/GBC/SGB game was running. This PR makes the engine system-aware: it detects which machine is live and automatically targets the GB bus, addresses, and code formats. SNES behavior is unchanged.

## GB cheat address space

Stored cheat addresses use a fixed-bank layout so cheats keep working no matter what the game has banked in:

| Range | Region |
|---|---|
| `0000-7FFF` | cart ROM (bank 0 patchable; `4000+` read-only via current mapping) |
| `A000-BFFF` | cart SRAM bank 0 (ignores MBC RAM-enable) |
| `C000-DFFF` | WRAM banks 0-1 |
| `FF80-FFFE` | HRAM |
| `10000-15FFF` | CGB WRAM banks 2-7 |
| `16000-23FFF` | cart SRAM banks 1-15 |
| `0x01000000\|ofs` | physical cart-ROM offset (Game Genie patches) |

## Changes

- **SGB core** (`sgb/sgb.{h,cpp}`): new side-effect-free `S9xSGBCheatRead/Write` facade + live region pointer/size accessors (WRAM/SRAM/HRAM/ROM). Also fixes `PeekRAByte`'s stale CGB extended-WRAM window (returned 0 from pre-CGB days) — RetroAchievements now sees banks 2-7.
- **Cheat core** (`cheats.{h,cpp}`, `cheats2.cpp`): `SCheatData` gains an `IRAM` pointer, per-region sizes, and `gb_mode`; the search engine is region-size driven (DMG 8K WRAM / CGB 32K / cart SRAM / HRAM). `S9xGetByteFree`/`S9xSetByteFree` route through the GB facade in GB mode. New parsers: GB GameShark (`01`/`8x`/`9x` types) and GB Game Genie (6/9-digit; banked addresses expand to each 16K bank whose byte matches the compare). SNES GG/PAR parsing is mode-gated since GB GameShark and SNES PAR share the 8-hex-digit shape.
- **ROM load** (`memmap.cpp`): BIOS-less GB loads now delete the previous game's cheats (before SGB teardown, so disable-restores hit the old machine) and load the per-game `.cht` file, matching the SNES paths.
- **Win32 UI** (`win32/wsnes9x.cpp`): search list, add-cheat dialog, mask dialog, watches, copy-address, and jump-to-address all display/parse native GB addresses in GB mode; HRAM is searchable (the SNES IRAM slot stays hidden as before); snapshot copies and value reads are bounds-guarded against null/short regions (e.g. SRAM-less carts) so a ROM swap under an open dialog can't crash.

## Cheats are applied

once per frame through the existing `S9xUpdateCheatsInMemory` hook, which the BIOS-less GB frame loop already reaches via `S9xEndScreenRefresh`.

## Verification

- `cheats.cpp`, `cheats2.cpp`, `memmap.cpp`, `sgb/sgb.cpp` pass `g++ -fsyntax-only`.
- Flat↔GB address mapping round-trips for every offset of all three regions; GameShark/Game Genie decode verified against known published codes (formula bit-identical to VBA-M's decoder).
- Game Genie compare-byte bank scan validated against a real cart: `FAE-67B-4C1` (RoboCop vs. The Terminator (USA), infinite energy) correctly resolves to ROM bank 2 at bus `$4E67` (compare `$EA`).

## Known limits

- BIOS-mode SGB sessions keep SNES-bus cheats (GB side not reachable there yet).
- 16/32-bit cheats added exactly at a bank-window seam write their upper bytes to the wrong region.
- A 9-digit Game Genie code whose compare byte matches no bank is rejected at entry (real hardware would accept it and stay dormant).