### PR TITLE
Game Boy frame-blend: Qt + GTK parity with win32

### DIFF
--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -134,6 +134,12 @@ int Snes9xConfig::load_defaults()
     ntsc_scanline_intensity = 1;
     scanline_filter_intensity = 0;
     Settings.BilinearFilter = false;
+    // Game Boy frame blending (Super Game Boy only) — single stored value in Settings,
+    // same as the win32 frontend. 0=off, 1=Simple Blend, 2=LCD Blend; layer 0=all,
+    // 1=bg, 2=window, 3=sprites; Auto picks both per-game from a built-in table.
+    Settings.GBFrameBlend = 0;
+    Settings.GBFrameBlendLayer = 0;
+    Settings.GBFrameBlendAuto = true;
     netplay_activated = false;
     netplay_server_up = false;
     netplay_is_server = false;
@@ -246,6 +252,10 @@ int Snes9xConfig::save_config_file()
     outbool("AutoVRR", auto_vrr, "Automatically use the best settings for variable sync in fullscreen mode");
     outint("OSDSize", osd_size, "Size of on-screen display elements. Default: 24pt");
     outint("MessageDisplayTime", Settings.InitialInfoStringTimeout, "Display timeout length of messages, in frames. Set to 0 to disable all message text. Default: 120.");
+    // Key names match the win32 config (wconfig.cpp) so a shared install reads/writes the same entries.
+    outint("BlendGBFrames", Settings.GBFrameBlend, "Game Boy frame-blend mode (Super Game Boy only): 0=off, 1=Simple Blend (mix each frame 50/50 with the previous, fixes flicker-based fake transparency e.g. ZAS), 2=LCD Blend (slow-decay LCD-style ghosting)");
+    outint("BlendGBFramesLayer", Settings.GBFrameBlendLayer, "Which Game Boy layer the frame-blend applies to: 0=all, 1=background (keeps moving sprites crisp), 2=window, 3=sprites");
+    outbool("BlendGBFramesAuto", Settings.GBFrameBlendAuto, "Auto-pick the GB frame-blend per game from a built-in known-flicker-game table at load (off for unlisted games); when false the manual mode/layer apply to every GB game");
     
     
     section = "NTSC";
@@ -479,6 +489,9 @@ int Snes9xConfig::load_config_file()
     inbool("AutoVRR", auto_vrr);
     inint("OSDSize", osd_size);
     inint("MessageDisplayTime", Settings.InitialInfoStringTimeout);
+    inint("BlendGBFrames", Settings.GBFrameBlend);
+    inint("BlendGBFramesLayer", Settings.GBFrameBlendLayer);
+    inbool("BlendGBFramesAuto", Settings.GBFrameBlendAuto);
 
     section = "NTSC";
     indouble("Hue", ntsc_setup.hue);
@@ -674,6 +687,8 @@ int Snes9xConfig::load_config_file()
         Settings.SoundSync = false;
 
     hires_effect = CLAMP(hires_effect, 0, 2);
+    Settings.GBFrameBlend = CLAMP(Settings.GBFrameBlend, 0, 2);
+    Settings.GBFrameBlendLayer = CLAMP(Settings.GBFrameBlendLayer, 0, 3);
     Settings.DynamicRateLimit = CLAMP(Settings.DynamicRateLimit, 1, 1000);
     Settings.SuperFXClockMultiplier = CLAMP(Settings.SuperFXClockMultiplier, 50, 400);
     ntsc_scanline_intensity = MIN(ntsc_scanline_intensity, 4);

--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -14,6 +14,7 @@
 #include "fmt/format.h"
 #include "snes9x.h"
 #include "gfx.h"
+#include "sgb/sgb.h"
 
 #define SAME_AS_GAME gettext("Same location as current game")
 
