### PR TITLE
feat(sgb): render BIOS-less GB/GBC/SGB borderless at native 160x144

### DIFF
--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -37,9 +37,9 @@ void S9xMainLoop (void)
 		}
 
 		IPPU.RenderThisFrame      = !Settings.InRunAhead;
-		PPU.ScreenHeight          = SNES_HEIGHT;
-		IPPU.RenderedScreenWidth  = SNES_WIDTH;
-		IPPU.RenderedScreenHeight = SNES_HEIGHT;
+		PPU.ScreenHeight          = SGB_GB_SCREEN_H;
+		IPPU.RenderedScreenWidth  = SGB_GB_SCREEN_W;
+		IPPU.RenderedScreenHeight = SGB_GB_SCREEN_H;
 
 		// Pipe the SNES controller 0 bitmask into the GB joypad. P6d's
 		// MLT_REQ handling reads from mlt_current_player; for now we
@@ -67,7 +67,9 @@ void S9xMainLoop (void)
 		S9xSGBRunFrame();
 		if (!Settings.InRunAhead)
 		{
-			S9xSGBBlitScreen(GFX.Screen, GFX.RealPPL);
+			IPPU.RenderedScreenWidth  = SGB_GB_SCREEN_W;
+			IPPU.RenderedScreenHeight = SGB_GB_SCREEN_H;
+			S9xSGBBlitScreenGB(GFX.Screen, GFX.RealPPL);
 			S9xEndScreenRefresh();
 		}
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -234,10 +234,8 @@ void S9xStartScreenRefresh (void)
 //     realigns to opposite phase.
 // BIOS-less mode is frame-locked 1:1 by RunFrame, so every frame is a clean
 // distinct step here.
-// GB picture placement inside the 256x224 SGB composite: standard SGB centers
-// the 160x144 GB screen at tile (6,5) = pixel (48,40). Same in BIOS / BIOS-less.
-#define GB_BLEND_X 48
-#define GB_BLEND_Y 40
+// GB picture placement: centered in the frame — (48,40) inside the 256x224
+// SGB composite (BIOS mode), (0,0) in the borderless 160x144 frame.
 #define GB_BLEND_W 160
 #define GB_BLEND_H 144
 
@@ -286,8 +284,9 @@ static void S9xBlendGameBoyFrames (void)
 	//     other frame), so "sprites" blends when OBJ appears in EITHER frame.
 	const uint8  layerSel = Settings.GBFrameBlendLayer;
 	const uint8 *curLayer = (layerSel != GB_BLEND_LAYER_ALL) ? S9xSGBGetGBLayerMask() : NULL;
-	const bool   useLayer = curLayer && w >= GB_BLEND_X + GB_BLEND_W
-	                                 && h >= GB_BLEND_Y + GB_BLEND_H;
+	const bool   useLayer = curLayer && w >= GB_BLEND_W && h >= GB_BLEND_H;
+	const uint32 gbX = useLayer ? (w - GB_BLEND_W) / 2 : 0;
+	const uint32 gbY = useLayer ? (h - GB_BLEND_H) / 2 : 0;
 
 	// In BIOS mode the GB is held in reset during the boot/reset splash (control
 	// bit 7 clear) and produces no frames while the BIOS animates its own logo.
@@ -416,9 +415,9 @@ static void S9xBlendGameBoyFrames (void)
 
 		// Per-row layer pointers (only the GB picture rows carry a layer map;
 		// the surrounding border is treated as background).
