### PR TITLE
fix(gb): SGB BIOS-mode soft reset — restore a settled-title snapshot

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -154,6 +154,61 @@ void S9xReset (void)
 	S9xInitCheatData();
 }
 
+static uint8  *sgb_softreset_state       = NULL;
+static uint32  sgb_softreset_state_size  = 0;
+static bool8   sgb_softreset_state_valid = FALSE;
+
+void S9xSGBCaptureSoftResetCheckpoint (void)
+{
+	if (!Settings.SGB_BIOSModeActive)
+		return;
+	uint32 sz = S9xFreezeSize();
+	if (sz == 0)
+		return;
+	if (sgb_softreset_state_size != sz)
+	{
+		delete[] sgb_softreset_state;
+		sgb_softreset_state      = new uint8[sz];
+		sgb_softreset_state_size = sz;
+	}
+	sgb_softreset_state_valid = S9xFreezeGameMem(sgb_softreset_state, sgb_softreset_state_size);
+}
+
+void S9xSGBInvalidateSoftResetCheckpoint (void)
+{
+	sgb_softreset_state_valid = FALSE;
+}
+
+static bool8 S9xSGBRestoreSoftResetCheckpoint (void)
+{
+	if (!sgb_softreset_state_valid)
+		return FALSE;
+
+	size_t  sram_size = S9xSGBGetSRAMSize();
+	uint8  *sram_copy = NULL;
+	if (sram_size > 0)
+	{
+		uint8 *live = S9xSGBGetSRAM();
+		if (live)
+		{
+			sram_copy = new uint8[sram_size];
+			memcpy(sram_copy, live, sram_size);
+		}
+	}
+
+	int result = S9xUnfreezeGameMem(sgb_softreset_state, sgb_softreset_state_size);
+
+	if (sram_copy)
+	{
+		uint8 *live = S9xSGBGetSRAM();
+		if (result == SUCCESS && live && S9xSGBGetSRAMSize() == sram_size)
+			memcpy(live, sram_copy, sram_size);
+		delete[] sram_copy;
+	}
+
+	return (result == SUCCESS) ? TRUE : FALSE;
+}
+
 void S9xSoftReset (void)
 {
 	// GB/GBC/SGB: a soft reset only warm-resets the GB core — the game
@@ -166,7 +221,22 @@ void S9xSoftReset (void)
 	// (BIOS-less mode must also bypass the SNES reset chain: the SNES
 	// is dormant and its stale SPC DSP state crashes on the reset-
 	// vector read — see S9xReset.)
-	if (Settings.SuperGameBoy || Settings.SGB_BIOSModeActive)
+	if (Settings.SGB_BIOSModeActive)
+	{
+		if (S9xSGBRestoreSoftResetCheckpoint())
+		{
+			S9xInitCheatData();
+			return;
+		}
+		if (!S9xSGBSoftReset())
+		{
+			S9xReset();
+			return;
+		}
+		S9xInitCheatData();
+		return;
+	}
+	if (Settings.SuperGameBoy)
 	{
 		if (!S9xSGBSoftReset())
 		{

--- a/cpuexec.h
+++ b/cpuexec.h
@@ -47,6 +47,8 @@ extern uint8			S9xOpLengthsM0X0[256];
 void S9xMainLoop (void);
 void S9xReset (void);
 void S9xSoftReset (void);
+void S9xSGBCaptureSoftResetCheckpoint (void);
+void S9xSGBInvalidateSoftResetCheckpoint (void);
 void S9xDoHEventProcessing (void);
 
 static inline void S9xUnpackStatus (void)

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -1651,6 +1651,12 @@ bool Emulator::IsBootHandoffCaptured() const
 	return impl_->boot_handoff_captured;
 }
 
+uint32_t Emulator::GetPacketCount() const
+{
+	if (!impl_) return 0;
+	return impl_->icd2.packets_received;
+}
+
 // Monotonic count of completed GB frames (bumped at each PPU VBlank entry, in
 // both BIOS and BIOS-less modes). The frame-blend hook samples this once per
 // SNES frame to tell a genuinely new GB frame from a duplicate/skip caused by
@@ -2505,6 +2511,7 @@ void S9xSGBSyncToSnesCycle(int32_t cpu_cycles)
 void S9xSGBOnPpuHBlank(void) { SGB::Instance().OnPpuHBlank(); }
 void S9xSGBOnPpuVBlank(void) { SGB::Instance().OnPpuVBlank(); }
 uint32_t S9xSGBGetGBFrameCount(void) { return SGB::g_gb_vblank_count; }
+uint32_t S9xSGBGetPacketCount(void) { return SGB::Instance().GetPacketCount(); }
 const uint8_t *S9xSGBGetGBLayerMask(void) { return SGB::Instance().GBLayerMask(); }
 void S9xSGBApplyAutoBlend(void) { SGB::Instance().ApplyAutoBlend(); }
 bool S9xSGBIsCgb(void) { return SGB::Instance().IsCgb(); }

--- a/sgb/sgb.h
+++ b/sgb/sgb.h
@@ -223,6 +223,7 @@ public:
 	bool    IsHandshakePending() const;
 
 	bool    IsBootHandoffCaptured() const;
+	uint32_t GetPacketCount() const;
 
 	// GB PPU scanline event hooks for SGB row/bank counter advance.
 	void    OnPpuHBlank();
@@ -321,6 +322,7 @@ void S9xSGBOnPpuVBlank(void);
 // BIOS and BIOS-less modes. The frame-blend hook reads it to pair frames
 // correctly across the GB↔SNES refresh-rate beat. See g_gb_vblank_count.
 uint32_t S9xSGBGetGBFrameCount(void);
+uint32_t S9xSGBGetPacketCount(void);
 // Source-layer tag values stored per pixel in the GB layer map (see GBLayerMask).
 enum GBPixelLayer
 {

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -4812,6 +4812,29 @@ int WINAPI WinMain(
 			RA_DoFrame();
 #endif
 			GUI.FrameCount++;
+			if (Settings.SGB_BIOSModeActive)
+			{
+				static bool   sgbCpDone  = false;
+				static uint32 sgbCpPkts  = 0;
+				static uint32 sgbCpQuiet = 0;
+				if (!S9xSGBBootHandoffCaptured())
+				{
+					S9xSGBInvalidateSoftResetCheckpoint();
+					sgbCpDone  = false;
+					sgbCpPkts  = S9xSGBGetPacketCount();
+					sgbCpQuiet = 0;
+				}
+				else if (!sgbCpDone)
+				{
+					uint32 pkts = S9xSGBGetPacketCount();
+					if (pkts != sgbCpPkts) { sgbCpPkts = pkts; sgbCpQuiet = 0; }
+					else if (++sgbCpQuiet >= 120)
+					{
+						S9xSGBCaptureSoftResetCheckpoint();
+						sgbCpDone = true;
+					}
+				}
+			}
 			DebugViewers_OnFrame();
 			if (GUI.CursorTimer)
 			{


### PR DESCRIPTION
## Problem

Doing a **Soft Reset** while an SGB-enhanced game runs in **SGB BIOS mode** produced two bugs:

1. **Garbled colours in the inner GB screen.** After the reset the bordered title area filled with scrambled coloured tile data before (sometimes instead of) settling to the real title.
2. **The SGB/SPC music kept playing** — the background music never stopped on reset.

A fresh load of the same game was always clean, so this was specific to the soft-reset path.

## Root cause

Diagnosed by driving the game's full SGB path in the headless GB harness and decoding its SGB command stream:

- On **every** start the game re-uploads its custom border via `CHR_TRN`/`PCT_TRN`, and it **never sends `MASK_EN`**. That upload streams the border's tile graphics *through the GB screen itself* — i.e. the "garble" is the border art mid-transfer.
- On a **cold boot** this is invisible because the SNES SGB BIOS isn't displaying the GB screen yet while the upload happens. On a **soft reset** the BIOS is already live in game-display mode, so it shows the un-masked upload → the garble.
- The **SPC** keeps playing because a GB-only warm reset never touches it, and it can't be cleanly reset mid-session — the SGB sound driver is uploaded by the BIOS only during its boot, so resetting the SPC alone leaves it permanently silent.

So a GB-only reset fundamentally can't avoid this; the only clean fix is to skip showing the messy re-init entirely.

## Fix

In BIOS mode, capture a **full in-memory savestate once the title is fully settled** and restore it on soft reset:

- **Capture timing is the key.** The host watches the SGB command stream and snapshots only after it has been **quiet for 120 frames** following the boot handoff — i.e. the game has finished uploading *and* the intro fade has settled. (Capturing mid-intro is what caused an earlier fade.)
- **Restore** jumps the whole system (SNES + GB + SPC) straight to that settled title: the re-upload never visibly happens (no garble), it's already at full brightness (no fade), and the SPC is restored to its clean state (music stops, sound still works).
- **Battery SRAM is preserved** across the restore, so saves / high-scores survive.
- Falls back to the plain GB warm reset until the snapshot has been captured (first few seconds), and re-arms on a hard reset.

## Changes

- `cpu.cpp` — `S9xSGBCaptureSoftResetCheckpoint` / restore helper (with SRAM preservation); `S9xSoftReset` BIOS branch restores the snapshot, else falls back to `S9xSGBSoftReset`.
- `sgb/sgb.{cpp,h}` — `S9xSGBGetPacketCount()` so the host can detect when the SGB command stream goes quiet.
- `cpuexec.h` — capture/invalidate declarations.
- `win32/wsnes9x.cpp` — capture-when-quiet trigger (the `120`-frame quiet threshold is the one tunable).

## Testing

Confirmed on Donkey Kong (SGB Enhanced): soft reset from the title now snaps instantly back to the clean, fully-coloured title — no garble, no fade — and the music stops and resumes correctly.