@@ -164,6 +165,13 @@ void Snes9xPreferences::connect_signals()
     });
     get_object<Gtk::CheckButton>("multithreading")->signal_toggled().connect([&] {
         enable_widget("num_threads", get_check("multithreading"));
+    });
+    // Game Boy Image: re-grey the dropdowns when Auto is toggled or the mode changes.
+    get_object<Gtk::CheckButton>("gb_frame_blend_auto")->signal_toggled().connect([&] {
+        update_gb_blend_enable_state();
+    });
+    get_object<Gtk::ComboBox>("gb_frame_blend")->signal_changed().connect([&] {
+        update_gb_blend_enable_state();
     });
     // Handle plurals on GtkLabel “threads_for_filtering_and_scaling_label”
     get_object<Gtk::SpinButton>("num_threads")->signal_value_changed().connect([&] {
@@ -339,6 +347,24 @@ void Snes9xPreferences::update_sgb_volume_enable_state()
         set_slider("sgb_mix_volume_gb", config->master_volume_regular);
         suppress_volume_sync = false;
     }
+}
+
+void Snes9xPreferences::update_gb_blend_enable_state()
+{
+    // The Game Boy Image options only apply to an SGB game; grey them out for SNES
+    // titles (or when nothing is loaded). With "Auto Layer Transparency" on, the two
+    // dropdowns are list-driven so they are greyed too; the layer dropdown also needs
+    // blending to be on (mode != Off). Mirrors the win32 and Qt frontends.
+    bool gb_active = Settings.SuperGameBoy || Settings.SGB_BIOSModeActive;
+    bool manual = gb_active && !get_check("gb_frame_blend_auto");
+    bool layer = manual && get_combo("gb_frame_blend") != 0;
+
+    enable_widget("gb_image_frame",             gb_active);
+    enable_widget("gb_frame_blend_auto",        gb_active);
+    enable_widget("gb_frame_blend",             manual);
+    enable_widget("gb_frame_blend_label",       manual);
+    enable_widget("gb_frame_blend_layer",       layer);
+    enable_widget("gb_frame_blend_layer_label", layer);
 }
 
 void Snes9xPreferences::about_dialog()
@@ -517,6 +543,9 @@ void Snes9xPreferences::move_settings_to_dialog()
     set_check("change_display_resolution", config->change_display_resolution);
     set_check("scale_to_fit",              config->scale_to_fit);
     set_check("overscan",                  config->overscan);
