### PR TITLE
Invalid-VRAM handling, GTK/Qt build fixes, and RetroAchievements parity

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -399,6 +399,7 @@ list(APPEND SOURCES
     ../bml.cpp
     ../cpuops.cpp
     ../cpuexec.cpp
+    ../voicekun.cpp
     ../sa1cpu.cpp
     ../cheats.cpp
     ../cheats2.cpp

--- a/gtk/src/gtk_control.cpp
+++ b/gtk/src/gtk_control.cpp
@@ -18,6 +18,10 @@
 #include "display.h"
 #include "gfx.h"
 
+#ifdef RETROACHIEVEMENTS_SUPPORT
+#include "retroachievements.h"
+#endif
+
 const BindingLink b_links[] =
 {
         /* Joypad-specific bindings. "Joypad# " will be prepended */
@@ -236,7 +240,14 @@ void S9xHandlePortCommand(s9xcommand_t cmd, int16 data1, int16 data2)
         if (cmd.port[0] == PORT_QUIT)
             quit_binding_down = true;
         else if (cmd.port[0] == PORT_REWIND)
+        {
+#ifdef RETROACHIEVEMENTS_SUPPORT
+            if (RA_IsHardcoreModeActive())
+                S9xSetInfoString(_("Rewind is not allowed in Hardcore mode"));
+            else
+#endif
             Settings.Rewinding = true;
+        }
     }
 
     if (data1 == false) /* Release */

--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -584,7 +584,17 @@ void Snes9xPreferences::move_settings_to_dialog()
     set_combo("scale_method_combo",        config->scale_method);
     set_spin ("save_sram_after_sec",       Settings.AutoSaveDelay);
     set_label("save_sram_after_sec_label", ngettext("second after change", "seconds after change", get_spin("save_sram_after_sec")));
-    set_check("allow_invalid_vram_access", !Settings.BlockInvalidVRAMAccessMaster);
+    // A game on the allow-invalid-VRAM list overrides the preference for
+    // itself; show that and disable the box so the automatic choice is visible
+    // without the saved preference being rewritten when the dialog is applied.
+    {
+        const bool vram_auto = !Settings.StopEmulation &&
+            Settings.BlockInvalidVRAMAccess != Settings.BlockInvalidVRAMAccessMaster;
+        set_check("allow_invalid_vram_access",
+                  vram_auto ? !Settings.BlockInvalidVRAMAccess
+                            : !Settings.BlockInvalidVRAMAccessMaster);
+        enable_widget("allow_invalid_vram_access", !vram_auto);
+    }
     set_check("upanddown",                 Settings.UpAndDown);
     set_combo("default_esc_behavior",      config->default_esc_behavior);
     set_check("prevent_screensaver",       config->prevent_screensaver);
@@ -766,7 +776,11 @@ void Snes9xPreferences::get_settings_from_dialog()
     Settings.AutoSaveDelay            = get_spin("save_sram_after_sec");
     config->multithreading            = get_check("multithreading");
     config->pause_emulation_on_switch = get_check("pause_emulation_on_switch");
-    Settings.BlockInvalidVRAMAccessMaster   = !get_check("allow_invalid_vram_access");
+    // Disabled means the current game forced the setting, so the box no longer
+    // reflects the preference and must not be read back over it.
+    if (Settings.StopEmulation ||
+        Settings.BlockInvalidVRAMAccess == Settings.BlockInvalidVRAMAccessMaster)
+        Settings.BlockInvalidVRAMAccessMaster = !get_check("allow_invalid_vram_access");
     Settings.UpAndDown                = get_check("upanddown");
     Settings.SuperFXClockMultiplier   = get_spin("superfx_multiplier");
     config->sound_driver              = get_combo("sound_driver");

--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -589,7 +589,7 @@ void Snes9xPreferences::move_settings_to_dialog()
     // without the saved preference being rewritten when the dialog is applied.
     {
         const bool vram_auto = !Settings.StopEmulation &&
-            Settings.BlockInvalidVRAMAccess != Settings.BlockInvalidVRAMAccessMaster;
+            Settings.BlockInvalidVRAMAccessOverride;
         set_check("allow_invalid_vram_access",
                   vram_auto ? !Settings.BlockInvalidVRAMAccess
                             : !Settings.BlockInvalidVRAMAccessMaster);

--- a/gtk/src/gtk_retroachievements.cpp
+++ b/gtk/src/gtk_retroachievements.cpp
@@ -17,6 +17,8 @@
 #include "rc_api_request.h"
 
 #include "snes9x.h"
+#include "memmap.h"
+#include "cpuexec.h"
 
 #include <glib/gi18n.h>
 #include <curl/curl.h>
@@ -194,40 +196,59 @@ class RAAchievementColumns : public Gtk::TreeModel::ColumnRecord
     Gtk::TreeModelColumn<Glib::ustring> title;
     Gtk::TreeModelColumn<Glib::ustring> points;
     Gtk::TreeModelColumn<Glib::ustring> status;
+    Gtk::TreeModelColumn<Glib::ustring> progress;
+    Gtk::TreeModelColumn<Glib::ustring> type;
     Gtk::TreeModelColumn<Glib::ustring> description;
+    Gtk::TreeModelColumn<int>           points_sort;
 
     RAAchievementColumns()
     {
         add(title);
         add(points);
         add(status);
+        add(progress);
+        add(type);
         add(description);
+        add(points_sort);
     }
 };
+
+// The list dialog is modeless and refreshes on a timer, so its widgets and the
+// column record must outlive the callback that creates it.
+struct RAAchievementsDialog
+{
+    RAAchievementColumns         columns;
+    Gtk::Dialog                 *dialog = nullptr;
+    Gtk::Label                  *summary = nullptr;
+    Glib::RefPtr<Gtk::ListStore> store;
+    sigc::connection             timer;
+};
+static RAAchievementsDialog *s_ach_dialog = nullptr;
+
+static const char *ra_gtk_type_string(uint8_t type)
+{
+    switch (type)
+    {
+    case RC_CLIENT_ACHIEVEMENT_TYPE_MISSABLE:    return _("Missable");
+    case RC_CLIENT_ACHIEVEMENT_TYPE_PROGRESSION: return _("Progression");
+    case RC_CLIENT_ACHIEVEMENT_TYPE_WIN:         return _("Win Condition");
+    default:                                     return "";
+    }
+}
 } // namespace
 