-		const bool   yIn = useLayer && y >= GB_BLEND_Y && y < GB_BLEND_Y + GB_BLEND_H;
-		const uint8 *clr = yIn ? curLayer  + (y - GB_BLEND_Y) * GB_BLEND_W : NULL;
-		const uint8 *plr = yIn ? prevLayer + (y - GB_BLEND_Y) * GB_BLEND_W : NULL;
+		const bool   yIn = useLayer && y >= gbY && y < gbY + GB_BLEND_H;
+		const uint8 *clr = yIn ? curLayer  + (y - gbY) * GB_BLEND_W : NULL;
+		const uint8 *plr = yIn ? prevLayer + (y - gbY) * GB_BLEND_W : NULL;
 
 		for (uint32 x = 0; x < w; x++)
 		{
@@ -429,9 +428,9 @@ static void S9xBlendGameBoyFrames (void)
 			if (useLayer)
 			{
 				uint8 cl = 0, pl = 0;   // border defaults to background (0)
-				if (yIn && x >= GB_BLEND_X && x < GB_BLEND_X + GB_BLEND_W)
+				if (yIn && x >= gbX && x < gbX + GB_BLEND_W)
 				{
-					const uint32 gi = x - GB_BLEND_X;
+					const uint32 gi = x - gbX;
 					cl = clr[gi];
 					pl = plr[gi];
 				}

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -1792,6 +1792,47 @@ void Emulator::BlitScreen(uint16_t *dest, uint32_t pitch_pixels)
 
 }
 
+void Emulator::BlitScreenGB(uint16_t *dest, uint32_t pitch_pixels)
+{
+	if (!impl_->has_rom || !dest) return;
+
+	const uint8_t *src_fb = impl_->ppu.framebuffer;
+	if (impl_->sgb_state.mask_mode == SGB_MASK_FREEZE &&
+	    impl_->sgb_state.frozen_frame_valid)
+	{
+		src_fb = impl_->sgb_state.frozen_frame;
+	}
+
+	for (uint32_t py = 0; py < GB_SCREEN_HEIGHT; ++py)
+	{
+		uint16_t *const dst_row = dest + py * pitch_pixels;
+		for (uint32_t px = 0; px < GB_SCREEN_WIDTH; ++px)
+		{
+			uint16_t color;
+			if (impl_->ppu.cgb)
+			{
+				color = impl_->ppu.color_fb[py * GB_SCREEN_WIDTH + px];
+			}
+			else switch (impl_->sgb_state.mask_mode)
+			{
+				case SGB_MASK_BLACK:
+					color = 0x0000;
+					break;
+				case SGB_MASK_BLANK:
+					color = impl_->sgb_state.active[0].colors[0];
+					break;
+				default:
+				{
+					const uint8_t shade = src_fb[py * GB_SCREEN_WIDTH + px];
+					color = SgbResolveColor(impl_->sgb_state, px / 8, py / 8, shade);
+					break;
+				}
+			}
+			dst_row[px] = BgrToHost(color);
+		}
+	}
+}
+
 static constexpr uint16_t BORDER_FADE_FRAMES = 24;
 
 void Emulator::OverlayBiosBorder(uint16_t *dest, uint32_t pitch_pixels)
@@ -2479,6 +2520,11 @@ void S9xSGBOnJoyserWrite(uint8_t v) { SGB::Instance().OnJoyserWrite(v); }
 void S9xSGBBlitScreen(uint16_t *dest, uint32_t pitch_pixels)
 {
 	SGB::Instance().BlitScreen(dest, pitch_pixels);
+}
+
+void S9xSGBBlitScreenGB(uint16_t *dest, uint32_t pitch_pixels)
+{
+	SGB::Instance().BlitScreenGB(dest, pitch_pixels);
 }
 
 void S9xSGBOverlayBiosBorder(uint16_t *dest, uint32_t pitch_pixels)

--- a/sgb/sgb.h
+++ b/sgb/sgb.h
@@ -191,6 +191,7 @@ public:
 	// buffer. `pitch_pixels` is the stride in uint16_t units (use 256
 	// for a tightly-packed buffer, or the SNES GFX.Screen's PPL).
 	void  BlitScreen(uint16_t *dest, uint32_t pitch_pixels);
+	void  BlitScreenGB(uint16_t *dest, uint32_t pitch_pixels);
 
 	// BIOS-mode overlay path — see S9xSGBOverlayBiosBorder for the
 	// full description. Renders the captured custom border on top of
@@ -363,6 +364,9 @@ bool S9xSGBIsActive(void);
 // 256 × 224 BGR555 buffer. `pitch_pixels` is the stride in uint16_t
 // units. Call after S9xSGBRunFrame.
 void S9xSGBBlitScreen(uint16_t *dest, uint32_t pitch_pixels);
+void S9xSGBBlitScreenGB(uint16_t *dest, uint32_t pitch_pixels);
+constexpr uint32_t SGB_GB_SCREEN_W = 160;
+constexpr uint32_t SGB_GB_SCREEN_H = 144;
 
 // BIOS-mode border overlay. In BIOS mode the SNES 65816 runs the SGB2
 // BIOS, which renders its OWN device-frame border into GFX.Screen via

--- a/win32/render.cpp
+++ b/win32/render.cpp
@@ -330,6 +330,14 @@ inline void SetRect(RECT* rect, unsigned int width, unsigned int height, int sca
 	rect->bottom = height * scale;
 }
 
+inline void SetRectForSource(RECT* rect, const SSurface &Src, unsigned int width, unsigned int height, int scale)
+{
+	if (Src.Width < SNES_WIDTH)
+		SetRect(rect, Src.Width, Src.Height, scale);
+	else
+		SetRect(rect, width, height, scale);
+}
+
 RECT GetFilterOutputSize(SSurface Src)
 {
 	RECT rect;
@@ -338,7 +346,7 @@ RECT GetFilterOutputSize(SSurface Src)
 		filterID = GUI.ScaleHiRes;
 	}
 	// default to fixed factor
-	SetRect(&rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, GetFilterScale(filterID));
+	SetRectForSource(&rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, GetFilterScale(filterID));
 
 	// handle special cases
 	switch (filterID)
@@ -350,8 +358,8 @@ RECT GetFilterOutputSize(SSurface Src)
 	case FILTER_BLARGGCOMP:
 	case FILTER_BLARGGSVID:
 	case FILTER_BLARGGRGB:
-		SetRect(&rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 2);
-		rect.right = SNES_NTSC_OUT_WIDTH(256);
+		SetRectForSource(&rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 2);
+		rect.right = SNES_NTSC_OUT_WIDTH(Src.Width < SNES_WIDTH ? Src.Width : 256);
 		break;
 	default:
 		break;
@@ -640,7 +648,7 @@ void RenderForced1X( SSurface Src, SSurface Dst, RECT *rect)
     uint16 *lpSrc;
     unsigned int H;
 
-	SetRect(rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 1);
+	SetRectForSource(rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 1);
 	const uint32 srcHeight = (rect->bottom - rect->top);
 
 	const unsigned int srcPitch = Src.Pitch >> 1;
@@ -693,7 +701,7 @@ void RenderFakeTV( SSurface Src, SSurface Dst, RECT *rect)
     uint16 *lpSrc;
     unsigned int H;
 
-	SetRect(rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 2);
+	SetRectForSource(rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 2);
 	const uint32 srcHeight = (rect->bottom - rect->top)/2;
 
 	const unsigned int srcPitch = Src.Pitch >> 1;
@@ -707,20 +715,20 @@ void RenderFakeTV( SSurface Src, SSurface Dst, RECT *rect)
 			if(Src.Width != 512)
 				for (H = 0; H < srcHeight; H++, lpSrc += srcPitch)
 					DoubleLine16 (lpDst, lpSrc, Src.Width), lpDst += dstPitch,
-					memset (lpDst, 0, 512*2), lpDst += dstPitch;
+					memset (lpDst, 0, rect->right*2), lpDst += dstPitch;
 			else
 				for (H = 0; H < srcHeight; H++, lpSrc += srcPitch)
 					memcpy (lpDst, lpSrc, Src.Width << 1), lpDst += dstPitch,
-					memset (lpDst, 0, 512*2), lpDst += dstPitch;
+					memset (lpDst, 0, rect->right*2), lpDst += dstPitch;
 		else
 			if(Src.Width != 512)
 				for (H = 0; H < Src.Height >> 1; H++, lpSrc += srcPitch << 1)
 					DoubleLine16 (lpDst, lpSrc, Src.Width), lpDst += dstPitch,
-					memset (lpDst, 0, 512*2), lpDst += dstPitch;
+					memset (lpDst, 0, rect->right*2), lpDst += dstPitch;
 			else
 				for (H = 0; H < Src.Height >> 1; H++, lpSrc += srcPitch << 1)
 					memcpy (lpDst, lpSrc, Src.Width << 1), lpDst += dstPitch,
-					memset (lpDst, 0, 512*2), lpDst += dstPitch;
+					memset (lpDst, 0, rect->right*2), lpDst += dstPitch;
 	}
 	else if(GUI.ScreenDepth == 32)
 	{
@@ -730,20 +738,20 @@ void RenderFakeTV( SSurface Src, SSurface Dst, RECT *rect)
 			if(Src.Width != 512)
 				for (H = 0; H < srcHeight; H++, lpSrc += srcPitch)
 					DoubleLine32 (lpDst, lpSrc, Src.Width), lpDst += dstPitch,
-					memset (lpDst, 0, 512*4), lpDst += dstPitch;
+					memset (lpDst, 0, rect->right*4), lpDst += dstPitch;
 			else
 				for (H = 0; H < srcHeight; H++, lpSrc += srcPitch)
 					SingleLine32 (lpDst, lpSrc, Src.Width), lpDst += dstPitch,
-					memset (lpDst, 0, 512*4), lpDst += dstPitch;
+					memset (lpDst, 0, rect->right*4), lpDst += dstPitch;
 		else
 			if(Src.Width != 512)
 				for (H = 0; H < Src.Height >> 1; H++, lpSrc += srcPitch << 1)
 					DoubleLine32 (lpDst, lpSrc, Src.Width), lpDst += dstPitch,
-					memset (lpDst, 0, 512*4), lpDst += dstPitch;
+					memset (lpDst, 0, rect->right*4), lpDst += dstPitch;
 			else
 				for (H = 0; H < Src.Height >> 1; H++, lpSrc += srcPitch << 1)
 					SingleLine32 (lpDst, lpSrc, Src.Width), lpDst += dstPitch,
-					memset (lpDst, 0, 512*4), lpDst += dstPitch;
+					memset (lpDst, 0, rect->right*4), lpDst += dstPitch;
 	}
 }
 