+    set_combo("gb_frame_blend",            Settings.GBFrameBlend);
+    set_combo("gb_frame_blend_layer",      Settings.GBFrameBlendLayer);
+    set_check("gb_frame_blend_auto",       Settings.GBFrameBlendAuto);
     set_check("multithreading",            config->multithreading);
     enable_widget("num_threads", get_check("multithreading"));
     set_label("threads_for_filtering_and_scaling_label",
@@ -576,6 +605,7 @@ void Snes9xPreferences::move_settings_to_dialog()
     suppress_volume_sync = false;
     prev_regular_volume = config->master_volume_regular;
     update_sgb_volume_enable_state();
+    update_gb_blend_enable_state();
     if (top_level->get_auto_input_rate() == 0)
     {
         config->auto_input_rate = false;
@@ -714,6 +744,19 @@ void Snes9xPreferences::get_settings_from_dialog()
     config->osd_size                  = get_spin("osd_size");
     config->scale_to_fit              = get_check("scale_to_fit");
     config->overscan                  = get_check("overscan");
+    // Game Boy frame-blend. Settings.GBFrameBlend* is the single stored value (saved
+    // straight to the config file), exactly like win32. When "Auto Layer Transparency"
+    // is on, the per-title table in sgb.cpp picks the mode/layer and overwrites it in
+    // place; reflect that back into the (disabled) dropdowns.
+    Settings.GBFrameBlendAuto         = get_check("gb_frame_blend_auto");
+    Settings.GBFrameBlend             = get_combo("gb_frame_blend");
+    Settings.GBFrameBlendLayer        = get_combo("gb_frame_blend_layer");
+    if (Settings.GBFrameBlendAuto)
+    {
+        S9xSGBApplyAutoBlend();
+        set_combo("gb_frame_blend",       Settings.GBFrameBlend);
+        set_combo("gb_frame_blend_layer", Settings.GBFrameBlendLayer);
+    }
     config->maintain_aspect_ratio     = get_check("maintain_aspect_ratio");
     config->aspect_ratio              = get_combo("aspect_ratio");
     config->scale_method              = get_combo("scale_method_combo");

--- a/gtk/src/gtk_preferences.h
+++ b/gtk/src/gtk_preferences.h
@@ -31,6 +31,7 @@ class Snes9xPreferences final : public GtkBuilderWindow
     void connect_signals();
     void input_rate_changed();
     void update_sgb_volume_enable_state();
+    void update_gb_blend_enable_state();
     bool key_pressed(GdkEventKey *event);
     void shader_select();
     void game_data_browse(const std::string &folder);

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1003,6 +1003,43 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="liststore_gb_blend">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Off</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Simple Blend</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">LCD Blend</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="liststore_gb_blend_layer">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">All</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Background</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Window</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Sprites</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="liststore2">
     <columns>
       <!-- column-name item -->
@@ -2960,6 +2997,144 @@
                               </packing>
                             </child>
 
+                            <child>
+                              <object class="GtkFrame" id="gb_image_frame">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0</property>
+                                <property name="shadow_type">none</property>
+                                <property name="tooltip_text" translatable="yes">These options only apply to Game Boy games played through the Super Game Boy.</property>
+                                <child>
+                                  <object class="GtkAlignment" id="gb_image_alignment">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
+                                    <child>
+                                      <object class="GtkVBox" id="gb_image_vbox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="border_width">5</property>
+                                        <property name="spacing">5</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="gb_frame_blend_auto">
+                                            <property name="label" translatable="yes">Auto Layer Transparency</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Pick the blend per game from a built-in list of known flicker-transparency games (off for the rest). Uncheck to set the mode and layer manually for every Game Boy game.</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkHBox" id="gb_frame_blend_box">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="spacing">12</property>
+                                            <child>
+                                              <object class="GtkLabel" id="gb_frame_blend_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Frame blend:</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBox" id="gb_frame_blend">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="model">liststore_gb_blend</property>
+                                                <property name="tooltip_text" translatable="yes">Simple Blend = 50/50 of the last two frames (cancels flicker-transparency); LCD Blend = slow-decay LCD-style ghosting.</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="gb_frame_blend_renderer"/>
+                                                  <attributes>
+                                                    <attribute name="text">0</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkHBox" id="gb_frame_blend_layer_box">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="spacing">12</property>
+                                            <child>
+                                              <object class="GtkLabel" id="gb_frame_blend_layer_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Blend layer:</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBox" id="gb_frame_blend_layer">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="model">liststore_gb_blend_layer</property>
+                                                <property name="tooltip_text" translatable="yes">Which Game Boy layer to blend: Background keeps moving sprites crisp; Window = the window/HUD layer; Sprites = objects only; All blends everything.</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="gb_frame_blend_layer_renderer"/>
+                                                  <attributes>
+                                                    <attribute name="text">0</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="gb_image_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">&lt;b&gt;Game Boy Image&lt;/b&gt;</property>
+                                    <property name="use_markup">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">6</property>
+                              </packing>
+                            </child>
 
                             <child>
                               <object class="GtkHBox" id="osd_box">

--- a/qt/src/DisplayPanel.cpp
+++ b/qt/src/DisplayPanel.cpp
@@ -3,6 +3,8 @@
 #include "EmuConfig.hpp"
 #include <QFileDialog>
 
+#include "snes9x.h"
+
 DisplayPanel::DisplayPanel(EmuApplication *app_)
     : app(app_)
 {
@@ -99,7 +101,53 @@ DisplayPanel::DisplayPanel(EmuApplication *app_)
             app->window->recreateUIAssets();
     });
 
+    // Game Boy frame blending (Super Game Boy). Mirrors the win32 "Game Boy Image"
+    // box: the Auto checkbox picks the blend per game from a built-in table, while
+    // the two dropdowns set it manually when Auto is off.
+    connect(checkBox_gb_frame_blend_auto, &QCheckBox::clicked, [&](bool checked) {
+        app->config->gb_frame_blend_auto = checked;
+        app->updateSettings();
+        if (checked)
+        {
+            // Re-pick the blend for the loaded game from the table (done on the
+            // emu thread by S9xSGBApplyAutoBlend) and reflect it in the now-disabled
+            // dropdowns, persisting it as the manual value like win32's single store.
+            app->emu_thread->runOnThread([&] {
+                app->config->gb_frame_blend = Settings.GBFrameBlend;
+                app->config->gb_frame_blend_layer = Settings.GBFrameBlendLayer;
+            }, true);
+            comboBox_gb_frame_blend->setCurrentIndex(app->config->gb_frame_blend);
+            comboBox_gb_frame_blend_layer->setCurrentIndex(app->config->gb_frame_blend_layer);
+        }
+        updateGBBlendEnabledState();
+    });
+
+    connect(comboBox_gb_frame_blend, &QComboBox::currentIndexChanged, [&](int index) {
+        app->config->gb_frame_blend = index;
+        app->updateSettings();
+        updateGBBlendEnabledState();
+    });
+
+    connect(comboBox_gb_frame_blend_layer, &QComboBox::currentIndexChanged, [&](int index) {
+        app->config->gb_frame_blend_layer = index;
+        app->updateSettings();
+    });
+
     groupBox_software_filters->hide();
+}
+
+void DisplayPanel::updateGBBlendEnabledState()
+{
+    // The Game Boy Image options only apply to a Game Boy / GBC / SGB game — grey
+    // them out for SNES titles (or when nothing is loaded). With Auto on, the two
+    // dropdowns are list-driven so they're greyed too; the layer one also needs
+    // blending to be on (mode != Off).
+    bool gb_active = (Settings.SuperGameBoy || Settings.SGB_BIOSModeActive);
+    bool manual = gb_active && !app->config->gb_frame_blend_auto;
+    groupBox_gb_image->setEnabled(gb_active);
+    checkBox_gb_frame_blend_auto->setEnabled(gb_active);
+    comboBox_gb_frame_blend->setEnabled(manual);
+    comboBox_gb_frame_blend_layer->setEnabled(manual && app->config->gb_frame_blend != EmuConfig::eGBBlendOff);
 }
 
 void DisplayPanel::selectShaderDialog()
