### PR TITLE
feat(gtk): RetroAchievements support (parity with win32/Qt)

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -153,6 +153,54 @@ list(APPEND SOURCES ../external/imgui/imgui.cpp
 ../external/imgui/snes9x_imgui.cpp)
 list(APPEND INCLUDES ../external/imgui)
 
+# RetroAchievements support (shared core + rcheevos + GTK platform layer).
+# Mirrors qt/CMakeLists.txt so both frontends share the same core + config keys.
+pkg_check_modules(CURL REQUIRED libcurl)
+list(APPEND ARGS ${CURL_CFLAGS})
+list(APPEND LIBS ${CURL_LIBRARIES})
+list(APPEND DEFINES RETROACHIEVEMENTS_SUPPORT RC_DISABLE_LUA RC_CLIENT_SUPPORTS_HASH)
+list(APPEND INCLUDES ../external/rcheevos/include ../external/stb)
+# The RA core badge decoder needs the stb_image implementation TU. USE_SLANG
+# already compiles it (for Vulkan); only add it here when that path is off.
+if(NOT USE_SLANG)
+    list(APPEND SOURCES ../external/stb/stb_image_implementation.cpp)
+endif()
+list(APPEND SOURCES
+    src/gtk_retroachievements.cpp
+    src/gtk_retroachievements.h
+    ../retroachievements.cpp
+    ../external/rcheevos/src/rc_client.c
+    ../external/rcheevos/src/rc_compat.c
+    ../external/rcheevos/src/rc_util.c
+    ../external/rcheevos/src/rc_version.c
+    ../external/rcheevos/src/rcheevos/alloc.c
+    ../external/rcheevos/src/rcheevos/condition.c
+    ../external/rcheevos/src/rcheevos/condset.c
+    ../external/rcheevos/src/rcheevos/consoleinfo.c
+    ../external/rcheevos/src/rcheevos/format.c
+    ../external/rcheevos/src/rcheevos/lboard.c
+    ../external/rcheevos/src/rcheevos/memref.c
+    ../external/rcheevos/src/rcheevos/operand.c
+    ../external/rcheevos/src/rcheevos/rc_validate.c
+    ../external/rcheevos/src/rcheevos/richpresence.c
+    ../external/rcheevos/src/rcheevos/runtime.c
+    ../external/rcheevos/src/rcheevos/runtime_progress.c
+    ../external/rcheevos/src/rcheevos/trigger.c
+    ../external/rcheevos/src/rcheevos/value.c
+    ../external/rcheevos/src/rapi/rc_api_common.c
+    ../external/rcheevos/src/rapi/rc_api_editor.c
+    ../external/rcheevos/src/rapi/rc_api_info.c
+    ../external/rcheevos/src/rapi/rc_api_runtime.c
+    ../external/rcheevos/src/rapi/rc_api_user.c
+    ../external/rcheevos/src/rhash/hash.c
+    ../external/rcheevos/src/rhash/hash_disc.c
+    ../external/rcheevos/src/rhash/hash_encrypted.c
+    ../external/rcheevos/src/rhash/hash_rom.c
+    ../external/rcheevos/src/rhash/hash_zip.c
+    ../external/rcheevos/src/rhash/aes.c
+    ../external/rcheevos/src/rhash/cdreader.c
+    ../external/rcheevos/src/rhash/md5.c)
+
 if(USE_WAYLAND)
     pkg_check_modules(WAYLAND REQUIRED wayland-client wayland-egl)
     list(APPEND DEFINES "USE_WAYLAND")

--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -150,6 +150,11 @@ int Snes9xConfig::load_defaults()
     netplay_last_rom.clear();
     netplay_last_host.clear();
     netplay_last_port = 6096;
+    ra_enabled = false;
+    ra_hardcore_mode = false;
+    ra_username.clear();
+    ra_api_token.clear();
+    ra_emulator_name = "SuperSnes9x";
     modal_dialogs = true;
     current_save_slot = 0;
     S9xCheatsEnable();