-static void ra_gtk_show_achievements()
+static void ra_gtk_refresh_achievements()
 {
-    if (!top_level || !top_level->window)
+    if (!s_ach_dialog)
         return;
 
     rc_client_t *client = RA_GetClient();
     if (!client)
         return;
 
-    Gtk::Dialog dialog(_("RetroAchievements"), *top_level->window.get(), true);
-    dialog.add_button(_("_Close"), Gtk::RESPONSE_CLOSE);
-    dialog.set_default_size(560, 420);
-
-    const rc_client_game_t *game = rc_client_get_game_info(client);
-    Gtk::Label title_label;
-    Glib::ustring game_title = (game && game->title[0]) ? game->title : _("No game loaded");
-    title_label.set_markup("<b>" + Glib::Markup::escape_text(game_title) + "</b>");
-    title_label.set_halign(Gtk::ALIGN_START);
-    title_label.set_margin_bottom(6);
-
-    RAAchievementColumns columns;
-    auto store = Gtk::ListStore::create(columns);
+    auto &columns = s_ach_dialog->columns;
+    auto store = s_ach_dialog->store;
+    store->clear();
 
     rc_client_achievement_list_t *list = rc_client_create_achievement_list(client,
         RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
@@ -256,30 +277,139 @@ static void ra_gtk_show_achievements()
                 row[columns.title] = ach->title ? ach->title : "";
                 row[columns.points] = std::to_string(ach->points);
                 row[columns.status] = status;
+                row[columns.progress] = ach->measured_progress;
+                row[columns.type] = ra_gtk_type_string(ach->type);
                 row[columns.description] = ach->description ? ach->description : "";
+                row[columns.points_sort] = (int)ach->points;
             }
         }
         rc_client_destroy_achievement_list(list);
     }
 
-    Gtk::TreeView tree(store);
-    tree.set_rules_hint(true);
-    tree.append_column(_("Title"), columns.title);
-    tree.append_column(_("Points"), columns.points);
-    tree.append_column(_("Status"), columns.status);
-    tree.append_column(_("Description"), columns.description);
+    if (!s_ach_dialog->summary)
+        return;
 
-    Gtk::ScrolledWindow scroll;
-    scroll.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
-    scroll.add(tree);
+    const rc_client_game_t *game = rc_client_get_game_info(client);
+    if (game && game->title[0])
+    {
+        rc_client_user_game_summary_t gs = {};
+        rc_client_get_user_game_summary(client, &gs);
 
-    auto *content = dialog.get_content_area();
+        char buf[512];
+        snprintf(buf, sizeof(buf),
+                 _("%s — %u of %u achievements, %u of %u points"),
+                 game->title, gs.num_unlocked_achievements, gs.num_core_achievements,
+                 gs.points_unlocked, gs.points_core);
+        std::string text = buf;
+
+        char user_buf[256];
+        if (RA_GetLoggedInUserString(user_buf, sizeof(user_buf)))
+        {
+            text += "    |    ";
+            text += _("Logged in as ");
+            text += user_buf;
+            if (RA_IsHardcoreModeActive())
+                text += _(" - Hardcore");
+        }
+        else
+        {
+            text += "    |    ";
+            text += _("Not logged in");
+        }
+
+        s_ach_dialog->summary->set_markup("<b>" + Glib::Markup::escape_text(text) + "</b>");
+    }
+    else
+    {
+        s_ach_dialog->summary->set_markup("<b>" + Glib::Markup::escape_text(_("No game loaded")) + "</b>");
+    }
+}
+
+static void ra_gtk_show_achievements()
+{
+    if (!top_level || !top_level->window)
+        return;
+
+    // Modeless: present the existing window rather than opening another.
+    if (s_ach_dialog && s_ach_dialog->dialog)
+    {
+        s_ach_dialog->dialog->present();
+        return;
+    }
+
+    if (!RA_GetClient())
+        return;
+
+    s_ach_dialog = new RAAchievementsDialog();
+
+    auto *dialog = new Gtk::Dialog(_("RetroAchievements"), *top_level->window.get(), false);
+    s_ach_dialog->dialog = dialog;
+    dialog->add_button(_("_Close"), Gtk::RESPONSE_CLOSE);
+    dialog->set_default_size(640, 460);
+
+    auto *summary = Gtk::manage(new Gtk::Label());
+    summary->set_halign(Gtk::ALIGN_START);
+    summary->set_margin_bottom(6);
+    summary->set_line_wrap(true);
+    s_ach_dialog->summary = summary;
+
+    s_ach_dialog->store = Gtk::ListStore::create(s_ach_dialog->columns);
+    auto *tree = Gtk::manage(new Gtk::TreeView(s_ach_dialog->store));
+    tree->set_rules_hint(true);
+
+    auto &columns = s_ach_dialog->columns;
+    tree->append_column(_("Title"), columns.title);
+    tree->append_column(_("Points"), columns.points);
+    tree->append_column(_("Status"), columns.status);
+    tree->append_column(_("Progress"), columns.progress);
+    tree->append_column(_("Type"), columns.type);
+    tree->append_column(_("Description"), columns.description);
+
+    // Make headers clickable to sort; Points sorts numerically, the rest as text.
+    tree->get_column(0)->set_sort_column(columns.title);
+    tree->get_column(1)->set_sort_column(columns.points_sort);
+    tree->get_column(2)->set_sort_column(columns.status);
+    tree->get_column(3)->set_sort_column(columns.progress);
+    tree->get_column(4)->set_sort_column(columns.type);
+    tree->get_column(5)->set_sort_column(columns.description);
+
+    auto *scroll = Gtk::manage(new Gtk::ScrolledWindow());
+    scroll->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
+    scroll->add(*tree);
+
+    auto *content = dialog->get_content_area();
     content->set_border_width(8);
-    content->pack_start(title_label, false, false, 0);
-    content->pack_start(scroll, true, true, 0);
-    dialog.show_all();
+    content->pack_start(*summary, false, false, 0);
+    content->pack_start(*scroll, true, true, 0);
 
-    dialog.run();
+    ra_gtk_refresh_achievements();
+
+    // Live refresh once a second while the game keeps running behind the dialog.
+    s_ach_dialog->timer = Glib::signal_timeout().connect([]() -> bool {
+        ra_gtk_refresh_achievements();
+        return true;
+    }, 1000);
+
+    // Tear down (Close button or window-manager close) without blocking.
+    // Clear the global synchronously so a re-open makes a fresh dialog, and
+    // defer the delete so we don't destroy the widget inside its own signal.
+    dialog->signal_response().connect([](int) {
+        if (!s_ach_dialog)
+            return;
+        s_ach_dialog->timer.disconnect();
+        RAAchievementsDialog *dead = s_ach_dialog;
+        s_ach_dialog = nullptr;
+        dead->dialog->hide();
+        g_idle_add([](gpointer p) -> gboolean {
+            auto *d = static_cast<RAAchievementsDialog *>(p);
+            delete d->dialog;
+            delete d;
+            return G_SOURCE_REMOVE;
+        }, dead);
+    });
+
+    dialog->show_all();
+    dialog->present();
 }
 
 // ---------------------------------------------------------------------------