@@ -756,7 +764,7 @@ void RenderSimple2X( SSurface Src, SSurface Dst, RECT *rect)
     uint16 *lpSrc;
     unsigned int H;
 
-	SetRect(rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 2);
+	SetRectForSource(rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 2);
 	const uint32 srcHeight = (rect->bottom - rect->top)/2;
 
 	const unsigned int srcPitch = Src.Pitch >> 1;
@@ -886,7 +894,7 @@ void RenderTVMode ( SSurface Src, SSurface Dst, RECT *rect)
     int height = Src.Height;
     uint8 *deltaPtr = ChangeLog [GUI.FlipCounter % GUI.NumFlipFrames];
 
-	SetRect(rect, 256, height, 2);
+	SetRect(rect, width, height, 2);
 
     dstPtr += rect->top * Dst.Pitch + rect->left * 2;
     nextLine = dstPtr + dstPitch;
@@ -1035,7 +1043,7 @@ void RenderSimple3X( SSurface Src, SSurface Dst, RECT *rect)
     uint16 *lpSrc;
     unsigned int H;
 
-	SetRect(rect, 256, 239, 3);
+	SetRectForSource(rect, Src, 256, 239, 3);
 	const uint32 srcHeight = (rect->bottom - rect->top)/3;
 
 	const unsigned int srcPitch = Src.Pitch >> 1;
