### PR TITLE
fix(snes): latch pending timer IRQ on $4211 read (Traverse birthday-screen freeze)

### DIFF
--- a/ppu.cpp
+++ b/ppu.cpp
@@ -1676,6 +1676,15 @@ uint8 S9xGetCPU (uint16 Address)
 				return ((byte & 0x80) | (OpenBus & 0x70) | Model->_5A22);
 
 			case 0x4211: // TIMEUP
+				// The main loop only latches CPU.IRQLine at opcode boundaries, so a $4211 read landing after the
+				// H/V-timer trigger cycle but before that boundary would miss the IRQ; latch it here as hardware would
+				// (Traverse: Starlight & Prairie polls $4210 as a 16-bit read and waits on this flag in bit 15).
+				if (!CPU.IRQLine && Timings.NextIRQTimer != 0x0fffffff &&
+					CPU.Cycles >= Timings.NextIRQTimer)
+				{
+					S9xUpdateIRQPositions(false);
+					CPU.IRQLine = TRUE;
+				}
 				byte = 0;
 				if (CPU.IRQLine)
 				{


### PR DESCRIPTION
## Problem

*Traverse - Starlight & Prairie (Japan)* freezes right after the birthday-entry screen — the zodiac-creature background loads but the **BLOOD-TYPE** selection menu never draws. Reported upstream as snes9xgit/snes9x#540 and snes9xgit/snes9x#614; it's a regression that appeared after 1.55 (the "calculate next IRQ time in advance" rework) and also affects current upstream. Mesen/hardware are fine.

## Root cause

The game arms an H+V-timer **IRQ** (`HTIME=0`, `VTIME=2`, `$4200=$B1`, `I=0`) and its vsync-wait at `$C0:CB36` is a **16-bit** `LDA $4210` + `BPL`. In 16-bit accumulator mode that reads a *word* — low byte `$4210` (NMI flag), high byte `$4211` (TIMEUP/IRQ flag) — so `BPL` tests **bit 15 = the timer-IRQ flag**, not the NMI flag. The loop is meant to catch the IRQ latch with its own read.

On hardware the IRQ line goes high mid-instruction (trigger dot ≈ cycle 10) and the loop's `$4211` half-read catches it before the CPU services the interrupt. But the main loop only latches `CPU.IRQLine` at **opcode boundaries** (the next IRQ cycle is computed in advance), so the loop's mid-`LDA` `$4211` read (≈ cycle 14) saw `IRQLine = 0` even though the trigger cycle (10) had already passed. The IRQ was then serviced by the game's handler, which reads/clears `$4211` first — so the polling loop never observed the flag and spun forever.

## Fix

In the `$4211` (TIMEUP) read, pump the IRQ state to the current cycle exactly as the main loop does, so a mid-instruction poll observes an IRQ whose trigger cycle has already elapsed:

```c
if (!CPU.IRQLine && Timings.NextIRQTimer != 0x0fffffff &&
    CPU.Cycles >= Timings.NextIRQTimer)
{
    S9xUpdateIRQPositions(false);
    CPU.IRQLine = TRUE;
}
```

This is a strict no-op for the normal case (an IRQ handler reads `$4211` with `IRQLine` already set) and adds no new state (savestate-safe).

## Testing

- Traverse now flows through the full character-creation sequence that used to freeze: **BLOOD-TYPE → PET-KIND → COLOR**, verified end-to-end from a cold boot.
- Regression sweep with a headless full-core harness (framebuffer-signature diff, baseline vs fixed):
  - 139-ROM, 900-frame boot sweep: **0 differences**.
  - All 25 SNES ROMs, 3000 frames, input driven into gameplay: **0 differences**.
  - 10 IRQ-heavy titles driven into gameplay (SMW status-bar split; Super Mario Kart / Yoshi's Safari / Circuit USA Mode-7; SF2 Turbo; Super SF2; RoboCop vs The Terminator; The Firemen; Yoshi's Island; MK2): **byte-identical framebuffers**.

Fixes snes9xgit/snes9x#540, snes9xgit/snes9x#614.
