### PR TITLE
sgb: reconstruct DMG BGP raster write timing (Prehistorik Man left/right bands)

### DIFF
--- a/sgb/gb_memory.h
+++ b/sgb/gb_memory.h
@@ -16,6 +16,7 @@ struct Ppu;
 struct Apu;
 struct Timer;
 struct Joypad;
+struct CpuState;
 
 // GB address space — flat 16-bit. All access goes through this one bus.
 //   0x0000-0x3FFF  ROM bank 0
@@ -36,6 +37,12 @@ struct Memory
 	Apu    *apu    = nullptr;
 	Timer  *timer  = nullptr;
 	Joypad *joypad = nullptr;
+	// CPU clock, for PPU-register write-time reconstruction. In the per-dot
+	// interleave the CPU trails the PPU by up to kMaxOpcodeTCycles, so at the
+	// moment a store reaches PpuWriteReg the PPU has already rendered dots the
+	// write should have affected; cpu->t_cycles gives the store's true dot.
+	// Transient wiring like ppu/apu above — never serialized.
+	const CpuState *cpu = nullptr;
 
 	uint8_t wram[0x8000];
 	uint8_t hram[0x7F];

--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -998,10 +998,74 @@ void PpuWriteReg(Ppu &p, Memory &mem, uint16_t addr, uint8_t value)
 		case 0xFF44: p.ly  = 0; RecomputeStatLine(p, mem); break;
 		case 0xFF45: p.lyc = value; RecomputeStatLine(p, mem); break;
 		case 0xFF47:
+		{
 			p.bgp = value;
 			if (p.mode == PpuMode::Transfer)
 				p.latched_bgp = value;
+			// DMG raster write-time reconstruction. In the per-dot interleave
+			// the CPU trails the PPU by up to kMaxOpcodeTCycles, so by the
+			// time this store reaches us the PPU has already emitted the
+			// pixels the write was aimed at, using the stale palette.
+			// Prehistorik Man's title streams BGP from a WRAM LD (HL),D/E
+			// chain timed so its first write lands in the 2-dot window
+			// before pixel 0 — landing a lag-window late instead exposed the
+			// previous line's blackout palette as a black block on the left
+			// edge. The raw 2-bit indices for the line are still in
+			// scanline_bg_raw, so re-map the lag window's pixels with the
+			// new palette. OBJ pixels keep their OBP colors. cpu->t_cycles
+			// still holds the instruction-start time when the store lands
+			// (cycles are added after Dispatch); +4 puts the effective dot
+			// on the store's actual memory microcycle.
+			if (!p.cgb && mem.cpu && !p.present_hold &&
+			    p.ly < GB_SCREEN_HEIGHT && (p.lcdc & 0x80))
+			{
+				int64_t lag = p.t_cycles - (mem.cpu->t_cycles + 4);
+				if (lag > 0 && lag <= 2 * kMaxOpcodeTCycles)
+				{
+					int x_end = -1;   // one past the last stale pixel
+					if (p.mode == PpuMode::Transfer)
+						x_end = static_cast<int>(p.draw_x);
+					else if (p.mode == PpuMode::HBlank && lag > p.mode_clock)
+					{
+						// Store's dot falls back inside mode 3 — the line's
+						// tail pixels were emitted with the stale palette.
+						x_end = GB_SCREEN_WIDTH;
+						lag  -= p.mode_clock;
+					}
+					if (x_end > 0)
+					{
+						int x0 = x_end - static_cast<int>(lag);
+						if (x0 < 0) x0 = 0;
+						uint8_t *const line = &p.framebuffer[p.ly * GB_SCREEN_WIDTH];
+						const uint8_t *const lay = &p.layer[p.ly * GB_SCREEN_WIDTH];
+						for (int x = x0; x < x_end; ++x)
+						{
+							if (lay[x] == GB_PIXEL_OBJ)
+								continue;
+							const bool hidden = (lay[x] == GB_PIXEL_WINDOW)
+							                        ? !p.show_window : !p.show_bg;
+							line[x] = ApplyPalette(value,
+							                       hidden ? 0 : p.scanline_bg_raw[x]);
+						}
+						// The HBlank back-spill lands AFTER FinalizeScanline
+						// already pushed this line into the SGB ICD2 capture
+						// ring — the SGB BIOS displays the ring, not the
+						// framebuffer, so without a re-push the correction is
+						// invisible in BIOS mode (black band on the RIGHT
+						// edge, mirror of the left-edge bug). Re-capture the
+						// corrected line: sgb_row/bank haven't advanced yet
+						// (that happens at HBlank end), so this overwrites
+						// the same ring slot, and the BIOS can't have drained
+						// this band yet — trailing raster writes arrive
+						// within ~35 dots of HBlank entry. Idempotent memcpy;
+						// no-op in BIOS-less mode and in the harness.
+						if (x_end == GB_SCREEN_WIDTH)
+							S9xSGBCaptureScanline(line);
+					}
+				}
+			}
 			break;
+		}
 		case 0xFF48: p.obp0 = value; break;
 		case 0xFF49: p.obp1 = value; break;
 		case 0xFF4A: p.wy = value;   break;

