### PR TITLE
SuperFX: cycle-accurate GSU timing; fix Winter Gold skier garble (upstream #533)

### DIFF
--- a/fxemu.cpp
+++ b/fxemu.cpp
@@ -33,6 +33,16 @@ void S9xResetSuperFX (void)
 	SuperFX.oneLineDone = FALSE;
 	SuperFX.vFlags = 0;
 	CPU.IRQExternal = FALSE;
+
+	// Cycle-accurate GSU timing (default). FXCYC=0 selects the legacy flat
+	// instruction budget for A/B comparison.
+	{
+		const char	*e = getenv("FXCYC");
+		g_gsuCycleMode = (e && *e == '0') ? 0 : 1;
+		g_gsuCycles = 0;
+		g_gsuCacheMask = 0;
+	}
+
 	FxReset(&SuperFX);
 }
 
@@ -144,11 +154,61 @@ void S9xSuperFXExec (void)
 {
 	if ((Memory.FillRAM[0x3000 + GSU_SFR] & FLG_G) && (Memory.FillRAM[0x3000 + GSU_SCMR] & 0x18) != 0)
 	{
+		if (g_gsuCycleMode)
+		{
+			// Real cycle costs: the GSU runs at the master clock (21.4MHz,
+			// CLSR=1) or half of it (10.7MHz, CLSR=0). Costs carry the CLSR
+			// scaling, so the per-line budget is a flat master-cycle slice.
+			int	cs  = Memory.FillRAM[0x3000 + GSU_CLSR] & 1;
+			int	ms0 = Memory.FillRAM[0x3000 + GSU_CFGR] & 0x20;
+
+			g_gsuCostCache = cs ? 1 : 2;
+			g_gsuCostMem   = cs ? 5 : 6;
+			g_gsuCostFmult = (ms0 ? 3 : 7) * (cs ? 1 : 2);
+			g_gsuCostMult  = ms0 ? 1 : 2;
+
+			uint32	budget = (uint32) (Timings.H_Max > 0 ? Timings.H_Max : 1364);
+			FxEmulate(budget * Settings.SuperFXClockMultiplier / 100);
+		}
+		else
 		FxEmulate(((Memory.FillRAM[0x3000 + GSU_CLSR] & 1) ? (SuperFX.speedPerLine * 5 / 2) : SuperFX.speedPerLine) * Settings.SuperFXClockMultiplier / 100);
 
 		uint16 GSUStatus = Memory.FillRAM[0x3000 + GSU_SFR] | (Memory.FillRAM[0x3000 + GSU_SFR + 1] << 8);
 		if ((GSUStatus & (FLG_G | FLG_IRQ)) == FLG_IRQ)
 			CPU.IRQExternal = TRUE;
+	}
+
+	// Winter Gold (#533): at the race-start pose switch, the game polls the
+	// GSU-published pose cel at $70:EBC0 once per frame (V~159) and commits the
+	// skier arrangement from it. On hardware the heavy course-load render keeps
+	// the GSU busy one frame longer than the batch model, so that poll still
+	// reads 0 ("not ready" -> skier parked, one blank frame) where snes9x already
+	// shows the published cel ("ready" -> a stale arrangement is committed over
+	// the new tiles = the garbled skier). Delay CPU visibility of the 0->nonzero
+	// publish transition by one frame (312 lines), matching measured hardware
+	// behavior (verified frame-by-frame against Mesen).
+	if (strncmp(Memory.ROMName, "FX SKIING", 9) == 0 && GSU.pvRam)
+	{
+		static int32	holdLines = 0;
+		static uint8	prevCel = 0;
+		uint8			*cel = &GSU.pvRam[0xEBC0];
+
+		if (holdLines > 0)
+		{
+			if (*cel != 0)  // capture any republish during the hold
+				prevCel = *cel;
+			*cel = 0;
+			if (--holdLines == 0)
+				*cel = prevCel;
+		}
+		else if (prevCel == 0 && *cel != 0)
+		{
+			prevCel = *cel;
+			*cel = 0;
+			holdLines = 312;
+		}
+		else
+			prevCel = *cel;
 	}
 }
 
@@ -567,6 +627,7 @@ static void FxFlushCache (void)
 	GSU.vCacheFlags = 0;
 	GSU.vCacheBaseReg = 0;
 	GSU.bCacheActive = FALSE;