@@ -1199,7 +1207,7 @@ struct uint96
 #define DrawInit(scale,uintDest)                                                            \
 	uint8 *srcPtr = Src.Surface, *dstPtr = Dst.Surface;                                     \
 	const uint32 srcPitch = Src.Pitch, dstPitch = Dst.Pitch;                                \
-	SetRect(rect, 256, Src.Height, scale);                                                  \
+	SetRectForSource(rect, Src, 256, Src.Height, scale);                                    \
 	dstPtr += rect->top * Dst.Pitch + rect->left * 2;                                       \
 	const uint32 srcHeight = (rect->bottom - rect->top)/scale;                              \
 	const uint32 srcWidth = (rect->right - rect->left)/scale;                               \
@@ -1842,7 +1850,7 @@ void RenderHQ2X (SSurface Src, SSurface Dst, RECT *rect)
     int width = Src.Width;
     int height = Src.Height;
 
-	SetRect(rect, 256, height, 2);
+	SetRect(rect, width, height, 2);
 
     dstPtr += rect->top * Dst.Pitch + rect->left * 2;
 
@@ -2220,7 +2228,7 @@ void RenderHQ3X (SSurface Src, SSurface Dst, RECT *rect)
     int width = Src.Width;
     int height = Src.Height;
 
-	SetRect(rect, 256, height, 3);
+	SetRect(rect, width, height, 3);
 
     dstPtr += rect->top * Dst.Pitch + rect->left * 2;
 