@@ -343,12 +473,90 @@ static gboolean ra_gtk_apply_credentials(gpointer data)
         {
             auto item = Glib::RefPtr<Gtk::MenuItem>::cast_static(login_obj);
             if (item)
-                item->set_label(u->logged_in ? _("_Logout") : _("_Login..."));
+            {
+                if (u->logged_in)
+                {
+                    // Show "Logout <user> (N points)" like the win32/Qt menus.
+                    char buf[256];
+                    if (RA_GetLoggedInUserString(buf, sizeof(buf)))
+                        item->set_label(Glib::ustring(_("_Logout ")) + buf);
+                    else
+                        item->set_label(_("_Logout"));
+                }
+                else
+                {
+                    item->set_label(_("_Login..."));
+                }
+            }
         }
     }
 
+    // Login state gates the achievement-list / view-profile items.
+    if (top_level)
+        top_level->configure_widgets();
+
     delete u;
     return G_SOURCE_REMOVE;
+}
+
+// ---------------------------------------------------------------------------
+// Login result — success/error feedback. May arrive on a background HTTP
+// thread, so the dialog is marshalled to the GTK main thread.
+// ---------------------------------------------------------------------------
+struct RALoginResult
+{
+    bool        success;
+    std::string message;
+    bool        user_initiated;
+};
+
+static gboolean ra_gtk_apply_login_result(gpointer data)
+{
+    auto *r = static_cast<RALoginResult *>(data);
+
+    if (top_level && top_level->window)
+    {
+        if (!r->success)
+        {
+            Gtk::MessageDialog dialog(*top_level->window.get(), r->message, false,
+                                      Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
+            dialog.set_title(_("RetroAchievements — Login Failed"));
+            dialog.run();
+        }
+        else if (r->user_initiated)
+        {
+            Gtk::MessageDialog dialog(*top_level->window.get(), r->message, false,
+                                      Gtk::MESSAGE_INFO, Gtk::BUTTONS_OK, true);
+            dialog.set_title(_("RetroAchievements"));
+            dialog.run();
+        }
+    }
+
+    delete r;
+    return G_SOURCE_REMOVE;
+}
+
+static void ra_gtk_on_login_result(bool success, const char *message, bool user_initiated)
+{
+    g_idle_add(ra_gtk_apply_login_result,
+               new RALoginResult{success, message ? message : "", user_initiated});
+}
+
+// ---------------------------------------------------------------------------
+// Reset emulator — achievement-integrity hard reset. May arrive on a
+// background HTTP thread; the emulation loop runs on the GTK main thread, so
+// marshal the reset there.
+// ---------------------------------------------------------------------------
+static gboolean ra_gtk_apply_reset(gpointer)
+{
+    S9xReset();
+    RA_OnReset();
+    return G_SOURCE_REMOVE;
+}
+
+static void ra_gtk_reset_emulator()
+{
+    g_idle_add(ra_gtk_apply_reset, nullptr);
 }
 
 static void ra_gtk_credentials_changed(const char *username, const char *token)
@@ -381,6 +589,8 @@ void RA_Gtk_RegisterCallbacks()
     cb.confirm_disable_hardcore = ra_gtk_confirm_disable_hardcore;
     cb.log_message = ra_gtk_log;
     cb.on_credentials_changed = ra_gtk_credentials_changed;
+    cb.on_login_result = ra_gtk_on_login_result;
+    cb.reset_emulator = ra_gtk_reset_emulator;
     RA_RegisterPlatformCallbacks(cb);
 }
 

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -354,6 +354,9 @@ static void game_loop()
         S9xMainLoop();
 
 #ifdef RETROACHIEVEMENTS_SUPPORT
+        // Suspend achievement processing during netplay so remote players'
+        // inputs can't earn unlocks on this account.
+        RA_SetNetplayActive(Settings.NetPlay || Settings.NetPlayServer);
         RA_DoFrame();
 #endif
 

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -351,6 +351,16 @@ void Snes9xWindow::connect_signals()
         RA_ShowAchievementList();
     });
 
+    get_object<Gtk::MenuItem>("ra_view_profile_item")->signal_activate().connect([] {
+        rc_client_t *client = RA_GetClient();
+        const rc_client_user_t *user = client ? rc_client_get_user_info(client) : nullptr;
+        if (user && user->username && user->username[0])
+        {
+            std::string url = std::string("https://retroachievements.org/user/") + user->username;
+            g_app_info_launch_default_for_uri(url.c_str(), nullptr, nullptr);
+        }
+    });
+
     // Stored credentials imply we auto-login at startup; reflect that in the label.
     if (!gui_config->ra_username.empty() && !gui_config->ra_api_token.empty())
         get_object<Gtk::MenuItem>("ra_login_item")->set_label(_("_Logout"));