--- a/sgb/sgb.cpp
+++ b/sgb/sgb.cpp
@@ -462,6 +462,7 @@ void Emulator::Reset()
 	impl_->mem.timer  = &impl_->timer;
 	impl_->mem.joypad = &impl_->joypad;
 	impl_->mem.cart   = &impl_->cart;
+	impl_->mem.cpu    = &impl_->cpu.State();
 
 	impl_->fb.pixels = impl_->ppu.framebuffer;
 	impl_->fb.width  = GB_SCREEN_WIDTH;
@@ -2357,6 +2358,7 @@ bool Emulator::StateLoad(const uint8_t *buffer, size_t size)
 	impl_->mem.timer  = &impl_->timer;
 	impl_->mem.joypad = &impl_->joypad;
 	impl_->mem.cart   = &impl_->cart;
+	impl_->mem.cpu    = &impl_->cpu.State();
 
 	impl_->cart.sram_dirty = false;
 	impl_->ds_extra        = -1;


### PR DESCRIPTION
## Problem

Prehistorik Man's title screen showed an intermittent **black band over the left edge** — every time a scrolling banner letter reached the left side of the screen, a block appeared over it (and stray bands popped in every few frames even without a letter). Reported in SGB BIOS mode; reproduces BIOS-less and in the headless harness too.

## Root cause

The title streams BGP from a **self-modifying WRAM chain** (`LD (HL),D`/`LD (HL),E` x22 at $D600, opcode bytes rewritten per frame), HALT+LYC-synced, one write per 8 dots — a cycle-exact palette raster painting the animated water band. On hardware each line's **first write lands in the 2-dot window before pixel 0** (SameBoy-verified grid: line dots 90..258).

In our per-dot interleave the CPU trails the PPU by up to `kMaxOpcodeTCycles` (~24 dots), so BGP stores reach the PPU after it already emitted the pixels they were aimed at (our grid landed at 104..272). Pixels 0-11 therefore kept the **previous line's trailing blackout palette ($FF)** — the black band. This is the write-side half of the skew that the RoboCop `stat_irq_delay=24` defer compensates on the IRQ/read side; the two are in conflict under the current interleave, so the fix deliberately avoids touching any timing.

## Fix

On a DMG BGP write, reconstruct the store's **true dot** from the CPU clock (`Memory` gains a transient `const CpuState *` — field-serialized struct, savestate-safe) and **re-map the pixels emitted inside the lag window** with the new palette. Raw 2-bit indices are still in `scanline_bg_raw`; OBJ pixels keep their OBP colors; window/BG visibility flags honored.

Writes arriving early in HBlank back-spill into the line's tail the same way — and **re-push the corrected line into the ICD2 capture ring**: the SGB BIOS displays the ring (captured at mode-3 end), not the framebuffer, so without the re-push the tail correction was invisible in BIOS mode and the band reappeared on the **right** edge.

No IRQ / defer / interleave changes — RoboCop stat-defer and Ken Griffey LYC-relatch timing untouched by construction.