@@ -2376,7 +2384,7 @@ void RenderLQ3XB (SSurface Src, SSurface Dst, RECT *rect)
     int width = Src.Width;
     int height = Src.Height;
 
-	SetRect(rect, 256, height, 3);
+	SetRect(rect, width, height, 3);
 
     dstPtr += rect->top * Dst.Pitch + rect->left * 2;
 	int	w1, w2, w3, w4, w5, w6, w7, w8, w9;
@@ -2486,7 +2494,7 @@ void RenderHQ4X (SSurface Src, SSurface Dst, RECT *rect)
 {
     uint8 *dstPtr = Dst.Surface;
 
-	SetRect(rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 4);
+	SetRectForSource(rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 4);
     dstPtr += rect->top * Dst.Pitch + rect->left * 2;
 
 	if (Src.Height > SNES_HEIGHT_EXTENDED || Src.Width == 512)
@@ -2507,7 +2515,7 @@ void RenderSimple4X( SSurface Src, SSurface Dst, RECT *rect)
     uint16 *lpSrc;
     unsigned int H;
 
-	SetRect(rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 4);
+	SetRectForSource(rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 4);
 	const uint32 srcHeight = (rect->bottom - rect->top)/4;
 
 	const unsigned int srcPitch = Src.Pitch >> 1;
@@ -2637,6 +2645,11 @@ DWORD WINAPI ThreadProc_XBRZ(VOID * pParam)
         if (xbrz_thread_data::src->Height % SNES_HEIGHT == 0)
             trgHeight = SNES_HEIGHT * xbrz_thread_data::scalingFactor;
 		trgWidth = SNES_WIDTH * xbrz_thread_data::scalingFactor;
+		if (xbrz_thread_data::src->Width < SNES_WIDTH)
+		{
+			trgWidth  = xbrz_thread_data::src->Width  * xbrz_thread_data::scalingFactor;
+			trgHeight = xbrz_thread_data::src->Height * xbrz_thread_data::scalingFactor;
+		}
         stretchImage32To16(&xbrzBuffer[0], xbrz_thread_data::src->Width * xbrz_thread_data::scalingFactor, xbrz_thread_data::src->Height * xbrz_thread_data::scalingFactor,
                            reinterpret_cast<uint16_t*>(xbrz_thread_data::dstPtr), trgWidth, trgHeight, xbrz_thread_data::dst->Pitch, thread_data->yFirst * xbrz_thread_data::scalingFactor, thread_data->yLast * xbrz_thread_data::scalingFactor);
         SetEvent(thread_data->xbrz_sync_event);
@@ -2674,7 +2687,7 @@ void RenderxBRZ(SSurface Src, SSurface Dst, RECT* rect, int scalingFactor)
     xbrz_thread_data::scalingFactor = scalingFactor;
     
 	xbrz_thread_data::dstPtr = Dst.Surface;
-    SetRect(rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, xbrz_thread_data::scalingFactor);
+    SetRectForSource(rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, xbrz_thread_data::scalingFactor);
     xbrz_thread_data::dstPtr += rect->top * Dst.Pitch + rect->left * sizeof(uint16_t);
 
     if (Src.Width  <= 0 || Src.Height <= 0)
@@ -2760,8 +2773,8 @@ void RenderBlarggNTSC(SSurface Src, SSurface Dst, RECT *rect)
 {
     static int burst_phase = 0;
 
-    SetRect(rect, 256, 239, 2);
-    rect->right = SNES_NTSC_OUT_WIDTH(256);
+    SetRectForSource(rect, Src, 256, 239, 2);
+    rect->right = SNES_NTSC_OUT_WIDTH(Src.Width < SNES_WIDTH ? Src.Width : 256);
 
     const unsigned int srcRowPixels = Src.Pitch / 2;
 
@@ -2784,6 +2797,6 @@ void RenderBlarggNTSC(SSurface Src, SSurface Dst, RECT *rect)
 
 void RenderSharpBilinear(SSurface Src, SSurface Dst, RECT *rect)
 {
-    SetRect(rect, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 4);
+    SetRectForSource(rect, Src, SNES_WIDTH, SNES_HEIGHT_EXTENDED, 4);
     sharpbilinear_4x(Src.Surface, Src.Pitch, Dst.Surface, Dst.Pitch, Src.Width, Src.Height);
 }

--- a/win32/win32.cpp
+++ b/win32/win32.cpp
@@ -15,6 +15,7 @@
 #include "../gfx.h"
 #include "../movie.h"
 #include "../netplay.h"
+#include "../sgb/sgb.h"
 
 #include "wsnes9x.h"
 #include "kaillera.h"
@@ -1092,6 +1093,11 @@ void DoAVIOpen(const TCHAR* filename)
 
 	avi_width = SNES_WIDTH;
 	avi_height = Settings.ShowOverscan ? SNES_HEIGHT_EXTENDED : SNES_HEIGHT;
+	if (Settings.SuperGameBoy)
+	{
+		avi_width = SGB_GB_SCREEN_W;
+		avi_height = SGB_GB_SCREEN_H;
+	}
 	avi_skip_frames = Settings.SkipFrames;
 
 	if(GUI.AVIHiRes) {


### PR DESCRIPTION
## Summary

In BIOS-less mode (`Settings.SuperGameBoy`) the GB picture was composited into the 256x224 SGB frame with the gray border around it. The border is an SGB BIOS feature, so BIOS-less mode now presents just the native 160x144 game picture and lets the host scale it to fill the window — exactly like SNES output. SGB/SGB2 BIOS mode is unchanged and keeps full border rendering (including game-uploaded CHR_TRN/PCT_TRN borders).

## Changes

- **sgb/sgb.cpp, sgb/sgb.h** — new `S9xSGBBlitScreenGB` writes only the 160x144 GB picture at (0,0) in host pixel format. SGB palette resolution, mask modes (BLACK/BLANK/FREEZE), and GBC color output all preserved. The existing 256x224 composite blit is untouched so the sgb test harness and its frame signatures are unaffected.
- **cpuexec.cpp** — the BIOS-less main loop reports a 160x144 frame and calls the new blit. Dimensions are re-asserted after `S9xStartScreenRefresh()` because `S9xGraphicsScreenResize` re-derives width 256 from the BG mode.
- **gfx.cpp** — the GB frame-blend derives the picture origin from the frame size (`(w-160)/2, (h-144)/2`), so layer-selective blending works with both the bordered BIOS frame (48,40) and the borderless frame (0,0).
- **win32/render.cpp** — most filters declared hardcoded 256x239-based output rects, which would have displayed a 160x144 source squashed into the top-left of a 256-wide canvas (borders again). All filters now route through `SetRectForSource`: sources narrower than 256 use their own dimensions; SNES sources keep the historical height-extend canvas bit-exact. Additional fixes this surfaced:
  - **Fake TV** cleared scanline rows with fixed 512-pixel memsets — a real buffer overrun on a 320-wide GB texture (OpenGL PBO). Now clears the rect width.
  - **xBRZ** force-stretched output to 256x239·scale; sub-SNES sources keep their native scaled size.
  - **Blargg NTSC** output width now derives from `SNES_NTSC_OUT_WIDTH(Src.Width)`.
  - **EPX/TV3X/DotMatrix** derive loop bounds from the rect, so the fix also stops them reading 96 stale columns past the GB image.
  - **`GetFilterOutputSize`** (texture sizing for OpenGL/Vulkan) kept consistent with the per-filter rects.
- **win32/win32.cpp** — AVI recording uses the GB frame size (160x144, or 320x288 hi-res) in BIOS-less mode instead of reading garbage out to 256x224.