### PR TITLE
fix(gb): silence ultrasonic tone channels that alias into the audible band

### DIFF
--- a/sgb/gb_apu.cpp
+++ b/sgb/gb_apu.cpp
@@ -71,6 +71,22 @@ inline int32_t WavePeriod(uint16_t freq)
 	return static_cast<int32_t>((2048 - freq) * 2);
 }
 
+inline bool WaveAboveNyquist(const Apu &a)
+{
+	const int32_t denom = 2048 - static_cast<int32_t>(a.ch3.freq);
+	if (denom <= 0) return true;
+	return static_cast<int64_t>(a.clock_hz) >
+	       static_cast<int64_t>(a.output_rate) * 32 * denom;
+}
+
+inline bool SquareAboveNyquist(const Apu &a, uint16_t freq)
+{
+	const int32_t denom = 2048 - static_cast<int32_t>(freq);
+	if (denom <= 0) return true;
+	return static_cast<int64_t>(a.clock_hz) >
+	       static_cast<int64_t>(a.output_rate) * 16 * denom;
+}
+
 inline int32_t NoisePeriod(uint8_t nr43)
 {
 	// divisor: 0 → 8, 1 → 16, 2 → 32, ..., 7 → 112.
@@ -558,6 +574,9 @@ void ApuSetClockHz(Apu &a, int32_t hz)
 // of O(cycles), with the same sample output.
 void ApuStep(Apu &a, int32_t tcycles)
 {
+	const bool ch1_ultra = SquareAboveNyquist(a, a.ch1.freq);
+	const bool ch2_ultra = SquareAboveNyquist(a, a.ch2.freq);
+	const bool ch3_ultra = WaveAboveNyquist(a);
 	while (tcycles > 0)
 	{
 		// Determine the size of the next constant-output chunk. Master
@@ -568,9 +587,9 @@ void ApuStep(Apu &a, int32_t tcycles)
 		if (a.master_enabled)
 		{
 			if (a.frame_seq_timer                   < chunk) chunk = a.frame_seq_timer;
-			if (a.ch1.enabled && a.ch1.freq_timer   < chunk) chunk = a.ch1.freq_timer;
-			if (a.ch2.enabled && a.ch2.freq_timer   < chunk) chunk = a.ch2.freq_timer;
-			if (a.ch3.enabled && a.ch3.freq_timer   < chunk) chunk = a.ch3.freq_timer;
+			if (a.ch1.enabled && !ch1_ultra && a.ch1.freq_timer < chunk) chunk = a.ch1.freq_timer;
+			if (a.ch2.enabled && !ch2_ultra && a.ch2.freq_timer < chunk) chunk = a.ch2.freq_timer;
+			if (a.ch3.enabled && !ch3_ultra && a.ch3.freq_timer < chunk) chunk = a.ch3.freq_timer;
 			if (a.ch4.enabled && a.ch4.freq_timer   < chunk) chunk = a.ch4.freq_timer;
 		}
 		if (chunk < 1) chunk = 1;  // safety against zero-period corner cases
@@ -591,26 +610,26 @@ void ApuStep(Apu &a, int32_t tcycles)
 		if (a.master_enabled)
 		{
 			a.frame_seq_timer -= chunk;
-			if (a.ch1.enabled) a.ch1.freq_timer -= chunk;
-			if (a.ch2.enabled) a.ch2.freq_timer -= chunk;
-			if (a.ch3.enabled) a.ch3.freq_timer -= chunk;
+			if (a.ch1.enabled && !ch1_ultra) a.ch1.freq_timer -= chunk;
+			if (a.ch2.enabled && !ch2_ultra) a.ch2.freq_timer -= chunk;
+			if (a.ch3.enabled && !ch3_ultra) a.ch3.freq_timer -= chunk;
 			if (a.ch4.enabled) a.ch4.freq_timer -= chunk;
 
 			// Handle expiries. Channel periods are positive, so a single
 			// reload per event suffices; for larger skips (e.g. a very
 			// short NR43 divisor), the next loop iteration's chunk math
 			// reconverges.
-			if (a.ch1.enabled && a.ch1.freq_timer <= 0)
+			if (a.ch1.enabled && !ch1_ultra && a.ch1.freq_timer <= 0)
 			{
 				a.ch1.freq_timer += SquarePeriod(a.ch1.freq);
 				a.ch1.duty_pos    = static_cast<uint8_t>((a.ch1.duty_pos + 1) & 7);
 			}
-			if (a.ch2.enabled && a.ch2.freq_timer <= 0)
+			if (a.ch2.enabled && !ch2_ultra && a.ch2.freq_timer <= 0)
 			{
 				a.ch2.freq_timer += SquarePeriod(a.ch2.freq);
 				a.ch2.duty_pos    = static_cast<uint8_t>((a.ch2.duty_pos + 1) & 7);
 			}
-			if (a.ch3.enabled && a.ch3.freq_timer <= 0)
+			if (a.ch3.enabled && !ch3_ultra && a.ch3.freq_timer <= 0)
 			{
 				a.ch3.freq_timer += WavePeriod(a.ch3.freq);
 				a.ch3.pos         = static_cast<uint8_t>((a.ch3.pos + 1) & 0x1F);


### PR DESCRIPTION
## Problem

Some Game Boy games leave a tone channel running at a frequency whose **fundamental is above the audio output's Nyquist rate** (e.g. `freq = 0x7FF`, a ~65–130 kHz tone). On real hardware the band-limited DAC output collapses to DC — silence after the analog high-pass — so nothing is heard. Our box-filter decimator instead folds that ultrasonic energy back down, producing a fixed **high-pitched tone / "tinnitus" whine** that shouldn't be there.

**Pit Fighter** is the clearest case:
- **CH3 (wave)** is left at `0x7FF` from boot through the title → a continuous ~17–19 kHz whine over what should be silence.
- **CH2 (square)** sits at `0x7FF` at full volume for essentially the whole fight (CH1 does it often too) → a ~13 kHz tone during gameplay / character-select.

## Fix

Detect when a channel's fundamental exceeds the output Nyquist and **freeze that channel's phase advance** so it emits a constant value, which the existing DC blocker removes → silence, matching a band-limited DAC.

- `WaveAboveNyquist` / `SquareAboveNyquist` derive the threshold from `clock_hz` and `output_rate`, so it is **rate-adaptive** (32k/48k) and correct across DMG / SGB / CGB clocks.
- Applied to CH1, CH2 and CH3 in `ApuStep` (chunk-bounding, timer decrement, and phase/duty advance).
- **No new serialized state** (computed from existing fields) — savestate-safe.
- Bonus: frozen ultrasonic channels no longer force ~2-T-cycle mixing chunks, so it slightly speeds up the APU.

## Validation

Ground-truthed against **SameBoy** (which uses band-limited synthesis):
- Pit Fighter title window: **−600 dBFS (dead silent), exactly matching SameBoy**; the CH3 whine is gone.
- Gameplay: the aliased ~13 kHz CH2 tone (base: −19 dB) is removed; our post-fix spectrum matches SameBoy's within ~0.1 dB across 4–10 kHz. Remaining high-frequency content during the fight is legitimate CH4 (noise) percussion — SameBoy has even more of it.

**Regression sweep** (per-ROM `globalPeak` / `framesWithAudio`, 115 GB ROMs, before vs after): **7 changed, all benign** — audible bands (0.2–10 kHz) preserved to ~1 dB, only ultrasonic alias content removed; no clipping. Digitized-voice effects (e.g. Pit Fighter's "YEAH") run on channels at *low* frequency and are never frozen.