@@ -327,6 +332,15 @@ int Snes9xConfig::save_config_file()
     outint("LastUsedPort", netplay_last_port);
     outstring("LastUsedROM", netplay_last_rom);
     outstring("LastUsedHost", netplay_last_host);
+
+    // Key names match the win32 (wconfig.cpp) and Qt (EmuConfig.cpp) configs so a
+    // shared install reads/writes the same RetroAchievements credentials.
+    section = "RetroAchievements";
+    outbool("Enabled", ra_enabled);
+    outbool("HardcoreMode", ra_hardcore_mode);
+    outstring("Username", ra_username);
+    outstring("ApiToken", ra_api_token);
+    outstring("EmulatorName", ra_emulator_name);
 
     section = "Behavior";
     outbool("PauseEmulationWhenFocusLost", pause_emulation_on_switch);
@@ -560,6 +574,13 @@ int Snes9xConfig::load_config_file()
     instr("LastUsedROM", netplay_last_rom);
     instr("LastUsedHost", netplay_last_host);
 
+    section = "RetroAchievements";
+    inbool("Enabled", ra_enabled);
+    inbool("HardcoreMode", ra_hardcore_mode);
+    instr("Username", ra_username);
+    instr("ApiToken", ra_api_token);
+    instr("EmulatorName", ra_emulator_name);
+
     section = "Behavior";
     inbool("PauseEmulationWhenFocusLost", pause_emulation_on_switch);
     inint("DefaultESCKeyBehavior", default_esc_behavior);
@@ -664,6 +685,10 @@ int Snes9xConfig::load_config_file()
 
     if (default_esc_behavior != ESC_TOGGLE_MENUBAR)
         fullscreen = false;
+
+    // The RA-registered emulator name must be non-empty (drives the User-Agent).
+    if (ra_emulator_name.empty())
+        ra_emulator_name = "SuperSnes9x";
 
 #ifdef USE_HQ2X
     if (scale_method >= NUM_FILTERS)

--- a/gtk/src/gtk_config.h
+++ b/gtk/src/gtk_config.h
@@ -118,6 +118,13 @@ class Snes9xConfig
     bool netplay_activated;
     bool netplay_server_up;
 
+    /* RetroAchievements */
+    bool ra_enabled;
+    bool ra_hardcore_mode;
+    std::string ra_username;
+    std::string ra_api_token;
+    std::string ra_emulator_name;
+
     /* Operational */
     std::vector<std::string> sound_drivers;
     std::vector<std::string> display_drivers;