@@ -1018,6 +1028,13 @@ void Snes9xWindow::configure_widgets()
     };
     for (auto &widget : enable_when_rom_loaded)
         enable_widget(widget, config->rom_loaded);
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    // The achievement list only makes sense with a game loaded and a user
+    // logged in (win32 gates it on a running game); View Profile needs a login.
+    enable_widget("ra_achievement_list_item", config->rom_loaded && RA_IsLoggedIn());
+    enable_widget("ra_view_profile_item", RA_IsLoggedIn());
+#endif
 
     enable_widget("sync_clients_item",
                   config->rom_loaded &&

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -2188,8 +2188,18 @@
                     <child>
                       <object class="GtkMenuItem" id="ra_achievement_list_item">
                         <property name="visible">True</property>
+                        <property name="sensitive">False</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">_Achievement List...</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="ra_view_profile_item">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">_View Profile</property>
                         <property name="use_underline">True</property>
                       </object>
                     </child>

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -4832,6 +4832,21 @@ static void S9xSimulateSFEXProtection (uint8 *rom, uint32 size, uint32 crc32)
 	printf("Street Fighter EX Plus Alpha: cart protection simulated\n");
 }
 
+// Titles that need invalid VRAM access allowed to render correctly. Keyed on
+// ROMCRC32; the effective setting is per-game, so the user's own preference in
+// the Hacks dialog is left untouched for every other cart.
+static const struct
+{
+	uint32		crc32;
+	const char	*title;
+} allow_invalid_vram[] =
+{
+	// DMAs the ASK Kodansha logo into VRAM with the screen still on: blocked,
+	// the title screen is a blank white BG1 and a soft reset comes back
+	// garbled. Verified both fixed with the transfer allowed.
+	{ 0xB56EC084, "Rin Kaihou Kudan no Igo Taidou (J)" },
+};
+
 void CMemory::ApplyROMFixes (void)
 {
 	Settings.BlockInvalidVRAMAccess = Settings.BlockInvalidVRAMAccessMaster;
@@ -4847,6 +4862,20 @@ void CMemory::ApplyROMFixes (void)
 	{
 		SNESGameFixes.RAMInitialValue = 0x00;
 		printf("Applied zeroed-WRAM hack.\n");
+	}
+
+	// Games that upload graphics to VRAM with the screen still on. Blocking
+	// those writes is right in general, so it stays on for everything else
+	// and the Hacks dialog checkbox keeps whatever the user chose; these
+	// titles just turn it off for themselves.
+	for (unsigned i = 0; i < sizeof(allow_invalid_vram) / sizeof(allow_invalid_vram[0]); i++)
+	{
+		if (ROMCRC32 == allow_invalid_vram[i].crc32)
+		{
+			Settings.BlockInvalidVRAMAccess = FALSE;
+			printf("Allowing invalid VRAM access for %s.\n", allow_invalid_vram[i].title);
+			break;
+		}
 	}
 
 	PF94.active = FALSE;

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -4850,6 +4850,7 @@ static const struct
 void CMemory::ApplyROMFixes (void)
 {
 	Settings.BlockInvalidVRAMAccess = Settings.BlockInvalidVRAMAccessMaster;
+	Settings.BlockInvalidVRAMAccessOverride = FALSE;
 
 	// Not gated on DisableGameSpecificHacks: this stands in for cart hardware
 	// we don't emulate, without which the game never boots at all.
@@ -4873,6 +4874,7 @@ void CMemory::ApplyROMFixes (void)
 		if (ROMCRC32 == allow_invalid_vram[i].crc32)
 		{
 			Settings.BlockInvalidVRAMAccess = FALSE;
+			Settings.BlockInvalidVRAMAccessOverride = TRUE;
 			printf("Allowing invalid VRAM access for %s.\n", allow_invalid_vram[i].title);
 			break;
 		}

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SNES9X_CORE_SOURCES
     ../bml.cpp
     ../cpuops.cpp
     ../cpuexec.cpp
+    ../voicekun.cpp
     ../sa1cpu.cpp
     ../cheats.cpp
     ../cheats2.cpp

--- a/qt/src/EmuApplication.cpp
+++ b/qt/src/EmuApplication.cpp
@@ -17,6 +17,8 @@
 #ifdef RETROACHIEVEMENTS_SUPPORT
 #include "RAIntegrationQt.hpp"
 #include "retroachievements.h"
+#include "snes9x.h"
+#include "display.h"
 #endif
 #ifdef KAILLERA_SUPPORT
 #include "kaillera_client.h"
@@ -304,6 +306,13 @@ void EmuApplication::mainLoop()
 
     core->mainLoop();
 #ifdef RETROACHIEVEMENTS_SUPPORT
+    // Suspend achievement processing during netplay so remote players' inputs
+    // can't earn unlocks on this account.
+    bool ra_netplay = Settings.NetPlay || Settings.NetPlayServer;
+#ifdef KAILLERA_SUPPORT
+    ra_netplay = ra_netplay || KailleraClientIsPlaying();
+#endif
+    RA_SetNetplayActive(ra_netplay);
     RA_DoFrame();
 #endif
 }
@@ -443,7 +452,11 @@ void EmuApplication::handleBinding(const std::string &name, bool pressed)
         {
 #ifdef RETROACHIEVEMENTS_SUPPORT
             if (RA_IsHardcoreModeActive())
+            {
                 core->rewinding = false;
+                if (pressed)
+                    S9xSetInfoString("Rewind is not allowed in Hardcore mode");
+            }
             else
 #endif
             core->rewinding = pressed;

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -33,6 +33,8 @@
 #include "memmap.h"
 
 #include <QMessageBox>
+#include <QDesktopServices>
+#include <QUrl>
 #undef KeyPress
 
 static EmuSettingsWindow *g_emu_settings_window = nullptr;
@@ -504,11 +506,22 @@ void EmuMainWindow::createWidgets()
         RA_ShowAchievementList();
     });
 
