### PR TITLE
fix(snes): Circuit USA glitchy menu - revert APU speedup hack to 2

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -4110,8 +4110,10 @@ void CMemory::ApplyROMFixes (void)
 		return;
 
 	// APU timing hacks
+	// 3 breaks the menu (snes9xgit/snes9x#563): the CGRAM upload races the
+	// game's own HDMA-disable and the armed CGADD HDMA folds the palette.
 	if (match_na("CIRCUIT USA"))
-		Timings.APUSpeedup = 3;
+		Timings.APUSpeedup = 2;
 
 	S9xAPUTimingSetSpeedup(Timings.APUSpeedup);
 


### PR DESCRIPTION
## Problem

**Circuit USA (Japan)** renders its main menu as torn black bars (upstream snes9xgit/snes9x#563, also listed on the SNESdev wiki under "DMA/HDMA timings are inaccurate"). Correct in bsnes/Mesen.

## Root cause

The menu palette arrives as a single 512-byte general DMA to $2122 (CGDATA). The game's code disables HDMA around that upload and lands it in VBlank on real hardware — but it's a race between two code paths, and the winner is decided by CPU↔APU handshake phase, i.e. by the `Timings.APUSpeedup` hack value this game has carried since 2017.

With the current value **3**, the upload fires at **V=97, mid-frame**, while the menu's CGRAM-gradient HDMA channels are still armed (ch1 writes CGADD=0 every scanline, ch2/3 stream colors 0/1). Every HBlank the HDMA interrupts the DMA and resets the CGRAM address, folding all 256 colors into entries $02–$79 — CGRAM ends up almost entirely $0000 and the menu tiles render black.

The hack was originally added as **2** in 2017 (`c226228`, which fixed exactly this menu). It was bumped to 3 during the 1.59 SMP-clock retune (`aeb0d4f7`) without re-checking the menu — upstream #563 was filed right after 1.60 shipped.

## Fix

Revert the hack value to 2. The speedup is a 256/(256−N) SPC clock trim (~0.4% per step, playback-rate compensated) and the hack matches only `CIRCUIT USA`, so there is no cross-game or audio impact.

## Validation (headless, full core)

- Palette upload lands at V≥225 (VBlank) with `PPU.HDMA=00` — verified for **every** one of ~100 uploads across a 14,000-frame attract run
- Menu pixel-matches the bsnes reference screenshot from upstream #563
- Gameplay (qualify race) frame-identical between speedup 2 and 3; boots, menus, and race all clean; no hangs
- Sweep of speedup 0/1/2/3: only 2 places the upload in VBlank (0→V=113, 1→V=108, 3→V=97, all corrupt the palette)