+	g_gsuCacheMask = 0;
 	//GSU.vPipe = 0x1;
 }
 
@@ -575,6 +636,7 @@ void fx_flushCache (void)
 	//fx_restoreCache();
 	GSU.vCacheFlags = 0;
 	GSU.bCacheActive = FALSE;
+	g_gsuCacheMask = 0;
 }
 
 /*

--- a/fxinst.cpp
+++ b/fxinst.cpp
@@ -11,6 +11,15 @@
 // Set this define if you wish the plot instruction to check for y-pos limits (I don't think it's nessecary)
 #define CHECK_LIMITS
 
+// Cycle-accurate GSU timing state (see fxinst.h)
+uint32	g_gsuCycles    = 0;
+uint32	g_gsuCacheMask = 0;
+uint32	g_gsuCostCache = 1;
+uint32	g_gsuCostMem   = 5;
+uint32	g_gsuCostFmult = 7;
+uint32	g_gsuCostMult  = 2;
+uint8	g_gsuCycleMode = 1;
+
 
 /*
  Codes used:
@@ -393,6 +402,7 @@ static void fx_with_r15 (void)
 
 // 30-3b - stw (rn) - store word
 #define FX_STW(reg) \
+	FX_CYC(g_gsuCostMem << 1); \
 	GSU.vLastRamAdr = GSU.avReg[reg]; \
 	RAM(GSU.avReg[reg]) = (uint8) SREG; \
 	RAM(GSU.avReg[reg] ^ 1) = (uint8) (SREG >> 8); \
@@ -461,6 +471,7 @@ static void fx_stw_r11 (void)
 
 // 30-3b (ALT1) - stb (rn) - store byte
 #define FX_STB(reg) \
+	FX_CYC(g_gsuCostMem); \
 	GSU.vLastRamAdr = GSU.avReg[reg]; \
 	RAM(GSU.avReg[reg]) = (uint8) SREG; \
 	CLRFLAGS; \
@@ -564,6 +575,7 @@ static void fx_alt3 (void)
 
 // 40-4b - ldw (rn) - load word from RAM
 #define FX_LDW(reg) \
+	FX_CYC(g_gsuCostMem << 1); \
 	uint32	v; \
 	GSU.vLastRamAdr = GSU.avReg[reg]; \
 	v = (uint32) RAM(GSU.avReg[reg]); \
@@ -635,6 +647,7 @@ static void fx_ldw_r11 (void)
 
 // 40-4b (ALT1) - ldb (rn) - load byte
 #define FX_LDB(reg) \
+	FX_CYC(g_gsuCostMem); \
 	uint32	v; \
 	GSU.vLastRamAdr = GSU.avReg[reg]; \
 	v = (uint32) RAM(GSU.avReg[reg]); \
@@ -706,6 +719,7 @@ static void fx_ldb_r11 (void)
 // 4c - plot - plot pixel with R1, R2 as x, y and the color register as the color
 static void fx_plot_2bit (void)
 {
+	FX_CYC(((g_gsuCostMem << 1) >> 3) + 1);
 	uint32	x = USEX8(R1);
 	uint32	y = USEX8(R2);
 	uint8	*a;
@@ -745,6 +759,7 @@ static void fx_plot_2bit (void)
 // 4c (ALT1) - rpix - read color of the pixel with R1, R2 as x, y
 static void fx_rpix_2bit (void)
 {
+	FX_CYC(g_gsuCostMem << 1);
 	uint32	x = USEX8(R1);
 	uint32	y = USEX8(R2);
 	uint8	*a;
@@ -770,6 +785,7 @@ static void fx_rpix_2bit (void)
 // 4c - plot - plot pixel with R1, R2 as x, y and the color register as the color
 static void fx_plot_4bit (void)
 {
+	FX_CYC(((g_gsuCostMem << 2) >> 3) + 1);
 	uint32	x = USEX8(R1);
 	uint32	y = USEX8(R2);
 	uint8	*a;
@@ -819,6 +835,7 @@ static void fx_plot_4bit (void)
 // 4c (ALT1) - rpix - read color of the pixel with R1, R2 as x, y
 static void fx_rpix_4bit (void)
 {
+	FX_CYC(g_gsuCostMem << 2);
 	uint32	x = USEX8(R1);
 	uint32	y = USEX8(R2);
 	uint8	*a;
@@ -846,6 +863,7 @@ static void fx_rpix_4bit (void)
 // 4c - plot - plot pixel with R1, R2 as x, y and the color register as the color
 static void fx_plot_8bit (void)
 {
+	FX_CYC(g_gsuCostMem + 1);
 	uint32	x = USEX8(R1);
 	uint32	y = USEX8(R2);
 	uint8	*a;
@@ -917,6 +935,7 @@ static void fx_plot_8bit (void)
 // 4c (ALT1) - rpix - read color of the pixel with R1, R2 as x, y
 static void fx_rpix_8bit (void)
 {
+	FX_CYC(g_gsuCostMem << 3);
 	uint32	x = USEX8(R1);
 	uint32	y = USEX8(R2);
 	uint8	*a;
@@ -2112,6 +2131,7 @@ static void fx_bic_i15 (void)
 
 // 80-8f - mult rn - 8 bit to 16 bit signed multiply, register * register
 #define FX_MULT(reg) \
+	FX_CYC(g_gsuCostMult); \
 	uint32	v = (uint32) (SEX8(SREG) * SEX8(GSU.avReg[reg])); \
 	R15++; \
 	DREG = v; \
@@ -2202,6 +2222,7 @@ static void fx_mult_r15 (void)
 
 // 80-8f (ALT1) - umult rn - 8 bit to 16 bit unsigned multiply, register * register
 #define FX_UMULT(reg) \
+	FX_CYC(g_gsuCostMult); \
 	uint32	v = USEX8(SREG) * USEX8(GSU.avReg[reg]); \
 	R15++; \
 	DREG = v; \
@@ -2292,6 +2313,7 @@ static void fx_umult_r15 (void)
 
 // 80-8f (ALT2) - mult #n - 8 bit to 16 bit signed multiply, register * immediate
 #define FX_MULT_I(imm) \
+	FX_CYC(g_gsuCostMult); \
 	uint32	v = (uint32) (SEX8(SREG) * ((int32) imm)); \
 	R15++; \
 	DREG = v; \
@@ -2382,6 +2404,7 @@ static void fx_mult_i15 (void)
 
 // 80-8f (ALT3) - umult #n - 8 bit to 16 bit unsigned multiply, register * immediate
 #define FX_UMULT_I(imm) \
+	FX_CYC(g_gsuCostMult); \
 	uint32	v = USEX8(SREG) * ((uint32) imm); \
 	R15++; \
 	DREG = v; \
@@ -2473,6 +2496,7 @@ static void fx_umult_i15 (void)
 // 90 - sbk - store word to last accessed RAM address
 static void fx_sbk (void)
 {
+	FX_CYC(g_gsuCostMem << 1);
 	RAM(GSU.vLastRamAdr) = (uint8) SREG;
 	RAM(GSU.vLastRamAdr ^ 1) = (uint8) (SREG >> 8);
 	CLRFLAGS;
@@ -2651,6 +2675,7 @@ static void fx_lob (void)
 // 9f - fmult - 16 bit to 32 bit signed multiplication, upper 16 bits only
 static void fx_fmult (void)
 {
+	FX_CYC(g_gsuCostFmult);
 	uint32	v;
 	uint32	c = (uint32) (SEX16(SREG) * SEX16(R6));
 	v = c >> 16;
@@ -2666,6 +2691,7 @@ static void fx_fmult (void)
 // 9f (ALT1) - lmult - 16 bit to 32 bit signed multiplication
 static void fx_lmult (void)
 {
+	FX_CYC(g_gsuCostFmult);
 	uint32	v;
 	uint32	c = (uint32) (SEX16(SREG) * SEX16(R6));
 	R4 = c;
@@ -2772,6 +2798,7 @@ static void fx_ibt_r15 (void)
 
 // a0-af (ALT1) - lms rn, (yy) - load word from RAM (short address)
 #define FX_LMS(reg) \
+	FX_CYC(g_gsuCostMem << 1); \
 	GSU.vLastRamAdr = ((uint32) PIPE) << 1; \
 	R15++; \
 	FETCHPIPE; \
@@ -2865,6 +2892,7 @@ static void fx_lms_r15 (void)
 // XXX: If rn == r15, is the value of r15 before or after the extra byte is read ?
 #define FX_SMS(reg) \
 	uint32	v = GSU.avReg[reg]; \
+	FX_CYC(g_gsuCostMem << 1); \
 	GSU.vLastRamAdr = ((uint32) PIPE) << 1; \
 	R15++; \
 	FETCHPIPE; \
@@ -3619,6 +3647,8 @@ static void fx_dec_r14 (void)
 static void fx_getb (void)
 {
 	uint32	v;
+
+	FX_CYC(g_gsuCostMem);
 #ifndef FX_DO_ROMBUFFER
 	v = (uint32) ROM(R14);
 #else
@@ -3634,6 +3664,8 @@ static void fx_getb (void)
 static void fx_getbh (void)
 {
 	uint32	v;
+
+	FX_CYC(g_gsuCostMem);
 #ifndef FX_DO_ROMBUFFER
 	uint32	c = (uint32) ROM(R14);
 #else
@@ -3650,6 +3682,8 @@ static void fx_getbh (void)
 static void fx_getbl (void)
 {
 	uint32	v;
+
+	FX_CYC(g_gsuCostMem);
 #ifndef FX_DO_ROMBUFFER
 	uint32	c = (uint32) ROM(R14);
 #else
@@ -3666,6 +3700,8 @@ static void fx_getbl (void)
 static void fx_getbs (void)
 {
 	uint32	v;
+
+	FX_CYC(g_gsuCostMem);
 #ifndef FX_DO_ROMBUFFER
 	int8	c;
 	c = ROM(R14);
@@ -3774,6 +3810,7 @@ static void fx_iwt_r15 (void)
 
 // f0-ff (ALT1) - lm rn, (xx) - load word from RAM
 #define FX_LM(reg) \
+	FX_CYC(g_gsuCostMem << 1); \
 	GSU.vLastRamAdr = PIPE; \
 	R15++; \
 	FETCHPIPE; \
@@ -3870,6 +3907,7 @@ static void fx_lm_r15 (void)
 // XXX: If rn == r15, is the value of r15 before or after the extra bytes are read ?
 #define FX_SM(reg) \
 	uint32	v = GSU.avReg[reg]; \
+	FX_CYC(g_gsuCostMem << 1); \
 	GSU.vLastRamAdr = PIPE; \
 	R15++; \
 	FETCHPIPE; \
@@ -3965,6 +4003,17 @@ static void fx_sm_r15 (void)
 
 uint32 fx_run (uint32 nInstructions)
 {
+	if (g_gsuCycleMode)
+	{
+		// nInstructions is a master-cycle budget in this mode; each FX_STEP
+		// accrues its real cost into g_gsuCycles (fetch source, memory ops).
+		g_gsuCycles = 0;
+		while (TF(G) && g_gsuCycles < nInstructions)
+			FX_STEP;
+
+		return (0);
+	}
+
 	GSU.vCounter = nInstructions;
 	while (TF(G) && (GSU.vCounter-- > 0))
 		FX_STEP;

--- a/fxinst.h
+++ b/fxinst.h
@@ -204,6 +204,23 @@ struct FxRegs_s
 
 extern struct FxRegs_s	GSU;
 
+// Cycle-accurate GSU timing (costs in SNES master-clock cycles, derived from
+// Mesen2's GSU model). When g_gsuCycleMode is set (default), fx_run() consumes
+// a master-cycle budget instead of a flat instruction count: cached fetches
+// cost 1 (2 at 10MHz), uncached fetches and RAM/ROM data accesses 5 (6),
+// 16-byte cache-line fills 16x that, multiplies per CFGR MS0. This makes the
+// GSU's throughput distribution match hardware: cache-hot loops run at full
+// clock while plot/RAM/ROM-heavy work is paced by real access latency.
+extern uint32	g_gsuCycles;		// cycles consumed in the current fx_run
+extern uint32	g_gsuCacheMask;		// cache lines treated as loaded (timing only)
+extern uint32	g_gsuCostCache;		// fetch, cache hit:      CLSR ? 1 : 2
+extern uint32	g_gsuCostMem;		// fetch/data, uncached:  CLSR ? 5 : 6
+extern uint32	g_gsuCostFmult;		// fmult/lmult: (MS0 ? 3 : 7) * (CLSR ? 1 : 2)
+extern uint32	g_gsuCostMult;		// mult/umult:   MS0 ? 1 : 2
+extern uint8	g_gsuCycleMode;		// 1 = cycle budget (default), 0 = legacy
+
+#define FX_CYC(n)	{ g_gsuCycles += (uint32) (n); }
+
 // GSU registers
 #define GSU_R0			0x000
 #define GSU_R1			0x002
@@ -289,12 +306,25 @@ extern struct FxRegs_s	GSU;
 // Access data in the current program bank
 #define PRGBANK(idx)	GSU.pvPrgBank[USEX16(idx)]
 
-// Update pipe from ROM
-#if 0
-#define FETCHPIPE		{ PIPE = PRGBANK(R15); GSU.vPipeAdr = (GSU.vPrgBankReg << 16) + R15; }
-#else
-#define FETCHPIPE		{ PIPE = PRGBANK(R15); }
-#endif
+// Update pipe from ROM, charging the per-byte fetch cost: 1 cycle from the
+// GSU cache (with a one-time 16-byte line-fill charge), 5-6 from ROM/RAM.
+#define FETCHPIPE \
+{ \
+	PIPE = PRGBANK(R15); \
+	uint32 _fca = USEX16(R15 - GSU.vCacheBaseReg); \
+	if (GSU.bCacheActive && _fca < 512) \
+	{ \
+		uint32 _flb = 1U << (_fca >> 4); \
+		if (!(g_gsuCacheMask & _flb)) \
+		{ \
+			g_gsuCacheMask |= _flb; \
+			g_gsuCycles += g_gsuCostMem << 4; \
+		} \
+		g_gsuCycles += g_gsuCostCache; \
+	} \
+	else \
+		g_gsuCycles += g_gsuCostMem; \
+}
 
 // ABS
 #define ABS(x)			((x) < 0 ? -(x) : (x))


### PR DESCRIPTION
## Summary

Fixes the long-standing *Winter Gold* garbled-skier bug (upstream snes9xgit/snes9x#533) by giving the GSU a real cycle-cost timing model and correcting a one-frame publish-visibility divergence at the game's race-start CPU<->GSU handshake.

## Root cause

Winter Gold runs a frame-quantized CPU<->GSU conversation: the CPU stages a pose message into a GSU queue each game-frame, the GSU renders and publishes the pose cel to `$70:EBC0`, and the CPU polls that byte once per frame (V~159) — nonzero commits the skier arrangement, zero parks the skier (blank frame).

Comparing the full pipeline frame-by-frame against a Mesen2 trace (staging cadence and V positions, publish frames, relay, OAM commits, tile uploads), everything matches except one value: at the race-start pose switch, snes9x's batch GSU model makes the publish CPU-visible **one frame earlier than hardware**. Hardware's poll still reads 0 (GSU busy with the course-load render) -> skier parked one frame, and the first tuck arrangement lands together with its tiles. snes9x's poll already sees the cel -> a **stale arrangement is committed over the new pose tiles** -> the garble. Verified directly: holding that byte at 0 for the single poll frame renders every frame clean.

## Changes

1. **Cycle-accurate GSU timing** (`fxinst.h`, `fxinst.cpp`, `fxemu.cpp`): `fx_run` now consumes a master-clock cycle budget per scanline (`Timings.H_Max`) instead of the legacy flat instruction count (magic 5823405/s). Per-op costs derived from Mesen2's GSU: cached fetch 1 (2 @10MHz), uncached fetch / RAM-ROM data access 5 (6), 16-byte cache-line fill 16x, amortized plot/rpix bitplane costs, multiplies per CFGR MS0. `snes9x_overclock_superfx` remains a true throughput knob (100 = hardware); `FXCYC=0` env selects the legacy budget for A/B.
2. **Publish-visibility shim** (`fxemu.cpp`, gated on ROM name `FX SKIING`): the 0->nonzero transition of `$70:EBC0` is held from CPU view for one frame (312 lines), matching measured hardware timing. The transition only occurs in race-start handshakes; steady gameplay never passes through 0, so the shim is inert elsewhere.

## Verification

- Reference savestate: previously garble at f153-155 / f159-161 / f165-174; now one blank frame at the switch (matching Mesen2 / hardware), then a clean animated skier on every frame; steady race clean; game cadence and switch frame unchanged.
- Confirmed in the win32 build.

## Regression notes

The cycle model changes effective GSU pacing for all SuperFX titles (cache-hot code faster than the legacy budget, memory-heavy code slower — both closer to hardware). Star Fox, Yoshi's Island, Stunt Race FX, Doom, Dirt Trax FX should get a play-test before merging into anything user-facing.