+    ra_view_profile_action = ra_menu->addAction(tr("&View Profile"));
+    ra_view_profile_action->setEnabled(false);
+    connect(ra_view_profile_action, &QAction::triggered, [&] {
+        rc_client_t *client = RA_GetClient();
+        const rc_client_user_t *user = client ? rc_client_get_user_info(client) : nullptr;
+        if (user && user->username && user->username[0])
+            QDesktopServices::openUrl(QUrl(
+                QString("https://retroachievements.org/user/%1").arg(user->username)));
+    });
+
     connect(ra_menu, &QMenu::aboutToShow, [this] {
         bool enabled = app->config->ra_enabled;
         ra_login_action->setEnabled(enabled);
         ra_hardcore_action->setEnabled(enabled);
-        ra_achievements_action->setEnabled(enabled && app->isCoreActive());
+        ra_achievements_action->setEnabled(enabled && app->isCoreActive() && RA_IsLoggedIn());
+        ra_view_profile_action->setEnabled(enabled && RA_IsLoggedIn());
     });
 
     menuBar()->addMenu(ra_menu);

--- a/qt/src/EmuMainWindow.hpp
+++ b/qt/src/EmuMainWindow.hpp
@@ -76,6 +76,7 @@ class EmuMainWindow : public QMainWindow
     QAction *ra_login_action = nullptr;
     QAction *ra_hardcore_action = nullptr;
     QAction *ra_achievements_action = nullptr;
+    QAction *ra_view_profile_action = nullptr;
 #endif
 #ifdef KAILLERA_SUPPORT
     QAction *kaillera_host_action = nullptr;

--- a/qt/src/EmulationPanel.cpp
+++ b/qt/src/EmulationPanel.cpp
@@ -1,6 +1,7 @@
 #include "EmulationPanel.hpp"
 #include "EmuApplication.hpp"
 #include "EmuConfig.hpp"
+#include "Snes9xController.hpp"
 #include "snes9x.h"
 
 EmulationPanel::EmulationPanel(EmuApplication *app_)
@@ -59,7 +60,9 @@ void EmulationPanel::showEvent(QShowEvent *event)
     // and cannot be written back over the preference. The handler is on
     // clicked(), so setting the state here raises no signal.
     {
-        const bool vram_auto = !Settings.StopEmulation &&
+        // core->active (not Settings.StopEmulation, which the Qt frontend
+        // never clears) is this frontend's "a ROM is running" flag.
+        const bool vram_auto = app->core->active &&
             Settings.BlockInvalidVRAMAccessOverride;
         checkBox_allow_invalid_vram_access->setChecked(
             vram_auto ? !Settings.BlockInvalidVRAMAccess : config->allow_invalid_vram_access);

--- a/qt/src/EmulationPanel.cpp
+++ b/qt/src/EmulationPanel.cpp
@@ -1,6 +1,7 @@
 #include "EmulationPanel.hpp"
 #include "EmuApplication.hpp"
 #include "EmuConfig.hpp"
+#include "snes9x.h"
 
 EmulationPanel::EmulationPanel(EmuApplication *app_)
     : app(app_)
@@ -53,7 +54,17 @@ void EmulationPanel::showEvent(QShowEvent *event)
     spinBox_rewind_buffer_size->setValue(config->rewind_buffer_size);
     spinBox_rewind_frames->setValue(config->rewind_frame_interval);
 
-    checkBox_allow_invalid_vram_access->setChecked(config->allow_invalid_vram_access);
+    // A game on the allow-invalid-VRAM list overrides the preference for
+    // itself; show that and disable the box so the automatic choice is visible
+    // and cannot be written back over the preference. The handler is on
+    // clicked(), so setting the state here raises no signal.
+    {
+        const bool vram_auto = !Settings.StopEmulation &&
+            Settings.BlockInvalidVRAMAccess != Settings.BlockInvalidVRAMAccessMaster;
+        checkBox_allow_invalid_vram_access->setChecked(
+            vram_auto ? !Settings.BlockInvalidVRAMAccess : config->allow_invalid_vram_access);
+        checkBox_allow_invalid_vram_access->setEnabled(!vram_auto);
+    }
     checkBox_allow_opposing_dpad_directions->setChecked(config->allow_opposing_dpad_directions);
     comboBox_overclock->setCurrentIndex(config->overclock);
     checkBox_remove_sprite_limit->setChecked(config->remove_sprite_limit);

--- a/qt/src/EmulationPanel.cpp
+++ b/qt/src/EmulationPanel.cpp
@@ -60,7 +60,7 @@ void EmulationPanel::showEvent(QShowEvent *event)
     // clicked(), so setting the state here raises no signal.
     {
         const bool vram_auto = !Settings.StopEmulation &&
-            Settings.BlockInvalidVRAMAccess != Settings.BlockInvalidVRAMAccessMaster;
+            Settings.BlockInvalidVRAMAccessOverride;
         checkBox_allow_invalid_vram_access->setChecked(
             vram_auto ? !Settings.BlockInvalidVRAMAccess : config->allow_invalid_vram_access);
         checkBox_allow_invalid_vram_access->setEnabled(!vram_auto);

--- a/qt/src/RAIntegrationQt.cpp
+++ b/qt/src/RAIntegrationQt.cpp
@@ -22,6 +22,9 @@
 #include <QHeaderView>
 #include <QApplication>
 #include <QThread>
+#include <QTimer>
+#include <QPointer>
+#include <QScrollBar>
 #include <thread>
 #include <cstdio>
 #include <cstring>
@@ -184,37 +187,34 @@ static void ra_qt_show_login()
 }
 
 // ---------------------------------------------------------------------------
-// Qt Achievement List Dialog
+// Qt Achievement List Dialog (modeless, refreshes once a second)
 // ---------------------------------------------------------------------------
-static void ra_qt_show_achievements()
-{
-    if (!g_app || !g_app->window)
-        return;
+static QPointer<QDialog> s_achievements_dlg;
 
+static QString ra_qt_type_string(uint8_t type)
+{
+    switch (type)
+    {
+    case RC_CLIENT_ACHIEVEMENT_TYPE_MISSABLE:    return "Missable";
+    case RC_CLIENT_ACHIEVEMENT_TYPE_PROGRESSION: return "Progression";
+    case RC_CLIENT_ACHIEVEMENT_TYPE_WIN:         return "Win Condition";
+    default:                                     return "";
+    }
+}
+
+static void ra_qt_populate_achievements(QTreeWidget *tree, QLabel *summary)
+{
     rc_client_t *client = RA_GetClient();
     if (!client)
         return;
 
-    QDialog dlg(g_app->window.get());
-    dlg.setWindowTitle("RetroAchievements");
-    dlg.resize(550, 400);
+    // Preserve the user's sort choice and scroll position across the refresh.
+    const int sort_col = tree->header()->sortIndicatorSection();
+    const Qt::SortOrder sort_order = tree->header()->sortIndicatorOrder();
+    const int scroll = tree->verticalScrollBar()->value();
 
-    auto *layout = new QVBoxLayout(&dlg);
-
-    const rc_client_game_t *game = rc_client_get_game_info(client);
-    auto *titleLabel = new QLabel(game ? game->title : "No game loaded");
-    auto font = titleLabel->font();
-    font.setBold(true);
-    titleLabel->setFont(font);
-    layout->addWidget(titleLabel);
-
-    auto *tree = new QTreeWidget();
-    tree->setHeaderLabels({"Title", "Points", "Status", "Description"});
-    tree->setRootIsDecorated(false);
-    tree->setAlternatingRowColors(true);
-    tree->setSortingEnabled(true);
-    tree->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
-    tree->header()->setStretchLastSection(true);
+    tree->setSortingEnabled(false);
+    tree->clear();
 
     rc_client_achievement_list_t *list = rc_client_create_achievement_list(client,
         RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
@@ -243,14 +243,90 @@ static void ra_qt_show_achievements()
                     ach->title,
                     QString::number(ach->points),
                     status,
+                    ach->measured_progress,
+                    ra_qt_type_string(ach->type),
                     ach->description
                 });
+                // Keep the Points column sorting numerically.
+                item->setData(1, Qt::UserRole, ach->points);
                 tree->addTopLevelItem(item);
             }
         }
         rc_client_destroy_achievement_list(list);
     }
 
