### PR TITLE
fix(gb): cycle-precise VBlank IRQ latch (Sumou Fighter title artifact)

### DIFF
--- a/sgb/gb_ppu.cpp
+++ b/sgb/gb_ppu.cpp
@@ -84,6 +84,10 @@ constexpr int32_t LINE_DOTS  = MODE2_DOTS + MODE3_DOTS + MODE0_DOTS;  // 456
 constexpr int32_t VISIBLE_LINES = 144;
 constexpr int32_t TOTAL_LINES   = 154;
 
+// VBlank IF latches at the LY=144 dot minus this lead: cpu->t_cycles stamps
+// instruction START but DMG samples IF on the LAST M-cycle (-8..-20 all match SameBoy).
+constexpr int64_t GB_VBLANK_IRQ_OFFSET = -12;
+
 inline uint8_t ApplyPalette(uint8_t palette, uint8_t color_idx)
 {
 	// BGP/OBP0/OBP1 are 2-bit mappings packed into 8 bits:
@@ -615,7 +619,7 @@ void PpuReset(Ppu &p)
 	p.mode_clock    = 0;
 	p.window_line   = 0;
 	p.stat_line_high = false;
-	p.vblank_irq_delay = 0;
+	p.vblank_irq_at = 0;
 	p.stat_irq_delay = 0;
 	p.present_hold  = false;
 	p.frame_ready   = false;
@@ -644,12 +648,12 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 	p.mode_clock += 1;
 	bool transitioned = false;
 
-	// Deferred VBlank IRQ — see Ppu::vblank_irq_delay for rationale.
-	if (p.vblank_irq_delay > 0)
+	// Deferred VBlank IRQ — latch IF.VBLANK once the CPU catches up to the
+	// LY=144 dot (cycle-precise), see Ppu::vblank_irq_at for rationale.
+	if (p.vblank_irq_at != 0 && mem.cpu && mem.cpu->t_cycles >= p.vblank_irq_at)
 	{
-		--p.vblank_irq_delay;
-		if (p.vblank_irq_delay == 0)
-			mem.if_ = static_cast<uint8_t>(mem.if_ | IRQ_VBLANK);
+		mem.if_ = static_cast<uint8_t>(mem.if_ | IRQ_VBLANK);
+		p.vblank_irq_at = 0;
 	}
 
 	if (p.stat_irq_delay > 0)
@@ -795,7 +799,7 @@ inline void ExecPpuDot(Ppu &p, Memory &mem)
 				p.window_line   = 0;
 				p.window_active = false;
 				p.wy_triggered  = false;
-				p.vblank_irq_delay = 24;
+				p.vblank_irq_at = p.t_cycles + GB_VBLANK_IRQ_OFFSET;
 				S9xSGBOnPpuVBlank();
 			}
 			else
@@ -879,7 +883,7 @@ void PpuStep(Ppu &p, Memory &mem, int32_t tcycles)
 		p.mode_clock     = 0;
 		p.window_line    = 0;
 		p.stat_line_high = false;
-		p.vblank_irq_delay = 0;
+		p.vblank_irq_at = 0;
 		p.stat_irq_delay = 0;
 		p.draw_x         = 0;
 		p.window_active  = false;

--- a/sgb/gb_ppu.h
+++ b/sgb/gb_ppu.h
@@ -155,18 +155,11 @@ struct Ppu
 	// boundary, so it is never observed between dots and is not serialized.
 	bool     lyc_relatch = false;
 
-	// VBlank IRQ latency. Real DMG samples IF on the LAST M-cycle of the
-	// current instruction, so when LY transitions to 144 mid-instruction the
-	// current LDH/CP/JR can still observe LY=144 before IRQ dispatch. Our
-	// CPU runs instructions atomically and checks IF before the next step —
-	// firing IF.VBLANK on the dot LY hits 144 pre-empts the polling LDH that
-	// would have caught LY=144. Defer the IF.VBLANK set by N dots: when LY
-	// transitions, arm this counter; ExecPpuDot decrements it; when it hits
-	// 0, set IF.VBLANK. 24 dots ≈ one LDH+CP — enough for Altered Space's
-	// "wait until LY=$90" busy loop at $078A to capture LY=144 into A.
-	uint8_t  vblank_irq_delay = 0;
+	// CPU t_cycle at which VBlank IF latches (armed at LY=144, fires when the CPU
+	// catches up — a fixed dot defer misfired Sumou Fighter's bank-switched tile copy). 0 = unarmed, transient.
+	int64_t  vblank_irq_at = 0;
 
-	// STAT counterpart of vblank_irq_delay (PPU-originated edges only).
+	// STAT counterpart of the VBlank defer above (PPU-originated edges only).
 	uint8_t  stat_irq_delay = 0;
 
 	// Real panels never display the first frame after LCD enable — hold the prior one.


### PR DESCRIPTION
## Problem

**Sumou Fighter - Toukaidou Basho (Japan)** shows a stray "07" tile below the subtitle while the title screen scrolls in. Clean in Mesen and SameBoy.

## Root cause

Not a rendering bug — a one-tile VRAM corruption. The VBlank IRQ used a fixed 24-dot `IF.VBLANK` defer (`vblank_irq_delay`), which fires the ISR one instruction late relative to hardware whenever the CPU's interleave lag happens to be small. Sumou Fighter's title tile-copy loop re-selects ROM bank 2 before each copy; the late ISR (which leaves bank 1 selected) pre-empted the loop one instruction later than real DMG, so exactly one copy read its source from bank 1 — a "0" glyph ($11) where bank 2 holds blank ($40) — and the wrong tile stayed in the BG map.

## Fix

Replace the fixed dot countdown with a cycle-precise latch: at LY=144 the PPU arms `vblank_irq_at` (the LY=144 T-cycle − 12), and `IF.VBLANK` sets once the **CPU's own clock** reaches it. The IRQ now lands on the hardware-correct instruction boundary regardless of how far the CPU trails the PPU, and LY=144 polling loops (Altered Space's LY=$90 wait) still observe LY=144 before dispatch. The −12 lead compensates for `cpu->t_cycles` stamping instruction start while DMG samples IF on the last M-cycle.

## Validation

- After the fix, Sumou Fighter's full 210-frame tile-copy sequence (source pointer + ROM bank per call) is **byte-identical to a SameBoy per-instruction trace**; any offset in −8..−20 matches, −12 sits mid-window.
- 114-ROM signature sweep: ~26 sigs changed (expected for a global VBlank-timing shift). Spot-checked against SameBoy: **RoboCop and Initial D Gaiden render byte-identical**; Altered Space boots with the poll intact; Pit Fighter / Super Mario Land / Castlevania II show only benign demo-animation phase offsets.