@@ -174,6 +222,11 @@ void DisplayPanel::showEvent(QShowEvent *event)
 
     comboBox_messages->setCurrentIndex(config->display_messages);
     spinBox_osd_size->setValue(config->osd_size);
+
+    checkBox_gb_frame_blend_auto->setChecked(config->gb_frame_blend_auto);
+    comboBox_gb_frame_blend->setCurrentIndex(config->gb_frame_blend);
+    comboBox_gb_frame_blend_layer->setCurrentIndex(config->gb_frame_blend_layer);
+    updateGBBlendEnabledState();
 
     QWidget::showEvent(event);
 }

--- a/qt/src/DisplayPanel.cpp
+++ b/qt/src/DisplayPanel.cpp
@@ -109,9 +109,9 @@ DisplayPanel::DisplayPanel(EmuApplication *app_)
         app->updateSettings();
         if (checked)
         {
-            // Re-pick the blend for the loaded game from the table (done on the
-            // emu thread by S9xSGBApplyAutoBlend) and reflect it in the now-disabled
-            // dropdowns, persisting it as the manual value like win32's single store.
+            // updateSettings just re-picked the blend for the loaded game via the
+            // table (S9xSGBApplyAutoBlend on the emu thread) and wrote it back into
+            // the single stored value; read it out to show in the disabled dropdowns.
             app->emu_thread->runOnThread([&] {
                 app->config->gb_frame_blend = Settings.GBFrameBlend;
                 app->config->gb_frame_blend_layer = Settings.GBFrameBlendLayer;
@@ -224,6 +224,16 @@ void DisplayPanel::showEvent(QShowEvent *event)
     spinBox_osd_size->setValue(config->osd_size);
 
     checkBox_gb_frame_blend_auto->setChecked(config->gb_frame_blend_auto);
+    if (config->gb_frame_blend_auto &&
+        (Settings.SuperGameBoy || Settings.SGB_BIOSModeActive))
+    {
+        // win32 shows the single stored value, which the auto table has already
+        // overwritten for the loaded game; mirror that by reading it back from core.
+        app->emu_thread->runOnThread([&] {
+            config->gb_frame_blend = Settings.GBFrameBlend;
+            config->gb_frame_blend_layer = Settings.GBFrameBlendLayer;
+        }, true);
+    }
     comboBox_gb_frame_blend->setCurrentIndex(config->gb_frame_blend);
     comboBox_gb_frame_blend_layer->setCurrentIndex(config->gb_frame_blend_layer);
     updateGBBlendEnabledState();

--- a/qt/src/DisplayPanel.hpp
+++ b/qt/src/DisplayPanel.hpp
@@ -11,6 +11,7 @@ class DisplayPanel :
     void showEvent(QShowEvent *event) override;
     void populateDevices();
     void selectShaderDialog();
+    void updateGBBlendEnabledState();
 
     std::vector<std::pair<int, std::string>> driver_list;
     bool updating = true;

--- a/qt/src/DisplayPanel.ui
+++ b/qt/src/DisplayPanel.ui
@@ -419,6 +419,120 @@ Output directly will cause the screen to change between the two modes and look w
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_gb_image">
+     <property name="toolTip">
+      <string>These options only apply to Game Boy games played through the Super Game Boy.</string>
+     </property>
+     <property name="title">
+      <string>Game Boy Image</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_gb_image">
+      <item>
+       <widget class="QCheckBox" name="checkBox_gb_frame_blend_auto">
+        <property name="toolTip">
+         <string>Auto Layer Transparency: pick the blend per game from a built-in list of known flicker-transparency games (off for the rest). Uncheck to set the mode and layer manually for every Game Boy game.</string>
+        </property>
+        <property name="text">
+         <string>Auto Layer Transparency</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="gridLayout_gb_blend">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_gb_frame_blend">
+          <property name="text">
+           <string>Frame blend:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="comboBox_gb_frame_blend">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Game Boy frame-blend mode: Simple Blend = 50/50 of the last two frames (cancels flicker-transparency); LCD Blend = slow-decay LCD-style ghosting.</string>
+          </property>
+          <item>
+           <property name="text">
+            <string>Off</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Simple Blend</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>LCD Blend</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_gb_frame_blend_layer">
+          <property name="text">
+           <string>Blend layer:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="comboBox_gb_frame_blend_layer">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Which Game Boy layer to blend: Background (BG) keeps moving sprites crisp; Window = the window/HUD layer; Sprites = objects only; All blends everything.</string>
+          </property>
+          <item>
+           <property name="text">
+            <string>All</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Background</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Window</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Sprites</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <spacer name="horizontalSpacer_gb_blend">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -479,9 +479,11 @@ void EmuConfig::config(const std::string &filename, bool write)
     Enum("DisplayMessages", display_messages, { "Onscreen", "Inscreen", "None" });
     Int("OSDSize", osd_size);
 
-    Enum("GBFrameBlend", gb_frame_blend, { "Off", "SimpleBlend", "LCDBlend" });
-    Enum("GBFrameBlendLayer", gb_frame_blend_layer, { "All", "Background", "Window", "Sprites" });
-    Bool("GBFrameBlendAuto", gb_frame_blend_auto);
+    // Key names match the win32 config (wconfig.cpp) so a shared install reads/writes
+    // the same entries.
+    Enum("BlendGBFrames", gb_frame_blend, { "Off", "SimpleBlend", "LCDBlend" });
+    Enum("BlendGBFramesLayer", gb_frame_blend_layer, { "All", "Background", "Window", "Sprites" });
+    Bool("BlendGBFramesAuto", gb_frame_blend_auto);
     EndSection();
 
     BeginSection("Sound");

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -246,6 +246,10 @@ bool EmuConfig::setDefaults(int section)
 
         display_messages = eOnscreen;
         osd_size = 24;
+
+        gb_frame_blend = eGBBlendOff;
+        gb_frame_blend_layer = eGBBlendLayerAll;
+        gb_frame_blend_auto = true;
     }
 
     if (section == -1 || section == 2)
@@ -474,6 +478,10 @@ void EmuConfig::config(const std::string &filename, bool write)
 
     Enum("DisplayMessages", display_messages, { "Onscreen", "Inscreen", "None" });
     Int("OSDSize", osd_size);
+
+    Enum("GBFrameBlend", gb_frame_blend, { "Off", "SimpleBlend", "LCDBlend" });
+    Enum("GBFrameBlendLayer", gb_frame_blend_layer, { "All", "Background", "Window", "Sprites" });
+    Bool("GBFrameBlendAuto", gb_frame_blend_auto);
     EndSection();
 
     BeginSection("Sound");

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -81,6 +81,29 @@ struct EmuConfig
     int display_messages;
     int osd_size;
 
+    // Game Boy frame blending (Super Game Boy / SGB BIOS games only). Mirrors the
+    // win32 "Game Boy Image" options: a blend mode, the layer it applies to, and an
+    // "Auto Layer Transparency" toggle that picks both per-game from a built-in
+    // known-flicker table. Maps onto Settings.GBFrameBlend / GBFrameBlendLayer /
+    // GBFrameBlendAuto and must stay in sync with the GBBlendMode / GBBlendLayer
+    // enums in snes9x.h.
+    enum GBFrameBlend
+    {
+        eGBBlendOff = 0,
+        eGBBlendSimple = 1,
+        eGBBlendLCD = 2
+    };
+    int gb_frame_blend;
+    enum GBFrameBlendLayer
+    {
+        eGBBlendLayerAll = 0,
+        eGBBlendLayerBackground = 1,
+        eGBBlendLayerWindow = 2,
+        eGBBlendLayerSprites = 3
+    };
+    int gb_frame_blend_layer;
+    bool gb_frame_blend_auto;
+
     // Sound
     std::string sound_driver;
     std::string sound_device;

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -20,6 +20,7 @@ namespace fs = std::filesystem;
 #include "display.h"
 #include "conffile.h"
 #include "statemanager.h"
+#include "sgb/sgb.h"
 
 Snes9xController *g_snes9xcontroller = nullptr;
 StateManager g_state_manager;
@@ -196,6 +197,16 @@ void Snes9xController::updateSettings(const EmuConfig * const config)
     Settings.TwoClockCycles = overclock_cycles[config->overclock][0] * 2;
 
     Settings.ShowOverscan = config->show_overscan;
+
+    // Game Boy frame-blend (Super Game Boy). Push the manual mode/layer first, then,
+    // when "Auto Layer Transparency" is on, let the per-title table in sgb.cpp pick
+    // the mode/layer for the loaded Game Boy game (overwriting the manual values).
+    // The actual blending and fast-forward bypass live in S9xBlendGameBoyFrames().
+    Settings.GBFrameBlendAuto  = config->gb_frame_blend_auto;
+    Settings.GBFrameBlend      = config->gb_frame_blend;
+    Settings.GBFrameBlendLayer = config->gb_frame_blend_layer;
+    if (config->gb_frame_blend_auto)
+        S9xSGBApplyAutoBlend();
 
     high_resolution_effect = config->high_resolution_effect;
 

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -115,7 +115,7 @@ void Snes9xController::deinit()
     S9xDeinitAPU();
 }
 
-void Snes9xController::updateSettings(const EmuConfig * const config)
+void Snes9xController::updateSettings(EmuConfig *config)
 {
     Settings.UpAndDown = config->allow_opposing_dpad_directions;
 
@@ -198,15 +198,21 @@ void Snes9xController::updateSettings(const EmuConfig * const config)
 
     Settings.ShowOverscan = config->show_overscan;
 
-    // Game Boy frame-blend (Super Game Boy). Push the manual mode/layer first, then,
+    // Game Boy frame-blend (Super Game Boy). Push the stored mode/layer first, then,
     // when "Auto Layer Transparency" is on, let the per-title table in sgb.cpp pick
-    // the mode/layer for the loaded Game Boy game (overwriting the manual values).
+    // the mode/layer for the loaded Game Boy game. Like win32, there is a single
+    // stored value: the auto pick overwrites it in place (config <- Settings) so it
+    // persists, rather than being kept beside a separate "manual" value.
     // The actual blending and fast-forward bypass live in S9xBlendGameBoyFrames().
     Settings.GBFrameBlendAuto  = config->gb_frame_blend_auto;
     Settings.GBFrameBlend      = config->gb_frame_blend;
     Settings.GBFrameBlendLayer = config->gb_frame_blend_layer;
     if (config->gb_frame_blend_auto)
+    {
         S9xSGBApplyAutoBlend();
+        config->gb_frame_blend       = Settings.GBFrameBlend;
+        config->gb_frame_blend_layer = Settings.GBFrameBlendLayer;
+    }
 
     high_resolution_effect = config->high_resolution_effect;
 

--- a/qt/src/Snes9xController.hpp
+++ b/qt/src/Snes9xController.hpp
@@ -22,7 +22,7 @@ class Snes9xController
     void loadUndoState();
     bool saveState(const std::string &filename);
     bool saveState(int slot);
-    void updateSettings(const EmuConfig * const config);
+    void updateSettings(EmuConfig *config);
     void updateBindings(const EmuConfig * const config);
     void reportBinding(EmuBinding b, bool active);
     void reportMouseButton(int button, bool pressed);


### PR DESCRIPTION
## Summary
Brings the Game Boy "frame-blend" / "Auto Layer Transparency" feature (already in win32) to the **Qt** and **GTK** frontends, at full parity with win32.

The blend modes/layers and the per-title auto table live in shared core (`sgb/sgb.cpp`, `Settings.GBFrameBlend*`); this PR only adds the frontend config + UI wiring.

## Changes

**Qt** (`ff83ea97`, `66c1096e`)
- New "Game Boy Image" controls on the Display panel: Auto Layer Transparency toggle + Frame blend / Blend layer dropdowns, SGB-only gating.
- Config keys renamed to the **win32 names** (`BlendGBFrames` / `BlendGBFramesLayer` / `BlendGBFramesAuto`).
- **Single-store** model like win32: when Auto is on, the per-title table picks the mode/layer and the result is written back into the one stored value (no separate preserved "manual" value); the panel reflects the effective value when reopened.

**GTK** (`1524c820`)
- New "Game Boy Image" group on the Display tab (GtkBuilder `.ui`): Auto toggle + two combos, greyed out for non-SGB games (and the dropdowns when Auto is on; layer also needs mode ≠ Off).
- Stored directly in `Settings.GBFrameBlend*` — the idiomatic GTK pattern for core settings and the truest match to win32's single store — under the same `BlendGBFrames*` config keys.
- Live at startup (config loads straight into `Settings`); the core's `ApplyAutoBlend()` at GB ROM-load handles per-game selection without opening Preferences.

## Parity
Identical enum values (`GBBlendMode` 0–2, `GBBlendLayer` 0–3), config key names, defaults (`0 / 0 / auto=true`), single-store behavior, and SGB-only gating across all three frontends.

## Testing
- Qt frontend builds cleanly (`cmake --build`).
- GTK frontend builds cleanly (`cmake --build`).
- win32 unchanged.