+    tree->setSortingEnabled(true);
+    tree->header()->setSortIndicator(sort_col, sort_order);
+    tree->verticalScrollBar()->setValue(scroll);
+
+    if (!summary)
+        return;
+
+    const rc_client_game_t *game = rc_client_get_game_info(client);
+    if (!game)
+    {
+        summary->setText("No game loaded");
+        return;
+    }
+
+    rc_client_user_game_summary_t gs = {};
+    rc_client_get_user_game_summary(client, &gs);
+    QString text = QString("%1 - %2 of %3 achievements, %4 of %5 points")
+                       .arg(game->title)
+                       .arg(gs.num_unlocked_achievements)
+                       .arg(gs.num_core_achievements)
+                       .arg(gs.points_unlocked)
+                       .arg(gs.points_core);
+
+    char user_buf[256];
+    if (RA_GetLoggedInUserString(user_buf, sizeof(user_buf)))
+        text += QString("    |    Logged in as %1%2")
+                    .arg(user_buf)
+                    .arg(RA_IsHardcoreModeActive() ? " - Hardcore" : "");
+    else
+        text += "    |    Not logged in";
+
+    summary->setText(text);
+}
+
+static void ra_qt_show_achievements()
+{
+    if (!g_app || !g_app->window)
+        return;
+
+    // Modeless: focus the existing window instead of opening a second one.
+    if (s_achievements_dlg)
+    {
+        s_achievements_dlg->raise();
+        s_achievements_dlg->activateWindow();
+        return;
+    }
+
+    if (!RA_GetClient())
+        return;
+
+    auto *dlg = new QDialog(g_app->window.get());
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->setWindowTitle("RetroAchievements");
+    dlg->resize(700, 440);
+    s_achievements_dlg = dlg;
+
+    auto *layout = new QVBoxLayout(dlg);
+
+    auto *summary = new QLabel();
+    auto font = summary->font();
+    font.setBold(true);
+    summary->setFont(font);
+    summary->setWordWrap(true);
+    layout->addWidget(summary);
+
+    auto *tree = new QTreeWidget();
+    tree->setHeaderLabels({"Title", "Points", "Status", "Progress", "Type", "Description"});
+    tree->setRootIsDecorated(false);
+    tree->setAlternatingRowColors(true);
+    tree->setSortingEnabled(true);
+    tree->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    tree->header()->setStretchLastSection(true);
     layout->addWidget(tree);
 
     auto *closeBtn = new QPushButton("Close");
@@ -259,10 +335,18 @@ static void ra_qt_show_achievements()
     btnLayout->addWidget(closeBtn);
     btnLayout->addStretch();
     layout->addLayout(btnLayout);
+    QObject::connect(closeBtn, &QPushButton::clicked, dlg, &QDialog::close);
 
-    QObject::connect(closeBtn, &QPushButton::clicked, &dlg, &QDialog::accept);
+    ra_qt_populate_achievements(tree, summary);
 
-    dlg.exec();
+    // Live refresh once a second while the game keeps running behind the dialog.
+    auto *timer = new QTimer(dlg);
+    QObject::connect(timer, &QTimer::timeout, dlg, [tree, summary]() {
+        ra_qt_populate_achievements(tree, summary);
+    });
+    timer->start(1000);
+
+    dlg->show();
 }
 
 // ---------------------------------------------------------------------------
@@ -325,10 +409,56 @@ static void ra_qt_credentials_changed(const char *username, const char *token)
         g_app->config->ra_enabled = logged_in;
         g_app->config->saveFile(EmuConfig::findConfigFile());
 
-        // Update Login/Logout menu text
-        if (g_app->window && g_app->window->ra_login_action)
-            g_app->window->ra_login_action->setText(logged_in ? "&Logout" : "&Login...");
+        if (!g_app->window)
+            return;
+
+        // Update Login/Logout menu text; when logged in, show "Logout <user> (N points)".
+        if (g_app->window->ra_login_action)
+        {
+            if (logged_in)
+            {
+                char buf[256];
+                if (RA_GetLoggedInUserString(buf, sizeof(buf)))
+                    g_app->window->ra_login_action->setText(QString("&Logout %1").arg(buf));
+                else
+                    g_app->window->ra_login_action->setText("&Logout");
+            }
+            else
+            {
+                g_app->window->ra_login_action->setText("&Login...");
+            }
+        }
+
+        if (g_app->window->ra_view_profile_action)
+            g_app->window->ra_view_profile_action->setEnabled(logged_in);
     }, Qt::QueuedConnection);
