### PR TITLE
fix(i18n): localize dialogs that overwrite their text in WM_INITDIALOG

### DIFF
--- a/i18n/README.md
+++ b/i18n/README.md
@@ -12,6 +12,13 @@ placed next to `snes9x.exe`. The on-disk `.po` files are also what drives the
 **Translations** menu: each `<lang>.po` present adds its language. Delete them and
 the app runs in English. No rebuild is needed to add or edit a translation.
 
+Dialogs call `LocalizeDialog(hDlg)` from `WM_INITDIALOG`, which localizes twice:
+once immediately, and once more after the handler returned (before the first
+paint), so a dialog that overwrites its `.rc` text with a hardcoded English
+`SetDlgItemText`/`SetWindowText` default still ends up translated. Text written
+to a control *after* init — tab switches, status lines — is not covered; wrap
+those in `_L(...)` at the call site.
+
 ## How the GTK build uses these
 GTK compiles `<lang>.po` → `.mo` via CMake (`gtk/CMakeLists.txt`) and loads it
 with gettext. To add a language to the GTK build, add its code to the

--- a/win32/wlocale.cpp
+++ b/win32/wlocale.cpp
@@ -16,6 +16,10 @@ static bool g_keysLoaded = false;
 static std::unordered_map<UINT, std::wstring> g_origMenuById;
 static std::unordered_map<HMENU, std::wstring> g_origMenuBySub;
 
+// Posted to the helper window to re-localize a dialog after its WM_INITDIALOG
+// handler finished; wParam is the dialog HWND.
+#define WM_LOCALIZE_REDO (WM_APP + 0x1F4)
+
 static const struct
 {
 	const wchar_t *code;
@@ -534,10 +538,8 @@ static BOOL CALLBACK LocalizeChildProc(HWND child, LPARAM lp)
 	return TRUE;
 }
 
-void LocalizeDialog(HWND dlg)
+static void LocalizeDialogPass(HWND dlg)
 {
-	if (!g_translated || dlg == NULL)
-		return;
 	wchar_t cap[1024];
 	int n = GetWindowTextW(dlg, cap, 1024);
 	if (n > 0)
@@ -550,6 +552,52 @@ void LocalizeDialog(HWND dlg)
 	EnumChildWindows(dlg, LocalizeChildProc, (LPARAM)&fit);
 	for (HWND c : fit)
 		FitTranslatedControl(c);
+}
+
+static LRESULT CALLBACK LocalizeHelperProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+	if (msg == WM_LOCALIZE_REDO)
+	{
+		HWND dlg = (HWND)wp;
+		if (g_translated && IsWindow(dlg))
+			LocalizeDialogPass(dlg);
+		return 0;
+	}
+	return DefWindowProcW(wnd, msg, wp, lp);
+}
+
+// Message-only sink for the deferred pass; keeping it off the dialog means we
+// never touch a dialog's own message chain.
+static HWND LocalizeHelperWnd()
+{
+	static HWND wnd = NULL;
+	static bool created = false;
+	if (!created)
+	{
+		created = true;
+		WNDCLASSEXW wc = {};
+		wc.cbSize = sizeof(wc);
+		wc.lpfnWndProc = LocalizeHelperProc;
+		wc.hInstance = GetModuleHandleW(NULL);
+		wc.lpszClassName = L"Snes9xLocalizeHelper";
+		RegisterClassExW(&wc);
+		wnd = CreateWindowExW(0, wc.lpszClassName, NULL, 0, 0, 0, 0, 0,
+							  HWND_MESSAGE, NULL, wc.hInstance, NULL);
+	}
+	return wnd;
+}
+
+void LocalizeDialog(HWND dlg)
+{
+	if (!g_translated || dlg == NULL)
+		return;
+	LocalizeDialogPass(dlg);
+
+	// Callers run this from the top of WM_INITDIALOG and then overwrite control
+	// text with hardcoded English, so repeat the pass once the handler returned.
+	HWND helper = LocalizeHelperWnd();
+	if (helper)
+		PostMessageW(helper, WM_LOCALIZE_REDO, (WPARAM)dlg, 0);
 }
 
 static void LoadKeysOnce()

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -13237,7 +13237,7 @@ static void set_hotkeyinfo(HWND hDlg, bool layoutChanged)
 		if (!savestates && item.key_entry)
 		{
 			SendMultiBindHotkeyToControl(hDlg, g_hotkeyControlIds[i], item.key_entry, item.extra_entry);
-			SetDlgItemText(hDlg, g_hotkeyLabelIds[i], item.description);
+			SetDlgItemText(hDlg, g_hotkeyLabelIds[i], _L(item.description));
 		}
 		else
 		{


### PR DESCRIPTION
Fixes #185.

## Cause

Every dialog proc calls `LocalizeDialog(hDlg)` as the *first* statement of `WM_INITDIALOG`, and roughly half of them then re-write the caption and their Static/Button text with the hardcoded English macros from `wlanguage.h`. The translation is applied and immediately thrown away.

Input Configuration (the screenshot in the issue) is the clearest case: the caption, `IDC_JPTOGGLE`, `IDC_OK`/`IDC_CANCEL` and every `IDC_LABEL_*` are overwritten and show English, while the controls nothing touches — Auto-assign, the group boxes, the second Enabled checkbox — stay translated. Nothing is missing from the catalogs; `ja.po` already has `"Up"`, `"Enabled"`, `"Input Configuration"` and the rest.

All 34 `LocalizeDialog()` call sites in the tree have this ordering, so the same latent bug affects Netplay Connect/Options, Emulator Settings, Hotkeys, About, Multi-cart and the movie dialogs too.

## Fix

Reordering the call in every dialog proc works but has to be re-derived per dialog and silently rots for new ones, so this localizes **twice** instead:

- `LocalizeDialog()` runs the pass immediately (unchanged behaviour), then posts `WM_LOCALIZE_REDO` to a lazily-created message-only helper window carrying the dialog `HWND`.
- The dialog's own modal loop delivers that posted message after `WM_INITDIALOG` has returned, and posted messages outrank `WM_PAINT`, so the second pass lands before the dialog is first painted — no visible English flash.
- A separate sink keeps this out of the dialog's message chain entirely (no subclassing); `IsWindow()` guards a dialog closed in the meantime.
- The second pass is a no-op for anything already translated, since `_L()` returns its argument unchanged when there is no `msgid` match. Only clobbered controls get touched.

The Hotkeys dialog relabels its slots on every tab switch — after init — so no init-time ordering can reach it; that one call site takes `_L()` directly.

Still English by design, as noted in the issue: strings built with `_stprintf`, list/tree view columns, and message box text.

## Test

Set language to Japanese, then open Input Configuration, Hotkeys (switch tabs), Netplay > Options and About. Not compiled in this environment.

https://claude.ai/code/session_01P3hEeP1qkyGCoRE1D24uJW
