### PR TITLE
feat(snes): Nintendo Campus Challenge '92 event-cart support

### DIFF
--- a/external/imgui/snes9x_imgui.cpp
+++ b/external/imgui/snes9x_imgui.cpp
@@ -286,7 +286,7 @@ bool S9xImGuiDraw(int width, int height)
                               ImGui::DrawTextAlignment::BEGIN);
     }
 
-    if (Settings.PF94TimerDisplay == 1)
+    if (S9xEventTimerDisplay() == 1)
     {
         int secs = S9xPF94TimeRemaining();
         if (secs >= 0)

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -4104,8 +4104,73 @@ bool8 CMemory::match_id (const char *str)
 
 SPF94 PF94;
 
+// Campus Challenge '92 (EVENT-CC92). All four images are plain LoROM:
+//   $00-$1F:8000-FFFF  selected game (0x09=SMW, 0x05=F-Zero, 0x03=Pilotwings)
+//   $80-$9F:8000-FFFF  menu (Program), always mapped
+//   $20-$3F,$A0-$BF:8000-FFFF  DSP-1 (uPD7725), for Pilotwings
+//   $C0:0000 status read, $E0:0000 select write
+// SRAM ($70-$7D,$F0-$FF:0000-7FFF) is mapped once at detection.
+static void CC92MapGameWindow (void)
+{
+	int id = 0;
+	if (PF94.select == 0x09)      id = 1;
+	else if (PF94.select == 0x05) id = 2;
+	else if (PF94.select == 0x03) id = 3;
+	if (!PF94.romSize[id])
+		id = 0;
+
+	uint8	*game = Memory.ROM + PF94.romOff[id];
+	uint32	gmask = PF94.romSize[id] - 1;
+	uint8	*menu = Memory.ROM + PF94.romOff[0];
+	uint32	mmask = PF94.romSize[0] - 1;
+
+	for (uint32 bank = 0; bank <= 0x1f; bank++)
+	{
+		uint8 *gbase = game + ((bank << 15) & gmask) - 0x8000;
+		uint8 *mbase = menu + ((bank << 15) & mmask) - 0x8000;
+		for (uint32 blk = 8; blk <= 15; blk++)
+		{
+			uint32 lo = (bank << 4) | blk;   // $00-$1F: selected game
+			uint32 hi = lo + 0x800;          // $80-$9F: menu
+			Memory.Map[lo] = gbase;
+			Memory.Map[hi] = mbase;
+			Memory.WriteMap[lo] = Memory.WriteMap[hi] = (uint8 *) CMemory::MAP_NONE;
+			Memory.BlockIsROM[lo] = Memory.BlockIsROM[hi] = TRUE;
+			Memory.BlockIsRAM[lo] = Memory.BlockIsRAM[hi] = FALSE;
+		}
+	}
+
+	// DSP-1 window $20-$3F,$A0-$BF:8000-FFFF (M_DSP1_LOROM_S layout).
+	for (uint32 bank = 0x20; bank <= 0x3f; bank++)
+	{
+		for (uint32 blk = 8; blk <= 15; blk++)
+		{
+			uint32 lo = (bank << 4) | blk;   // $20-$3F
+			uint32 hi = lo + 0x800;          // $A0-$BF
+			Memory.Map[lo] = Memory.Map[hi] = (uint8 *) CMemory::MAP_DSP;
+			Memory.WriteMap[lo] = Memory.WriteMap[hi] = (uint8 *) CMemory::MAP_DSP;
+			Memory.BlockIsROM[lo] = Memory.BlockIsROM[hi] = FALSE;
+			Memory.BlockIsRAM[lo] = Memory.BlockIsRAM[hi] = FALSE;
+		}
+	}
+
+	// MCU registers: status read $C0:0000, select write $E0:0000.
+	Memory.Map[(0xC0 << 4) | 0]      = (uint8 *) CMemory::MAP_EVENT;
+	Memory.WriteMap[(0xC0 << 4) | 0] = (uint8 *) CMemory::MAP_NONE;
+	Memory.BlockIsROM[(0xC0 << 4) | 0] = Memory.BlockIsRAM[(0xC0 << 4) | 0] = FALSE;
+	Memory.Map[(0xE0 << 4) | 0]      = (uint8 *) CMemory::MAP_NONE;
+	Memory.WriteMap[(0xE0 << 4) | 0] = (uint8 *) CMemory::MAP_EVENT;
+	Memory.BlockIsROM[(0xE0 << 4) | 0] = Memory.BlockIsRAM[(0xE0 << 4) | 0] = FALSE;
+}
+
 static void PF94MapGameWindow (void)
 {
+	if (PF94.board == EVENT_BOARD_CC92)
+	{
+		CC92MapGameWindow();
+		return;
+	}
+
 	int id = 0;
 	if (PF94.select == 0x09)      id = 1;
 	else if (PF94.select == 0x0c) id = 2;
@@ -4165,6 +4230,17 @@ static void PF94MapGameWindow (void)
 
 uint8 S9xGetEvent (uint32 Address)
 {
+	// Campus Challenge '92: status register at $C0:0000 (only MAP_EVENT read).
+	if (PF94.board == EVENT_BOARD_CC92)
+	{
+		if (PF94.timerOn && (IPPU.TotalEmulatedFrames - PF94.timerStart) >= PF94.timerFrames)
+		{
+			PF94.timerOn = FALSE;
+			PF94.status |= 0x02;
+		}
+		return (PF94.status);
+	}
+
 	if ((Address & 0x7f0000) == 0x100000)
 	{
 		if (PF94.timerOn && (IPPU.TotalEmulatedFrames - PF94.timerStart) >= PF94.timerFrames)
@@ -4179,6 +4255,20 @@ uint8 S9xGetEvent (uint32 Address)
 
 void S9xSetEvent (uint8 Byte, uint32 Address)
 {
+	// Campus Challenge '92: select register at $E0:0000 (only MAP_EVENT write).
+	// 0x09=SMW (starts the session clock), 0x05=F-Zero, 0x03=Pilotwings.
+	if (PF94.board == EVENT_BOARD_CC92)
+	{
+		PF94.select = Byte;
+		if (Byte == 0x09 && !PF94.timerOn && !(PF94.status & 0x02))
+		{
+			PF94.timerOn = TRUE;
+			PF94.timerStart = IPPU.TotalEmulatedFrames;
+		}
+		PF94MapGameWindow();
+		return;
+	}
+
 	if ((Address & 0x7f0000) == 0x200000)
 	{
 		PF94.select = Byte;
@@ -4243,12 +4333,39 @@ int S9xPF94TimeRemaining (void)
 	return ((PF94.timerFrames - elapsed + fps - 1) / fps);
 }
 
+// The two event carts keep independent timer settings; these return the loaded
+// board's value (PowerFest '94 vs Campus Challenge '92), clamped to valid ranges.
+int S9xEventTimerMinutes (void)
+{
+	int m = (PF94.board == EVENT_BOARD_CC92) ? Settings.CC92TimerMinutes : Settings.PF94TimerMinutes;
+	return (m >= 3 && m <= 18) ? m : 6;
+}
+
+int S9xEventTimerDisplay (void)
+{
+	int d = (PF94.board == EVENT_BOARD_CC92) ? Settings.CC92TimerDisplay : Settings.PF94TimerDisplay;
+	return (d >= 0 && d <= 2) ? d : 0;
+}
+
 static uint32 PF94LoadAuxROM (const std::string &dir, const char *const *names, size_t count, uint8 *dst, uint32 maxSize);
 
 void S9xPF94LoadGames (void)
 {
 	if (!PF94.active)
 		return;
+
+	// Campus Challenge '92 is a single combined image (menu + 3 games already
+	// resident); there are no sibling ROMs to load. Just (re)arm the DSP-1 that
+	// Pilotwings uses, in the LoROM window the board maps it into.
+	if (PF94.board == EVENT_BOARD_CC92)
+	{
+		Settings.DSP = 1;
+		DSP0.boundary = 0xc000;
+		DSP0.maptype = M_DSP1_LOROM_S;
+		SetDSP = &DSP1SetByte;
+		GetDSP = &DSP1GetByte;
+		return;
+	}
 
 	std::string dir = Memory.ROMFilename;
 	size_t slash = dir.find_last_of("/\\");
@@ -4349,6 +4466,7 @@ void CMemory::ApplyROMFixes (void)
 	Settings.BlockInvalidVRAMAccess = Settings.BlockInvalidVRAMAccessMaster;
 
 	PF94.active = FALSE;
+	PF94.board  = EVENT_BOARD_PF94;
 
 	if (Settings.DisableGameSpecificHacks)
 		return;
@@ -4445,6 +4563,53 @@ void CMemory::ApplyROMFixes (void)
 		PF94.romSize[0] = CalculatedSize;
 
 		S9xPF94LoadGames();
+	}
+
+	// Nintendo Campus Challenge '92 (SNES-EVENT board) — the canonical combined
+	// cart image: 256KB menu (Program) + Super Mario World + F-Zero + Pilotwings
+	// (512KB each) = 0x1C0000. Identified by the menu's boot code at offset 0, its
+	// EVENT select write (STA $E00000 @ menu 0x6002), and the SMW segment header at
+	// 0x47FC0. Activates the EVENT-CC92 map: status $C0:0000, select $E0:0000, LoROM
+	// game window $00-$1F, menu forced $80-$9F, DSP-1 $20-$3F/$A0-$BF, board work
+	// RAM $70-$7D,$F0-$FF:0000-7FFF. select 0x09=SMW (starts the clock), 0x05=F-Zero,
+	// 0x03=Pilotwings.
+	static const uint8 cc92_boot[16] = { 0xA9, 0x00, 0x8F, 0x00, 0x00, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	static const uint8 cc92_reset[16] = { 0x78, 0x18, 0xFB, 0xC2, 0x30, 0xA2, 0xFF, 0x1F, 0x9A, 0xA0, 0x00, 0x00, 0x5A, 0x2B, 0xCA, 0x74 };
+	if (memcmp(ROM, cc92_reset, 16) == 0 &&
+		memcmp(ROM + 0x6000, cc92_boot, 6) == 0 &&
+		memcmp(ROM + 0x47FC0, "SUPER MARIOWORLD", 16) == 0)
+	{
+		// Board work RAM (LoROM SRAM) at $70-$7D,$F0-$FD:0000-7FFF.
+		SRAMSize = 3;
+		SRAMMask = ((1 << (SRAMSize + 3)) * 128) - 1;
+		for (uint32 bank = 0x70; bank <= 0x7d; bank++)
+		{
+			for (uint32 blk = 0; blk <= 7; blk++)
+			{
+				uint32 i = (bank << 4) | blk;
+				Map[i] = Map[i + 0x800] = (uint8 *) MAP_LOROM_SRAM;
+				WriteMap[i] = WriteMap[i + 0x800] = (uint8 *) MAP_LOROM_SRAM;
+				BlockIsRAM[i] = BlockIsRAM[i + 0x800] = TRUE;
+				BlockIsROM[i] = BlockIsROM[i + 0x800] = FALSE;
+			}
+		}
+
+		PF94.active = TRUE;
+		PF94.board  = EVENT_BOARD_CC92;
+		PF94.select = 0;
+		PF94.status = 0;
+		PF94.timerOn = FALSE;
+		int cc92min = (Settings.CC92TimerMinutes >= 3 && Settings.CC92TimerMinutes <= 18) ? Settings.CC92TimerMinutes : 6;
+		PF94.timerFrames = cc92min * 60 * (Settings.PAL ? 50 : 60);
+		PF94.romOff[0] = 0x000000; PF94.romSize[0] = 0x40000;   // menu (Program)
+		PF94.romOff[1] = 0x040000; PF94.romSize[1] = 0x80000;   // Super Mario World
+		PF94.romOff[2] = 0x0C0000; PF94.romSize[2] = 0x80000;   // F-Zero
+		PF94.romOff[3] = 0x140000; PF94.romSize[3] = 0x80000;   // Pilotwings
+
+		S9xPF94LoadGames();   // CC92 branch arms the DSP-1
+		PF94MapGameWindow();  // CC92 branch builds the window / DSP / registers
+
+		printf("Nintendo Campus Challenge '92 board active (menu + SMW + F-Zero + Pilotwings).\n");
 	}
 
 	// PowerFest '94 - Super Mario Bros. - The Lost Levels (event cart sub-ROM),

--- a/memmap.h
+++ b/memmap.h
@@ -225,12 +225,19 @@ bool8 S9xSGBBIOSAvailable(uint8 mode, const char *gb_rom_path);
 // from the SNES/BS-X/Sufami load paths.
 bool S9xRomBytesAreGb(const uint8 *rom, int32 size);
 
-// PowerFest '94 (MX15001) event board: status/select registers, session timer,
-// board work-RAM and the four-image game window. Active only when the scoring
-// (master program) ROM is the loaded cart.
+// NEC uPD78214 SNES-EVENT board: status/select registers, session timer,
+// board work-RAM and the four-image game window. Shared by the two known
+// event carts, distinguished by SPF94::board:
+//   EVENT_BOARD_PF94 — PowerFest '94  (status $10:6000, select $20:6000)
+//   EVENT_BOARD_CC92 — Campus Challenge '92 (status $C0:0000, select $E0:0000)
+// Active only when the event cart (master program / combined image) is loaded.
+#define EVENT_BOARD_PF94	0
+#define EVENT_BOARD_CC92	1
+
 struct SPF94
 {
 	bool8	active;
+	uint8	board;
 	uint8	select, status;
 	bool8	timerOn;
 	uint32	timerStart, timerFrames;
@@ -245,6 +252,8 @@ void S9xPF94Reset (void);
 void S9xPF94PostLoadState (void);
 void S9xPF94LoadGames (void);
 int S9xPF94TimeRemaining (void);
+int S9xEventTimerMinutes (void);
+int S9xEventTimerDisplay (void);
 
 enum s9xwrap_t
 {

--- a/snes9x.h
+++ b/snes9x.h
@@ -344,6 +344,8 @@ struct SSettings
     int OverclockMode;
     int PF94TimerMinutes;
     int PF94TimerDisplay;
+    int CC92TimerMinutes;
+    int CC92TimerDisplay;
 	int	OneClockCycle;
 	int	OneSlowClockCycle;
 	int	TwoClockCycles;

--- a/win32/wconfig.cpp
+++ b/win32/wconfig.cpp
@@ -703,6 +703,12 @@ void WinPostLoad(ConfigFile& conf)
     if (Settings.PF94TimerDisplay < 0 || Settings.PF94TimerDisplay > 2)
         Settings.PF94TimerDisplay = 0;
 
+    if (Settings.CC92TimerMinutes < 3 || Settings.CC92TimerMinutes > 18)
+        Settings.CC92TimerMinutes = 6;
+
+    if (Settings.CC92TimerDisplay < 0 || Settings.CC92TimerDisplay > 2)
+        Settings.CC92TimerDisplay = 0;
+
     switch (Settings.OverclockMode)
     {
         default:
@@ -1078,6 +1084,8 @@ void WinRegisterConfigItems()
     AddBoolC("SeparateEchoBuffer", Settings.SeparateEchoBuffer, false, "Separate echo buffer from APU ram. For old hacks only.");
     AddUIntC("PowerFest94TimeLimit", Settings.PF94TimerMinutes, 6, "PowerFest '94 event cart session length in minutes (DIP switches, 3-18)");
     AddUIntC("PowerFest94TimerDisplay", Settings.PF94TimerDisplay, 0, "PowerFest '94 session timer display: 0=none, 1=on screen, 2=window title");
+    AddUIntC("CampusChallenge92TimeLimit", Settings.CC92TimerMinutes, 6, "Campus Challenge '92 event cart session length in minutes (DIP switches, 3-18)");
+    AddUIntC("CampusChallenge92TimerDisplay", Settings.CC92TimerDisplay, 0, "Campus Challenge '92 session timer display: 0=none, 1=on screen, 2=window title");
 #undef CATEGORY
 
 #ifdef RETROACHIEVEMENTS_SUPPORT

--- a/win32/win32_display.cpp
+++ b/win32/win32_display.cpp
@@ -355,7 +355,7 @@ bool8 S9xContinueUpdate(int Width, int Height)
 // do the actual rendering of a frame
 bool8 S9xDeinitUpdate (int Width, int Height)
 {
-	if (PF94.active && Settings.PF94TimerDisplay == 2)
+	if (PF94.active && S9xEventTimerDisplay() == 2)
 	{
 		static int lastShownSecs = -2;
 		int secs = S9xPF94TimeRemaining();

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -777,7 +777,7 @@ void S9xRestoreWindowTitle ()
         _tcscat(buf, TEXT(" [Hardcore]"));
 #endif
 
-    if (PF94.active && Settings.PF94TimerDisplay == 2)
+    if (PF94.active && S9xEventTimerDisplay() == 2)
     {
         int pf94secs = S9xPF94TimeRemaining();
         if (pf94secs >= 0)
@@ -6788,24 +6788,35 @@ INT_PTR CALLBACK DlgEmulatorHacksProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM
         CheckDlgButton(hDlg, IDC_ALLOW_EXE_ICON, GUI.ExeIconRewriteOK);
 
         {
+            // The event-cart rows serve whichever board is loaded; relabel and
+            // bind them to that board's own saved timer settings.
+            const TCHAR *evName = (PF94.board == EVENT_BOARD_CC92) ? TEXT("Campus Challenge '92") : TEXT("PowerFest '94");
+            TCHAR lbl[64];
+            _sntprintf(lbl, 64, TEXT("%s Time Limit:"), evName);
+            SetDlgItemText(hDlg, IDC_PF94_TIME_LABEL, lbl);
+            _sntprintf(lbl, 64, TEXT("%s Timer:"), evName);
+            SetDlgItemText(hDlg, IDC_PF94_TIMER_SHOW_LABEL, lbl);
+
             TCHAR pf94buf[16];
             for (int m = 3; m <= 18; m++)
             {
                 _sntprintf(pf94buf, 16, TEXT("%d minutes"), m);
                 SendDlgItemMessage(hDlg, IDC_PF94_TIME, CB_ADDSTRING, 0, (LPARAM)pf94buf);
             }
-            int pf94min = (Settings.PF94TimerMinutes >= 3 && Settings.PF94TimerMinutes <= 18) ? Settings.PF94TimerMinutes : 6;
-            SendDlgItemMessage(hDlg, IDC_PF94_TIME, CB_SETCURSEL, pf94min - 3, 0);
+            SendDlgItemMessage(hDlg, IDC_PF94_TIME, CB_SETCURSEL, S9xEventTimerMinutes() - 3, 0);
+
+            CreateToolTip(IDC_PF94_TIME, hDlg, (PF94.board == EVENT_BOARD_CC92)
+                ? TEXT("Session length for the Campus Challenge '92 competition\ncart (the board's DIP switches, 3-18 minutes).\nTakes effect immediately, even mid-session.")
+                : TEXT("Session length for the PowerFest '94 competition\ncart (the board's DIP switches, 3-18 minutes).\nTakes effect immediately, even mid-session."));
         }
         ShowWindow(GetDlgItem(hDlg, IDC_PF94_TIME), PF94.active ? SW_SHOW : SW_HIDE);
         ShowWindow(GetDlgItem(hDlg, IDC_PF94_TIME_LABEL), PF94.active ? SW_SHOW : SW_HIDE);
         SendDlgItemMessage(hDlg, IDC_PF94_TIMER_SHOW, CB_ADDSTRING, 0, (LPARAM)TEXT("None"));
         SendDlgItemMessage(hDlg, IDC_PF94_TIMER_SHOW, CB_ADDSTRING, 0, (LPARAM)TEXT("On Screen"));
         SendDlgItemMessage(hDlg, IDC_PF94_TIMER_SHOW, CB_ADDSTRING, 0, (LPARAM)TEXT("Title Screen"));
-        SendDlgItemMessage(hDlg, IDC_PF94_TIMER_SHOW, CB_SETCURSEL, (Settings.PF94TimerDisplay >= 0 && Settings.PF94TimerDisplay <= 2) ? Settings.PF94TimerDisplay : 0, 0);
+        SendDlgItemMessage(hDlg, IDC_PF94_TIMER_SHOW, CB_SETCURSEL, S9xEventTimerDisplay(), 0);
         ShowWindow(GetDlgItem(hDlg, IDC_PF94_TIMER_SHOW), PF94.active ? SW_SHOW : SW_HIDE);
         ShowWindow(GetDlgItem(hDlg, IDC_PF94_TIMER_SHOW_LABEL), PF94.active ? SW_SHOW : SW_HIDE);
-        CreateToolTip(IDC_PF94_TIME, hDlg, TEXT("Session length for the PowerFest '94 competition\ncart (the board's DIP switches, 3-18 minutes).\nTakes effect immediately, even mid-session."));
 
         CreateToolTip(IDC_ALLOW_EXE_ICON, hDlg, TEXT("When checked, choosing a logo also overwrites\nthe icon embedded in the SuperSnes9x .exe on disk,\nso it shows in Explorer, on shortcuts and the\ntaskbar. SuperSnes9x will restart to apply.\nWhen unchecked, only the in-app icon changes."));
 
@@ -6862,10 +6873,22 @@ INT_PTR CALLBACK DlgEmulatorHacksProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM
             Settings.MaxSpriteTilesPerLine = IsDlgButtonChecked(hDlg, IDC_NO_SPRITE_LIMIT) ? 128 : 34;
             GUI.ExeIconRewriteOK = IsDlgButtonChecked(hDlg, IDC_ALLOW_EXE_ICON);
 
-            Settings.PF94TimerMinutes = 3 + (int)SendDlgItemMessage(hDlg, IDC_PF94_TIME, CB_GETCURSEL, 0, 0);
-            if (PF94.active)
-                PF94.timerFrames = Settings.PF94TimerMinutes * 60 * (Settings.PAL ? 50 : 60);
-            Settings.PF94TimerDisplay = (int)SendDlgItemMessage(hDlg, IDC_PF94_TIMER_SHOW, CB_GETCURSEL, 0, 0);
+            {
+                int evmin  = 3 + (int)SendDlgItemMessage(hDlg, IDC_PF94_TIME, CB_GETCURSEL, 0, 0);
+                int evdisp = (int)SendDlgItemMessage(hDlg, IDC_PF94_TIMER_SHOW, CB_GETCURSEL, 0, 0);
+                if (PF94.board == EVENT_BOARD_CC92)
+                {
+                    Settings.CC92TimerMinutes = evmin;
+                    Settings.CC92TimerDisplay = evdisp;
+                }
+                else
+                {
+                    Settings.PF94TimerMinutes = evmin;
+                    Settings.PF94TimerDisplay = evdisp;
+                }
+                if (PF94.active)
+                    PF94.timerFrames = evmin * 60 * (Settings.PAL ? 50 : 60);
+            }
             S9xRestoreWindowTitle();
 
             switch (Settings.OverclockMode)


### PR DESCRIPTION
## Nintendo Campus Challenge '92 (SNES-EVENT board)

Adds support for the **Nintendo Campus Challenge 1992** competition cart — the sibling of PowerFest '94, built on the same NEC µPD78214 SNES-EVENT board (the `EVENT-CC92` variant). Loading the canonical combined cart image boots the menu and chains **Super Mario World → F-Zero → Pilotwings** under a session timer, like the real competition.

### How it works
Reuses PowerFest '94's event machinery via a `board` discriminator on `SPF94`, leaving the existing PF94 path untouched:

- **Memory map** (`CC92MapGameWindow`): LoROM game window `$00–$1F:8000–FFFF` (selected game), menu forced in `$80–$9F`, DSP-1 (µPD7725, for Pilotwings) at `$20–$3F/$A0–$BF`, board work RAM `$70–$7D/$F0–$FF:0000–7FFF`.
- **MCU registers**: status read `$C0:0000`, select write `$E0:0000` (`0x09`=SMW and starts the session clock, `0x05`=F-Zero, `0x03`=Pilotwings).
- **Detection**: the canonical combined image (256K menu + 3×512K games = `0x1C0000`) is recognized by content signatures (menu boot code, its `STA $E00000`, the SMW segment header) and mapped directly — no sibling files.

Board behavior follows bsnes's `EVENT-CC92` manifest + event HLE.

### Per-board timer settings
The two event carts now keep **independent** timer state. Added `CC92TimerMinutes`/`CC92TimerDisplay` (separate conf keys `CampusChallenge92TimeLimit`/`...TimerDisplay`), a board-aware getter pair (`S9xEventTimerMinutes`/`S9xEventTimerDisplay`) that every timer consumer routes through, and the config dialog relabels per loaded cart ("Campus Challenge '92 Time Limit"/"Timer").

### Status
- ✅ Boots — menu title screen renders, session-timer OSD runs.
- ⏳ Menu → game launch flow and Pilotwings/DSP-1 pending hardware-accurate verification.