+}
+
+// ---------------------------------------------------------------------------
+// Qt Login Result — show success/error feedback (may arrive on HTTP thread)
+// ---------------------------------------------------------------------------
+static void ra_qt_on_login_result(bool success, const char *message, bool user_initiated)
+{
+    std::string msg = message ? message : "";
+    QMetaObject::invokeMethod(QApplication::instance(), [=]() {
+        QWidget *parent = g_app ? g_app->window.get() : nullptr;
+        if (!success)
+            QMessageBox::critical(parent, "RetroAchievements - Login Failed",
+                                  QString::fromStdString(msg));
+        else if (user_initiated)
+            QMessageBox::information(parent, "RetroAchievements",
+                                     QString::fromStdString(msg));
+    }, Qt::QueuedConnection);
+}
+
+// ---------------------------------------------------------------------------
+// Qt Reset Emulator — achievement-integrity hard reset (may arrive on HTTP thread)
+// ---------------------------------------------------------------------------
+static void ra_qt_reset_emulator()
+{
+    // powerCycle() marshals to the emu thread and calls RA_OnReset().
+    if (g_app)
+        g_app->powerCycle();
 }
 
 // ---------------------------------------------------------------------------
@@ -353,6 +483,8 @@ void RA_Qt_RegisterCallbacks(EmuApplication *app)
     cb.confirm_disable_hardcore = ra_qt_confirm_disable_hardcore;
     cb.log_message = ra_qt_log;
     cb.on_credentials_changed = ra_qt_credentials_changed;
+    cb.on_login_result = ra_qt_on_login_result;
+    cb.reset_emulator = ra_qt_reset_emulator;
     RA_RegisterPlatformCallbacks(cb);
 }
 

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -74,7 +74,7 @@ void Snes9xController::init()
     Settings.DisplayIndicators = true;
     Settings.SoundPlaybackRate = 48000;
     Settings.SoundInputRate = 32040;
-    Settings.BlockInvalidVRAMAccess = true;
+    Settings.BlockInvalidVRAMAccessMaster = true;
     Settings.SoundSync = false;
     Settings.Mute = false;
     Settings.DynamicRateControl = false;
@@ -156,7 +156,10 @@ void Snes9xController::updateSettings(EmuConfig *config)
         S9xUpdateDynamicRate();
     }
 
-    Settings.BlockInvalidVRAMAccess = !config->allow_invalid_vram_access;
+    // The preference lives in ...Master; ApplyROMFixes copies it into the
+    // effective flag per game, so writing the effective one here was lost on
+    // every ROM load.
+    Settings.BlockInvalidVRAMAccessMaster = !config->allow_invalid_vram_access;
 
     Settings.SoundSync = config->speed_sync_method == EmuConfig::eSoundSync;
 

--- a/snes9x.h
+++ b/snes9x.h
@@ -302,6 +302,7 @@ struct SSettings
 	bool8	DisableGameSpecificHacks;
 	bool8	BlockInvalidVRAMAccessMaster;
 	bool8	BlockInvalidVRAMAccess;