--- a/gtk/src/gtk_retroachievements.cpp
+++ b/gtk/src/gtk_retroachievements.cpp
@@ -1,0 +1,387 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+
+#include "gtk_retroachievements.h"
+#include "gtk_compat.h"
+#include "gtk_config.h"
+#include "gtk_s9x.h"
+#include "gtk_builder_window.h"
+
+#include "retroachievements.h"
+#include "rc_client.h"
+#include "rc_api_request.h"
+
+#include "snes9x.h"
+
+#include <glib/gi18n.h>
+#include <curl/curl.h>
+
+#include <string>
+#include <thread>
+#include <cstdio>
+
+// ---------------------------------------------------------------------------
+// libcurl HTTP implementation (runs on detached background threads)
+//
+// Mirrors the Qt port (RAIntegrationQt.cpp): rc_client hands us a request, we
+// perform it off the GTK main thread and invoke the completion callback with
+// the response — even on error. rc_client is internally locked and configured
+// with background memory reads, so calling back from this thread is safe.
+// ---------------------------------------------------------------------------
+static size_t ra_curl_write_cb(char *contents, size_t size, size_t nmemb, void *userp)
+{
+    auto *body = static_cast<std::string *>(userp);
+    body->append(contents, size * nmemb);
+    return size * nmemb;
+}
+
+struct CurlHttpRequest
+{
+    std::string url;
+    std::string post_data;
+    std::string content_type;
+    rc_client_server_callback_t callback;
+    void *callback_data;
+};
+
+static void ra_curl_http_thread(CurlHttpRequest *req)
+{
+    rc_api_server_response_t response = {};
+    std::string response_body;
+
+    CURL *curl = curl_easy_init();
+    if (!curl)
+    {
+        response.http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR;
+        req->callback(&response, req->callback_data);
+        delete req;
+        return;
+    }
+
+    const char *emuName = (gui_config && !gui_config->ra_emulator_name.empty())
+        ? gui_config->ra_emulator_name.c_str() : "SuperSnes9x";
+    char user_agent[256];
+    snprintf(user_agent, sizeof(user_agent), "%s/%s", emuName, VERSION);
+
+    curl_easy_setopt(curl, CURLOPT_URL, req->url.c_str());
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, ra_curl_write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+
+    struct curl_slist *headers = nullptr;
+    if (!req->post_data.empty())
+    {
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, req->post_data.c_str());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)req->post_data.size());
+        if (!req->content_type.empty())
+        {
+            std::string ct_header = "Content-Type: " + req->content_type;
+            headers = curl_slist_append(headers, ct_header.c_str());
+            curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+        }
+    }
+
+    CURLcode res = curl_easy_perform(curl);
+
+    if (res == CURLE_OK)
+    {
+        long http_code = 0;
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+        response.http_status_code = (int)http_code;
+    }
+    else
+    {
+        response.http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR;
+    }
+
+    response.body = response_body.c_str();
+    response.body_length = response_body.size();
+
+    if (headers)
+        curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    req->callback(&response, req->callback_data);
+    delete req;
+}
+
+static void RC_CCONV ra_gtk_server_call(const rc_api_request_t *request,
+                                         rc_client_server_callback_t callback,
+                                         void *callback_data, rc_client_t *client)
+{
+    auto *req = new CurlHttpRequest();
+    req->url = request->url ? request->url : "";
+    req->post_data = request->post_data ? request->post_data : "";
+    req->content_type = request->content_type ? request->content_type : "";
+    req->callback = callback;
+    req->callback_data = callback_data;
+
+    std::thread(ra_curl_http_thread, req).detach();
+}
+
+// ---------------------------------------------------------------------------
+// Login dialog
+// ---------------------------------------------------------------------------
+static void ra_gtk_show_login()
+{
+    if (!top_level || !top_level->window)
+        return;
+
+    Gtk::Dialog dialog(_("RetroAchievements Login"), *top_level->window.get(), true);
+    dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
+    dialog.add_button(_("_Login"), Gtk::RESPONSE_ACCEPT);
+    dialog.set_default_response(Gtk::RESPONSE_ACCEPT);
+
+    Gtk::Grid grid;
+    grid.set_row_spacing(6);
+    grid.set_column_spacing(8);
+    grid.set_border_width(12);
+
+    Gtk::Label user_label(_("Username:"));
+    user_label.set_halign(Gtk::ALIGN_END);
+    Gtk::Entry user_entry;
+    user_entry.set_text(gui_config ? gui_config->ra_username : "");
+    user_entry.set_activates_default(true);
+
+    Gtk::Label pass_label(_("Password:"));
+    pass_label.set_halign(Gtk::ALIGN_END);
+    Gtk::Entry pass_entry;
+    pass_entry.set_visibility(false);
+    pass_entry.set_activates_default(true);
+
+    Gtk::Label note(_("Your password is only used to obtain a login token.\n"
+                      "It is never saved."));
+    note.set_halign(Gtk::ALIGN_START);
+    note.get_style_context()->add_class("dim-label");
+
+    grid.attach(user_label, 0, 0, 1, 1);
+    grid.attach(user_entry, 1, 0, 1, 1);
+    grid.attach(pass_label, 0, 1, 1, 1);
+    grid.attach(pass_entry, 1, 1, 1, 1);
+    grid.attach(note, 0, 2, 2, 1);
+
+    dialog.get_content_area()->pack_start(grid, true, true, 0);
+    dialog.show_all();
+
+    if (user_entry.get_text().empty())
+        user_entry.grab_focus();
+    else
+        pass_entry.grab_focus();
+
+    if (dialog.run() == Gtk::RESPONSE_ACCEPT)
+    {
+        auto u = user_entry.get_text();
+        auto p = pass_entry.get_text();
+        if (!u.empty() && !p.empty())
+            RA_LoginWithPassword(u.c_str(), p.c_str());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Achievement list dialog
+// ---------------------------------------------------------------------------
+namespace {
+class RAAchievementColumns : public Gtk::TreeModel::ColumnRecord
+{
+  public:
+    Gtk::TreeModelColumn<Glib::ustring> title;
+    Gtk::TreeModelColumn<Glib::ustring> points;
+    Gtk::TreeModelColumn<Glib::ustring> status;
+    Gtk::TreeModelColumn<Glib::ustring> description;
+
+    RAAchievementColumns()
+    {
+        add(title);
+        add(points);
+        add(status);
+        add(description);
+    }
+};
+} // namespace
+
+static void ra_gtk_show_achievements()
+{
+    if (!top_level || !top_level->window)
+        return;
+
+    rc_client_t *client = RA_GetClient();
+    if (!client)
+        return;
+
+    Gtk::Dialog dialog(_("RetroAchievements"), *top_level->window.get(), true);
+    dialog.add_button(_("_Close"), Gtk::RESPONSE_CLOSE);
+    dialog.set_default_size(560, 420);
+
+    const rc_client_game_t *game = rc_client_get_game_info(client);
+    Gtk::Label title_label;
+    Glib::ustring game_title = (game && game->title[0]) ? game->title : _("No game loaded");
+    title_label.set_markup("<b>" + Glib::Markup::escape_text(game_title) + "</b>");
+    title_label.set_halign(Gtk::ALIGN_START);
+    title_label.set_margin_bottom(6);
+
+    RAAchievementColumns columns;
+    auto store = Gtk::ListStore::create(columns);
+
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(client,
+        RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+
+    if (list)
+    {
+        for (uint32_t b = 0; b < list->num_buckets; b++)
+        {
+            const rc_client_achievement_bucket_t *bucket = &list->buckets[b];
+            for (uint32_t a = 0; a < bucket->num_achievements; a++)
+            {
+                const rc_client_achievement_t *ach = bucket->achievements[a];
+
+                const char *status;
+                if (ach->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE)
+                    status = _("Unlocked (Hardcore)");
+                else if (ach->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE)
+                    status = _("Unlocked");
+                else if (ach->state == RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE)
+                    status = _("Locked");
+                else
+                    status = _("Inactive");
+
+                auto row = *(store->append());
+                row[columns.title] = ach->title ? ach->title : "";
+                row[columns.points] = std::to_string(ach->points);
+                row[columns.status] = status;
+                row[columns.description] = ach->description ? ach->description : "";
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+
+    Gtk::TreeView tree(store);
+    tree.set_rules_hint(true);
+    tree.append_column(_("Title"), columns.title);
+    tree.append_column(_("Points"), columns.points);
+    tree.append_column(_("Status"), columns.status);
+    tree.append_column(_("Description"), columns.description);
+
+    Gtk::ScrolledWindow scroll;
+    scroll.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
+    scroll.add(tree);
+
+    auto *content = dialog.get_content_area();
+    content->set_border_width(8);
+    content->pack_start(title_label, false, false, 0);
+    content->pack_start(scroll, true, true, 0);
+    dialog.show_all();
+
+    dialog.run();
+}
+
+// ---------------------------------------------------------------------------
+// Confirm disable hardcore (blocking yes/no). Only ever invoked from the GTK
+// main thread (the port calls RA_WarnDisableHardcore from menu handlers).
+// ---------------------------------------------------------------------------
+static bool ra_gtk_confirm_disable_hardcore(const char *activity)
+{
+    Gtk::MessageDialog dialog(
+        *top_level->window.get(),
+        std::string(activity ? activity : _("This action")) +
+            _(" is not allowed while Hardcore mode is active."),
+        false, Gtk::MESSAGE_WARNING, Gtk::BUTTONS_YES_NO, true);
+    dialog.set_title(_("RetroAchievements — Hardcore Mode"));
+    dialog.set_secondary_text(
+        _("Disable Hardcore mode to proceed?\n"
+          "(Achievement progress for this session will be lost.)"));
+
+    return dialog.run() == Gtk::RESPONSE_YES;
+}
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+static void ra_gtk_log(const char *message)
+{
+    fprintf(stderr, "%s\n", message);
+}
+
+// ---------------------------------------------------------------------------
+// Credentials changed — persist to config and refresh the menu.
+//
+// This can be invoked from a background HTTP thread (login completion), so all
+// GTK / config work is marshalled to the main thread with g_idle_add.
+// ---------------------------------------------------------------------------
+struct RACredentialsUpdate
+{
+    std::string username;
+    std::string token;
+    bool logged_in;
+};
+
+static gboolean ra_gtk_apply_credentials(gpointer data)
+{
+    auto *u = static_cast<RACredentialsUpdate *>(data);
+
+    if (gui_config)
+    {
+        gui_config->ra_username = u->username;
+        gui_config->ra_api_token = u->token;
+        gui_config->ra_enabled = u->logged_in;
+        gui_config->save_config_file();
+    }
+
+    // Only refresh the Login/Logout label. The "Enabled" check item is left
+    // untouched here — toggling it would re-fire its handler and recurse.
+    if (global_builder)
+    {
+        auto login_obj = global_builder->get_object("ra_login_item");
+        if (login_obj)
+        {
+            auto item = Glib::RefPtr<Gtk::MenuItem>::cast_static(login_obj);
+            if (item)
+                item->set_label(u->logged_in ? _("_Logout") : _("_Login..."));
+        }
+    }
+
+    delete u;
+    return G_SOURCE_REMOVE;
+}
+
+static void ra_gtk_credentials_changed(const char *username, const char *token)
+{
+    bool logged_in = (username && username[0] && token && token[0]);
+    auto *u = new RACredentialsUpdate{
+        username ? username : "",
+        token ? token : "",
+        logged_in
+    };
+    g_idle_add(ra_gtk_apply_credentials, u);
+}
+
+// ---------------------------------------------------------------------------
+// Public: register callbacks with the core
+// ---------------------------------------------------------------------------
+void RA_Gtk_RegisterCallbacks()
+{
+    static bool curl_initialized = false;
+    if (!curl_initialized)
+    {
+        curl_global_init(CURL_GLOBAL_DEFAULT);
+        curl_initialized = true;
+    }
+
+    RAPlatformCallbacks cb = {};
+    cb.server_call = ra_gtk_server_call;
+    cb.show_login_dialog = ra_gtk_show_login;
+    cb.show_achievement_list = ra_gtk_show_achievements;
+    cb.confirm_disable_hardcore = ra_gtk_confirm_disable_hardcore;
+    cb.log_message = ra_gtk_log;
+    cb.on_credentials_changed = ra_gtk_credentials_changed;
+    RA_RegisterPlatformCallbacks(cb);
+}
+
+#endif // RETROACHIEVEMENTS_SUPPORT

--- a/gtk/src/gtk_retroachievements.h
+++ b/gtk/src/gtk_retroachievements.h
@@ -1,0 +1,15 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+
+// Registers the GTK platform callbacks (HTTP, dialogs, credential persistence)
+// with the shared RetroAchievements core. Safe to call more than once.
+void RA_Gtk_RegisterCallbacks();
+
+#endif // RETROACHIEVEMENTS_SUPPORT

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -14,6 +14,8 @@
 #include "gtk_sound.h"
 #include "gtk_display.h"
 #include "gtk_netplay.h"
+#include "gtk_retroachievements.h"
+#include "retroachievements.h"
 #include "statemanager.h"
 #include "background_particles.h"
 #include "snes9x.h"
@@ -125,6 +127,17 @@ int main(int argc, char *argv[])
     gui_config->rebind_keys();
     top_level->update_accelerators();
 
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    if (gui_config->ra_enabled)
+    {
+        RA_Gtk_RegisterCallbacks();
+        RA_Init();
+        RA_SetEnabled(true);
+        RA_SetHardcoreEnabled(gui_config->ra_hardcore_mode);
+        RA_AttemptLogin(gui_config->ra_username.c_str(), gui_config->ra_api_token.c_str());
+    }
+#endif
+
     Settings.Paused = true;
     S9xNoROMLoaded();
 
@@ -156,6 +169,9 @@ int S9xOpenROM(const char *rom_filename)
     if (gui_config->rom_loaded)
     {
         S9xAutoSaveSRAM();
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnCloseROM();
+#endif
     }
 
     S9xNetplayDisconnect();
@@ -208,6 +224,10 @@ void S9xROMLoaded()
     gui_config->rom_loaded = true;
     top_level->configure_widgets();
 
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    RA_OnLoadROM();
+#endif
+
     if (gui_config->full_screen_on_open)
     {
         Settings.Paused = false;
@@ -219,6 +239,9 @@ void S9xROMLoaded()
 
 void S9xNoROMLoaded()
 {
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    RA_OnCloseROM();
+#endif
     S9xSoundStop();
     gui_config->rom_loaded = false;
     S9xDisplayRefresh();
@@ -329,6 +352,10 @@ static void game_loop()
             Settings.Mute &= ~0x80;
 
         S9xMainLoop();
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_DoFrame();
+#endif
 
         S9xNetplayPop();
     }
@@ -587,6 +614,10 @@ static void check_pointer_timer()
 void S9xExit()
 {
     gui_config->save_config_file();
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    RA_Shutdown();
+#endif
 
     top_level->leave_fullscreen_mode();
 

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -27,6 +27,8 @@
 #include "gtk_control.h"
 #include "gtk_cheat.h"
 #include "gtk_netplay.h"
+#include "gtk_retroachievements.h"
+#include "retroachievements.h"
 #include "gtk_s9xwindow.h"
 
 #include "fmt/format.h"
@@ -167,10 +169,16 @@ void Snes9xWindow::connect_signals()
 
     get_object<Gtk::MenuItem>("reset_item")->signal_activate().connect([&] {
         S9xSoftReset();
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnReset();
+#endif
     });
 
     get_object<Gtk::MenuItem>("hard_reset_item")->signal_activate().connect([&] {
         S9xReset();
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnReset();
+#endif
     });
 
     auto reload_with_bios_pref = [&](uint8_t pref) {
@@ -209,6 +217,10 @@ void Snes9xWindow::connect_signals()
     {
         std::string name = "load_state_" + std::to_string(i);
         get_object<Gtk::MenuItem>(name.c_str())->signal_activate().connect([i] {
+#ifdef RETROACHIEVEMENTS_SUPPORT
+            if (!RA_WarnDisableHardcore(_("Loading save states")))
+                return;
+#endif
             S9xQuickLoadSlot(i);
         });
         name = "save_state_" + std::to_string(i);
@@ -291,6 +303,60 @@ void Snes9xWindow::connect_signals()
     get_object<Gtk::MenuItem>("open_multicart_item")->signal_activate().connect([&] {
         open_multicart_dialog();
     });
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    get_object<Gtk::CheckMenuItem>("ra_enabled_item")->set_active(gui_config->ra_enabled);
+    get_object<Gtk::CheckMenuItem>("ra_enabled_item")->signal_toggled().connect([this] {
+        bool checked = get_object<Gtk::CheckMenuItem>("ra_enabled_item")->get_active();
+        gui_config->ra_enabled = checked;
+        gui_config->save_config_file();
+        RA_SetEnabled(checked);
+        if (checked)
+        {
+            RA_Gtk_RegisterCallbacks();
+            RA_Init();
+            RA_SetHardcoreEnabled(gui_config->ra_hardcore_mode);
+            RA_AttemptLogin(gui_config->ra_username.c_str(), gui_config->ra_api_token.c_str());
+            if (gui_config->rom_loaded)
+                RA_OnLoadROM();
+        }
+        else
+        {
+            RA_Shutdown();
+        }
+    });
+
+    get_object<Gtk::MenuItem>("ra_login_item")->signal_activate().connect([this] {
+        RA_Gtk_RegisterCallbacks();
+        RA_Init();
+        if (RA_IsLoggedIn())
+        {
+            RA_Logout();
+            get_object<Gtk::MenuItem>("ra_login_item")->set_label(_("_Login..."));
+        }
+        else
+        {
+            RA_ShowLoginDialog();
+        }
+    });
+
+    get_object<Gtk::CheckMenuItem>("ra_hardcore_item")->set_active(gui_config->ra_hardcore_mode);
+    get_object<Gtk::CheckMenuItem>("ra_hardcore_item")->signal_toggled().connect([this] {
+        bool checked = get_object<Gtk::CheckMenuItem>("ra_hardcore_item")->get_active();
+        gui_config->ra_hardcore_mode = checked;
+        RA_SetHardcoreEnabled(checked);
+    });
+
+    get_object<Gtk::MenuItem>("ra_achievement_list_item")->signal_activate().connect([] {
+        RA_ShowAchievementList();
+    });
+
+    // Stored credentials imply we auto-login at startup; reflect that in the label.
+    if (!gui_config->ra_username.empty() && !gui_config->ra_api_token.empty())
+        get_object<Gtk::MenuItem>("ra_login_item")->set_label(_("_Logout"));
+#else
+    get_object<Gtk::Widget>("retroachievements_menu_item")->hide();
+#endif
 }
 
 bool Snes9xWindow::button_press(GdkEventButton *event)
@@ -753,7 +819,18 @@ void Snes9xWindow::load_state_dialog()
     dialog.hide();
     if (result == Gtk::RESPONSE_ACCEPT)
     {
-        S9xLoadState(dialog.get_filename());
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        if (!RA_WarnDisableHardcore(_("Loading save states")))
+        {
+            unpause_from_focus_change();
+            return;
+        }
+#endif
+        std::string filename = dialog.get_filename();
+        S9xLoadState(filename.c_str());
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnLoadState(filename.c_str());
+#endif
     }
 
     unpause_from_focus_change();
@@ -813,7 +890,13 @@ void Snes9xWindow::save_state_dialog()
     dialog.hide();
 
     if (result == GTK_RESPONSE_ACCEPT)
-        S9xSaveState(dialog.get_filename());
+    {
+        std::string filename = dialog.get_filename();
+        S9xSaveState(filename.c_str());
+#ifdef RETROACHIEVEMENTS_SUPPORT
+        RA_OnSaveState(filename.c_str());
+#endif
+    }
 
     unpause_from_focus_change();
 }

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -2146,6 +2146,57 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="GtkMenuItem" id="retroachievements_menu_item">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_RetroAchievements</property>
+                <property name="use_underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu" id="retroachievements_menu_item_menu">
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="ra_enabled_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">_Enabled</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="ra_login_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">_Login...</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="ra_hardcore_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">_Hardcore Mode</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="ra_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="ra_achievement_list_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">_Achievement List...</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Ports the RetroAchievements integration to the GTK frontend, mirroring the existing Qt platform layer. GTK was the only frontend missing it.

- gtk_retroachievements.{cpp,h}: GTK platform callbacks — libcurl HTTP on detached threads, gtkmm login + achievement-list dialogs, hardcore confirm prompt, credential persistence marshalled to the main thread via g_idle_add (login completes off the GTK main thread).
- gtk_config: ra_* settings under a [RetroAchievements] section; keys match win32/Qt so a shared install reuses the same credentials.
- Lifecycle wired in gtk_s9x.cpp (init/shutdown/DoFrame/OnLoadROM/ OnCloseROM) and gtk_s9xwindow.cpp (reset, save/load-state, menu).
- New RetroAchievements menu in snes9x.ui (Enabled, Login/Logout, Hardcore Mode, Achievement List).
- CMakeLists: RETROACHIEVEMENTS_SUPPORT + rcheevos sources + libcurl.

Unlock toasts and challenge/progress badges render via the shared snes9x_imgui RA_RenderOverlay already used by the GTK OpenGL/Vulkan drivers.