### PR TITLE
feat(snes): NFL Football (Europe) (Proto) SRAM/PAL mapping

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2698,6 +2698,24 @@ void CMemory::InitROM (void)
 
 	ParseSNESHeader(RomHeader);
 
+	// NFL Football (Europe) (Proto) - Sculptured Software, board SHVC-4PV5B-01
+	// (LoROM, 256Kbit battery SRAM, PAL-only). The proto ships a junk internal
+	// header, so auto-detection maps it LoROM with a garbage SRAM size; the game
+	// reads open bus / wrapped save RAM and runs off the rails - glitched menus,
+	// black in-game, crashes. Pin the real board: 32KB SRAM + PAL region.
+	static const uint8	nfl_boot[16] =
+		{ 0x5C, 0x92, 0x81, 0x81, 0x78, 0x18, 0xFB, 0xD8, 0x5C, 0x0C, 0x80, 0x80, 0xC2, 0x30, 0x5C, 0x78 };
+	if (CalculatedSize == 0x200000 &&
+		memcmp(ROM, nfl_boot, sizeof(nfl_boot)) == 0 &&
+		memcmp(ROM + 0x7FC0, "SDEBUG1", 7) == 0)
+	{
+		ROMType   = 0x00;
+		ROMSpeed  = 0x20;
+		ROMSize   = 0x0B;
+		SRAMSize  = 5;
+		ROMRegion = 2;
+	}
+
 	//// Detect and initialize chips
 	//// detection codes are compatible with NSRT
 


### PR DESCRIPTION
## Problem

*NFL Football (Europe) (Proto)* (Sculptured Software, board **SHVC-4PV5B-01**) is broken in snes9x: glitchy menus, a **black screen once you go in-game**, and frequent crashes.

## Root cause

The prototype ships a **junk internal cartridge header** — both the LoROM (`$7FC0`) and HiROM (`$FFC0`) header offsets are `FF`-filler (the only readable text is the shared "SDEBUG1" debug-engine title). Auto-detection gets the **map right** (LoROM — that's why the menus render at all) but reads a garbage SRAM-size byte (`0xFF`), which collapses to a tiny wrapped/undefined SRAM mask, and it defaults to **NTSC**. The game then reads open-bus / wrapped save RAM and runs off the rails.

Databases list the board as "HiROM", but forcing HiROM on this dump renders **completely black** (the reset `JML $81:8192` resolves to different ROM bytes per map) — LoROM is correct. The real board is **LoROM + 256 kbit (32 KB) battery SRAM + PAL**.

## Fix

In `CMemory::InitROM`, match this exact ROM by a precise signature (2 MB size + its unique 16-byte boot table at `ROM[0]` + the "SDEBUG1" title) and pin the real board: `SRAMSize = 5` (32 KB), `ROMRegion = 2` (PAL), with clean ROM type/speed/size. The LoROM map is left as detected. No other ROM can match the signature. 18 lines, isolated to one game.

## Verification

- Map stays **LoROM**, region is now **PAL**, SRAM mask is a proper `0x7FFF` (32 KB).
- Menus render cleanly; navigating into EXHIBITION → GAME OPTIONS works.
- **In-game renders perfectly** — full Mode 7 perspective field (stadium/crowd/players) with all HDMA effects, no black screen, no crash (confirmed on hardware-accurate savestate playback).

Note: with `NUMBER OF PLAYERS = 0` (the default) PLAY GAME runs a CPU-vs-CPU attract demo that any button ends — that's the game's design, not related to this fix.