+	bool8	BlockInvalidVRAMAccessOverride;
 	int32	HDMATimingHack;
 
 	bool8	ForcedPause;

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -7122,7 +7122,7 @@ INT_PTR CALLBACK DlgEmulatorHacksProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM
         // visible without the saved preference being rewritten.
         {
             const bool vram_auto = !Settings.StopEmulation &&
-                Settings.BlockInvalidVRAMAccess != Settings.BlockInvalidVRAMAccessMaster;
+                Settings.BlockInvalidVRAMAccessOverride;
             CheckDlgButton(hDlg, IDC_INVALID_VRAM,
                 vram_auto ? !Settings.BlockInvalidVRAMAccess : !Settings.BlockInvalidVRAMAccessMaster);
             EnableWindow(GetDlgItem(hDlg, IDC_INVALID_VRAM), !vram_auto);

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -7117,7 +7117,16 @@ INT_PTR CALLBACK DlgEmulatorHacksProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM
         SendDlgItemMessage(hDlg, IDC_SOUND_INTERPOLATION, CB_ADDSTRING, 0, (LPARAM)TEXT("Sinc"));
         SendDlgItemMessage(hDlg, IDC_SOUND_INTERPOLATION, CB_SETCURSEL, Settings.InterpolationMethod, 0);
 
-        CheckDlgButton(hDlg, IDC_INVALID_VRAM, !Settings.BlockInvalidVRAMAccessMaster);
+        // A game on the allow-invalid-VRAM list overrides the preference for
+        // itself; show that state and grey the box so the automatic choice is
+        // visible without the saved preference being rewritten.
+        {
+            const bool vram_auto = !Settings.StopEmulation &&
+                Settings.BlockInvalidVRAMAccess != Settings.BlockInvalidVRAMAccessMaster;
+            CheckDlgButton(hDlg, IDC_INVALID_VRAM,
+                vram_auto ? !Settings.BlockInvalidVRAMAccess : !Settings.BlockInvalidVRAMAccessMaster);
+            EnableWindow(GetDlgItem(hDlg, IDC_INVALID_VRAM), !vram_auto);
+        }
         CheckDlgButton(hDlg, IDC_SEPARATE_ECHO_BUFFER, Settings.SeparateEchoBuffer);
         CheckDlgButton(hDlg, IDC_NO_SPRITE_LIMIT, Settings.MaxSpriteTilesPerLine == 128);
         CheckDlgButton(hDlg, IDC_ALLOW_EXE_ICON, GUI.ExeIconRewriteOK);
@@ -7225,7 +7234,10 @@ INT_PTR CALLBACK DlgEmulatorHacksProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM
         switch (LOWORD(wParam))
         {
         case IDOK:
-            if (((Settings.BlockInvalidVRAMAccessMaster != !IsDlgButtonChecked(hDlg, IDC_INVALID_VRAM)) ||
+            // Greyed means the current game forced the setting, so the box no
+            // longer reflects the preference and must not be read back.
+            if (((IsWindowEnabled(GetDlgItem(hDlg, IDC_INVALID_VRAM)) &&
+                  Settings.BlockInvalidVRAMAccessMaster != !IsDlgButtonChecked(hDlg, IDC_INVALID_VRAM)) ||
                 (Settings.SeparateEchoBuffer != IsDlgButtonChecked(hDlg, IDC_SEPARATE_ECHO_BUFFER)))
                 && !Settings.StopEmulation)
             {
@@ -7238,7 +7250,8 @@ INT_PTR CALLBACK DlgEmulatorHacksProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM
             Settings.SuperFXClockMultiplier = SendDlgItemMessage(hDlg, IDC_SFX_CLOCK_SPEED_SPIN, UDM_GETPOS, 0, 0);
             Settings.OverclockMode = SendDlgItemMessage(hDlg, IDC_CPU_OVERCLOCK, CB_GETCURSEL, 0, 0);
             Settings.InterpolationMethod = SendDlgItemMessage(hDlg, IDC_SOUND_INTERPOLATION, CB_GETCURSEL, 0, 0);
-            Settings.BlockInvalidVRAMAccessMaster = !IsDlgButtonChecked(hDlg, IDC_INVALID_VRAM);
+            if (IsWindowEnabled(GetDlgItem(hDlg, IDC_INVALID_VRAM)))
+                Settings.BlockInvalidVRAMAccessMaster = !IsDlgButtonChecked(hDlg, IDC_INVALID_VRAM);
             Settings.SeparateEchoBuffer = IsDlgButtonChecked(hDlg, IDC_SEPARATE_ECHO_BUFFER);
             Settings.MaxSpriteTilesPerLine = IsDlgButtonChecked(hDlg, IDC_NO_SPRITE_LIMIT) ? 128 : 34;
             GUI.ExeIconRewriteOK = IsDlgButtonChecked(hDlg, IDC_ALLOW_EXE_ICON);


### PR DESCRIPTION
## Summary

A batch of cross-platform emulation fixes touching three areas:

1. **Invalid-VRAM access** — allow it for the specific games that need it, persist the preference correctly, and surface the per-game override in the GTK/Qt UI without clobbering the user's saved setting.
2. **Build fixes** — link `voicekun.cpp` into the GTK and Qt builds so the core resolves.
3. **RetroAchievements** — port the win32 RA usability/correctness overhaul to the GTK and Qt frontends so all three platforms behave the same.

Everything is gtk/qt (+ shared core); the one win32 hunk is a shared-flag rename that keeps win32 consistent. Both `snes9x-gtk` and `snes9x-qt` build cleanly.

---

## 1. Invalid VRAM access

Some titles DMA graphics into VRAM with the screen still on. Blocking those writes is correct in general, but a few games render incorrectly (or don't boot) without them.

- **Per-game allow list** (`memmap.cpp`): `ApplyROMFixes()` turns off `BlockInvalidVRAMAccess` for CRC-matched titles. First entry: `Rin Kaihou Kudan no Igo Taidou (J)` (`0xB56EC084`) — otherwise its title screen is a blank white BG1 and a soft reset comes back garbled.
- **Preference persistence** (Qt): the user's choice is applied to `...Master` so it survives a ROM load instead of being overwritten.
- **UI override display** (GTK + Qt): when a listed game forces the setting, the "Allow Invalid VRAM Access" checkbox reflects the automatic choice and is **grayed out**, so the automatic state is visible and the saved preference is never rewritten.
- **Robust override detection** (`snes9x.h`, `memmap.cpp`, GTK/Qt/win32): the earlier detection compared effective-vs-master, which collapsed to "no override" whenever the user's own preference already enabled invalid-VRAM. Replaced with an explicit `Settings.BlockInvalidVRAMAccessOverride` flag set in `ApplyROMFixes()`, so the checkbox grays out reliably regardless of the saved preference.
- Qt gates the "auto" display on the frontend's real running flag (`core->active`) rather than `Settings.StopEmulation`, which the Qt frontend never clears on a normal ROM load.

## 2. Build fixes

- `gtk/CMakeLists.txt`, `qt/CMakeLists.txt`: add `../voicekun.cpp`. Both frontends referenced the `S9xVoiceKun*` symbols / `VoiceKunHook` from the core but never compiled `voicekun.cpp`, causing undefined-reference link errors.

## 3. RetroAchievements port (GTK + Qt → parity with win32)

The shared core already exposed the new callbacks/hooks; this wires them into both frontends and adds the UI:

- **Login feedback** (`on_login_result`): success/error dialogs — errors always shown, success (with points) only for user-initiated logins — marshalled from the HTTP worker thread to the UI thread.
- **Integrity reset** (`reset_emulator`): hard reset marshalled to the emu thread (Qt `powerCycle()`, GTK `g_idle_add` → `S9xReset()` + `RA_OnReset()`).
- **Netplay suspension**: `RA_SetNetplayActive()` called each frame so remote players' inputs can't earn unlocks on this account (Qt also folds in Kaillera).
- **Menu**: new **View Profile** item (opens `retroachievements.org/user/<name>`) and a dynamic **"Logout &lt;user&gt; (N points)"** label via `RA_GetLoggedInUserString()`.
- **Achievement list**: now **modeless** (game keeps running), **refreshes once a second**, and gains **Progress** and **Type** (Missable / Progression / Win Condition) columns plus a game/user **summary header**. Sort order and scroll position are preserved across refreshes.
- **Hardcore**: rewind shows an OSD notice instead of failing silently.
- **Menu gating**: the Achievement List and View Profile items are disabled until a game is loaded **and** a user is logged in.

---

## Testing

- `snes9x-gtk` and `snes9x-qt` both compile and link cleanly.
- VRAM checkbox verified graying out for the listed game (`Rin Kaihou Kudan no Igo Taidou`) regardless of the saved preference.
