### PR TITLE
A.S.P. Air Strike Patrol: render the beam-raced mid-scanline PPU effects

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -225,6 +225,10 @@ static bool mid_line_event_pos (int &line, int &x)
 		return (false);
 	if (CPU.V_Counter < FIRST_VISIBLE_LINE || CPU.V_Counter >= PPU.ScreenHeight + FIRST_VISIBLE_LINE)
 		return (false);
+	// Writes from HBlank onward (HBlank-IRQ splits, HDMA) belong to the next
+	// line and stay on the ordinary per-line latch path.
+	if (CPU.Cycles >= Timings.HBlankStart)
+		return (false);
 	line = CPU.V_Counter - FIRST_VISIBLE_LINE;
 	x = CPU.Cycles / ONE_DOT_CYCLE - 22;
 	return (x >= 1 && x <= 255 && line <= 239);

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -403,7 +403,7 @@ static void S9xApplyMidLineRaster (void)
 		{
 			uint16	firstOld[8], lastNew[8], savedOfs[8];
 			bool	touched[8] = { false };
-			int		firstX = 256, lastX = 0;
+			int		maxFirstX = 0, lastX = 0;
 			bool	any = false;
 
 			for (int j = i; j < end; j++)
@@ -412,28 +412,37 @@ static void S9xApplyMidLineRaster (void)
 					continue;
 				const int	r = raster_events[j].reg;
 				if (!touched[r])
-					{ touched[r] = true; firstOld[r] = raster_events[j].oldV; }
+				{
+					touched[r] = true;
+					firstOld[r] = raster_events[j].oldV;
+					if (raster_events[j].x > maxFirstX)
+						maxFirstX = raster_events[j].x;
+				}
 				lastNew[r] = raster_events[j].newV;
-				if (raster_events[j].x < firstX)	firstX = raster_events[j].x;
-				if (raster_events[j].x > lastX)		lastX  = raster_events[j].x;
+				if (raster_events[j].x > lastX)
+					lastX = raster_events[j].x;
 				any = true;
 			}
 			if (!any)
 				continue;
 
-			// True timeline: left of the first write the old values rule,
-			// right of the last write the final values do; between them the
-			// line latch (whatever was live at the latch dot) already drew.
-			// Scroll writes act through the BG fetch pipeline, so their right
-			// boundary gets a one-tile margin before the reverted span.
+			// True timeline: the raster state rules from when its last
+			// register is set (+2 dots of pipeline) until its restore; the
+			// old values rule to the left, the final ones to the right.
+			// Scroll writes act through the BG fetch pipeline, so their
+			// right boundary gets a one-tile margin instead.
+			const int	leftEnd    = maxFirstX + 2;
+			int			rightStart = cls ? lastX + 8 : (lastX > 2 ? lastX - 2 : lastX);
+			if (rightStart < leftEnd)
+				rightStart = leftEnd;
+
 			for (int side = 0; side < 2; side++)
 			{
-				const int	rspanX = cls ? lastX + 8 : lastX;
 				raster_span_count = 0;
-				if (side == 0 && firstX > 1)
-					{ raster_span_l[0] = 0; raster_span_r[0] = firstX; raster_span_count = 1; }
-				if (side == 1 && rspanX < 255)
-					{ raster_span_l[0] = rspanX; raster_span_r[0] = 256; raster_span_count = 1; }
+				if (side == 0 && maxFirstX > 1 && leftEnd < 256)
+					{ raster_span_l[0] = 0; raster_span_r[0] = leftEnd; raster_span_count = 1; }
+				if (side == 1 && rightStart < 255)
+					{ raster_span_l[0] = rightStart; raster_span_r[0] = 256; raster_span_count = 1; }
 				if (!raster_span_count)
 					continue;
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -404,8 +404,9 @@ static void S9xApplyMidLineRaster (void)
 		for (int cls = 0; line < (int) PPU.ScreenHeight && cls < 2; cls++)
 		{
 			uint16	firstOld[8], lastNew[8], savedOfs[8];
+			uint8	lastXPerReg[8];
 			bool	touched[8] = { false };
-			int		maxFirstX = 0, lastX = 0;
+			int		maxFirstX = 0;
 			bool	any = false;
 
 			for (int j = i; j < end; j++)
@@ -421,20 +422,23 @@ static void S9xApplyMidLineRaster (void)
 						maxFirstX = raster_events[j].x;
 				}
 				lastNew[r] = raster_events[j].newV;
-				if (raster_events[j].x > lastX)
-					lastX = raster_events[j].x;
+				lastXPerReg[r] = raster_events[j].x;
 				any = true;
 			}
 			if (!any)
 				continue;
 
-			// True timeline: the raster state rules from when its last
-			// register is set (+2 dots of pipeline) until its restore; the
-			// old values rule to the left, the final ones to the right.
-			// Scroll writes act through the BG fetch pipeline, so their
-			// right boundary gets a one-tile margin instead.
+			// True timeline: the raster state is fully in effect once its
+			// last register is set and stops when the first one reverts,
+			// each taking effect ~2 dots after the write. Scroll writes act
+			// through the BG fetch pipeline, so their right boundary gets a
+			// one-tile margin instead.
+			int	minLastX = 256;
+			for (int r = 0; r < 8; r++)
+				if (touched[r] && lastXPerReg[r] < minLastX)
+					minLastX = lastXPerReg[r];
 			const int	leftEnd    = maxFirstX + 2;
-			int			rightStart = cls ? lastX + 8 : (lastX > 2 ? lastX - 2 : lastX);
+			int			rightStart = minLastX + (cls ? 8 : 2);
 			if (rightStart < leftEnd)
 				rightStart = leftEnd;
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -403,8 +403,8 @@ static void S9xApplyMidLineRaster (void)
 
 		for (int cls = 0; line < (int) PPU.ScreenHeight && cls < 2; cls++)
 		{
-			uint16	firstOld[8], lastNew[8], savedOfs[8];
-			uint8	lastXPerReg[8];
+			uint16	firstOld[8], firstNew[8], lastNew[8], savedOfs[8];
+			uint8	firstXPerReg[8], lastXPerReg[8];
 			bool	touched[8] = { false };
 			int		maxFirstX = 0, minFirstX = 256;
 			bool	any = false;
@@ -418,6 +418,8 @@ static void S9xApplyMidLineRaster (void)
 				{
 					touched[r] = true;
 					firstOld[r] = raster_events[j].oldV;
+					firstNew[r] = raster_events[j].newV;
+					firstXPerReg[r] = raster_events[j].x;
 					if (raster_events[j].x > maxFirstX)
 						maxFirstX = raster_events[j].x;
 					if (raster_events[j].x < minFirstX)
@@ -442,9 +444,27 @@ static void S9xApplyMidLineRaster (void)
 				if (touched[r] && (cls == 0 || !(r & 1)) && lastXPerReg[r] < minLastX)
 					minLastX = lastXPerReg[r];
 			// Windows switch as a set (both regs written before the effect
-			// shows); scroll offsets each take effect at their own write.
-			const int	leftEnd    = (cls ? minFirstX : maxFirstX) + 2;
-			int			rightStart = (minLastX >= 256) ? 256 : minLastX + (cls ? 8 : 2);
+			// shows); scroll offsets each take effect at their own write;
+			// mosaic starts at its next block-grid boundary, which keeps the
+			// grow-in's box border clear of the 14x14 blocks like hardware.
+			int	leftEnd = minFirstX + 2;
+			if (cls == 0)
+			{
+				for (int r = 0; r < 3; r++)
+					if (touched[r] && firstXPerReg[r] + 2 > leftEnd)
+						leftEnd = firstXPerReg[r] + 2;
+				if (touched[3])
+				{
+					// a mid-line mosaic enable takes roughly a max-size block
+					// to engage; A.S.P. times the grow-in's write so that
+					// latency spares the box border (block size animates, so
+					// grid rounding alone lands mid-border on small blocks)
+					const int	onset = firstXPerReg[3] + 14;
+					if (onset > leftEnd)
+						leftEnd = onset;
+				}
+			}
+			int	rightStart = (minLastX >= 256) ? 256 : minLastX + (cls ? 8 : 2);
 			if (rightStart < leftEnd)
 				rightStart = leftEnd;
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -257,7 +257,7 @@ static void S9xApplyMidLineBrightness (void)
 // per-line latch applies the rastered value to the whole line, so the events
 // are recorded here and the outer spans are re-rendered with the pre-raster
 // state after the frame, clipped through the normal window-segment lists.
-#define MAX_RASTER_EVENTS 512
+#define MAX_RASTER_EVENTS 1536
 static struct
 {
 	uint8	line, x, cls, reg;   // cls 0 = $2123+reg window byte, 1 = $210d+reg scroll
@@ -267,6 +267,11 @@ static int	raster_event_count = 0;
 
 static int		raster_span_count = 0;   // re-render clip restriction, consumed by S9xUpdateScreen
 static uint16	raster_span_l[2], raster_span_r[2];
+
+// Window positions are HDMA-driven per line (gauge shapes, the radar sweep),
+// so the end-of-frame values are wrong for a re-render; RenderLine snapshots
+// what each line actually latched.
+static uint8	line_windows[240][4];
 
 static bool mid_line_event_pos (int &line, int &x)
 {
@@ -307,9 +312,20 @@ void S9xRecordMidLineScroll (int reg, uint16 oldVal, uint16 newVal)
 	raster_event_count++;
 }
 
-// Same field decode as the $2123-$2125 handlers, without flush/record.
-static void apply_window_sel (int reg, uint8 byte)
+// Same field decode as the $2123-$2125/$2106 handlers, without flush/record.
+// reg 0-2 = W12SEL/W34SEL/WOBJSEL, reg 3 = MOSAIC (the map grow-in effect).
+static void apply_byte_reg (int reg, uint8 byte)
 {
+	if (reg == 3)
+	{
+		PPU.Mosaic     = (byte >> 4) + 1;
+		PPU.BGMosaic[0] = (byte & 1);
+		PPU.BGMosaic[1] = (byte & 2);
+		PPU.BGMosaic[2] = (byte & 4);
+		PPU.BGMosaic[3] = (byte & 8);
+		return;
+	}
+
 	const int	n = reg * 2;
 	PPU.ClipWindow1Enable[n]     = !!(byte & 0x02);
 	PPU.ClipWindow1Enable[n + 1] = !!(byte & 0x20);
@@ -319,6 +335,11 @@ static void apply_window_sel (int reg, uint8 byte)
 	PPU.ClipWindow1Inside[n + 1] = !(byte & 0x10);
 	PPU.ClipWindow2Inside[n]     = !(byte & 0x04);
 	PPU.ClipWindow2Inside[n + 1] = !(byte & 0x40);
+}
+
+static inline uint16 byte_reg_addr (int reg)
+{
+	return (reg == 3) ? 0x2106 : (0x2123 + reg);
 }
 
 // Intersect every layer's clip segments with the allowed re-render spans.
@@ -383,7 +404,7 @@ static void S9xApplyMidLineRaster (void)
 			uint16	firstOld[8], lastNew[8], savedOfs[8];
 			bool	touched[8] = { false };
 			int		firstX = 256, lastX = 0;
-			bool	any = false, restored = true;
+			bool	any = false;
 
 			for (int j = i; j < end; j++)
 			{
@@ -397,57 +418,82 @@ static void S9xApplyMidLineRaster (void)
 				if (raster_events[j].x > lastX)		lastX  = raster_events[j].x;
 				any = true;
 			}
-
-			for (int r = 0; r < 8; r++)
-				if (touched[r] && lastNew[r] != firstOld[r])
-					restored = false;
-			if (!any || !restored)
-				continue;   // no clean write/restore pair: the whole-line latch stands
-
-			// The pre-raster state rules left of the first write; for window
-			// rasters also right of the restore. Scroll restores land inside
-			// the BG fetch pipeline, so the right side keeps the line latch.
-			raster_span_count = 0;
-			if (firstX > 1)
-				{ raster_span_l[raster_span_count] = 0; raster_span_r[raster_span_count++] = firstX; }
-			if (cls == 0 && lastX < 255)
-				{ raster_span_l[raster_span_count] = lastX; raster_span_r[raster_span_count++] = 256; }
-			if (!raster_span_count)
+			if (!any)
 				continue;
 
-			for (int r = 0; r < 8; r++)
+			// True timeline: left of the first write the old values rule,
+			// right of the last write the final values do; between them the
+			// line latch (whatever was live at the latch dot) already drew.
+			// Scroll writes act through the BG fetch pipeline, so their right
+			// boundary gets a one-tile margin before the reverted span.
+			for (int side = 0; side < 2; side++)
 			{
-				if (!touched[r])
+				const int	rspanX = cls ? lastX + 8 : lastX;
+				raster_span_count = 0;
+				if (side == 0 && firstX > 1)
+					{ raster_span_l[0] = 0; raster_span_r[0] = firstX; raster_span_count = 1; }
+				if (side == 1 && rspanX < 255)
+					{ raster_span_l[0] = rspanX; raster_span_r[0] = 256; raster_span_count = 1; }
+				if (!raster_span_count)
 					continue;
-				if (cls == 0)
-					apply_window_sel(r, (uint8) firstOld[r]);
-				else if (r & 1)
-					{ savedOfs[r] = LineData[line].BG[r >> 1].VOffset; LineData[line].BG[r >> 1].VOffset = firstOld[r] + 1; }
-				else
-					{ savedOfs[r] = LineData[line].BG[r >> 1].HOffset; LineData[line].BG[r >> 1].HOffset = firstOld[r]; }
-			}
 
-			// depth values from the first pass would reject the re-render
-			uint32	zrow = line * GFX.PPL + ((GFX.DoInterlace && S9xInterlaceField()) ? GFX.RealPPL : 0);
-			memset(GFX.ZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
-			memset(GFX.SubZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
+				const uint16	*vals = side ? lastNew : firstOld;
+				for (int r = 0; r < 8; r++)
+				{
+					if (!touched[r])
+						continue;
+					if (cls == 0)
+						apply_byte_reg(r, (uint8) vals[r]);
+					else if (r & 1)
+					{
+						savedOfs[r] = LineData[line].BG[r >> 1].VOffset;
+						LineData[line].BG[r >> 1].VOffset = vals[r] + 1;
+					}
+					else
+					{
+						savedOfs[r] = LineData[line].BG[r >> 1].HOffset;
+						LineData[line].BG[r >> 1].HOffset = vals[r];
+					}
+				}
 
-			IPPU.PreviousLine = line;
-			IPPU.CurrentLine  = line + 1;
-			PPU.RecomputeClipWindows = TRUE;
-			S9xUpdateScreen();
-			raster_span_count = 0;
+				// this line's HDMA-written window positions, not the frame's last
+				const uint8	savedWin[4] =
+				{
+					Memory.FillRAM[0x2126], Memory.FillRAM[0x2127],
+					Memory.FillRAM[0x2128], Memory.FillRAM[0x2129],
+				};
+				PPU.Window1Left  = line_windows[line][0];
+				PPU.Window1Right = line_windows[line][1];
+				PPU.Window2Left  = line_windows[line][2];
+				PPU.Window2Right = line_windows[line][3];
 
-			for (int r = 0; r < 8; r++)
-			{
-				if (!touched[r])
-					continue;
-				if (cls == 0)
-					apply_window_sel(r, Memory.FillRAM[0x2123 + r]);
-				else if (r & 1)
-					LineData[line].BG[r >> 1].VOffset = savedOfs[r];
-				else
-					LineData[line].BG[r >> 1].HOffset = savedOfs[r];
+				// depth values from the first pass would reject the re-render
+				uint32	zrow = line * GFX.PPL + ((GFX.DoInterlace && S9xInterlaceField()) ? GFX.RealPPL : 0);
+				memset(GFX.ZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
+				memset(GFX.SubZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
+
+				IPPU.PreviousLine = line;
+				IPPU.CurrentLine  = line + 1;
+				PPU.RecomputeClipWindows = TRUE;
+				S9xUpdateScreen();
+				raster_span_count = 0;
+
+				PPU.Window1Left  = savedWin[0];
+				PPU.Window1Right = savedWin[1];
+				PPU.Window2Left  = savedWin[2];
+				PPU.Window2Right = savedWin[3];
+
+				for (int r = 0; r < 8; r++)
+				{
+					if (!touched[r])
+						continue;
+					if (cls == 0)
+						apply_byte_reg(r, Memory.FillRAM[byte_reg_addr(r)]);
+					else if (r & 1)
+						LineData[line].BG[r >> 1].VOffset = savedOfs[r];
+					else
+						LineData[line].BG[r >> 1].HOffset = savedOfs[r];
+				}
 			}
 			PPU.RecomputeClipWindows = TRUE;
 		}
@@ -892,7 +938,13 @@ void RenderLine (uint8 C)
 	if (IPPU.RenderThisFrame)
 	{
 		if (C < 240)
+		{
 			line_brightness[C] = PPU.Brightness;
+			line_windows[C][0] = Memory.FillRAM[0x2126];
+			line_windows[C][1] = Memory.FillRAM[0x2127];
+			line_windows[C][2] = Memory.FillRAM[0x2128];
+			line_windows[C][3] = Memory.FillRAM[0x2129];
+		}
 
 		LineData[C].BG[0].VOffset = PPU.BG[0].VOffset + 1;
 		LineData[C].BG[0].HOffset = PPU.BG[0].HOffset;

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -406,7 +406,7 @@ static void S9xApplyMidLineRaster (void)
 			uint16	firstOld[8], lastNew[8], savedOfs[8];
 			uint8	lastXPerReg[8];
 			bool	touched[8] = { false };
-			int		maxFirstX = 0;
+			int		maxFirstX = 0, minFirstX = 256;
 			bool	any = false;
 
 			for (int j = i; j < end; j++)
@@ -420,6 +420,8 @@ static void S9xApplyMidLineRaster (void)
 					firstOld[r] = raster_events[j].oldV;
 					if (raster_events[j].x > maxFirstX)
 						maxFirstX = raster_events[j].x;
+					if (raster_events[j].x < minFirstX)
+						minFirstX = raster_events[j].x;
 				}
 				lastNew[r] = raster_events[j].newV;
 				lastXPerReg[r] = raster_events[j].x;
@@ -439,7 +441,9 @@ static void S9xApplyMidLineRaster (void)
 			for (int r = 0; r < 8; r++)
 				if (touched[r] && (cls == 0 || !(r & 1)) && lastXPerReg[r] < minLastX)
 					minLastX = lastXPerReg[r];
-			const int	leftEnd    = maxFirstX + 2;
+			// Windows switch as a set (both regs written before the effect
+			// shows); scroll offsets each take effect at their own write.
+			const int	leftEnd    = (cls ? minFirstX : maxFirstX) + 2;
 			int			rightStart = (minLastX >= 256) ? 256 : minLastX + (cls ? 8 : 2);
 			if (rightStart < leftEnd)
 				rightStart = leftEnd;

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -192,63 +192,7 @@ void S9xRecordMidLineBrightness (int line, int x, uint8 oldBright, uint8 newBrig
 	bright_event_count++;
 }
 
-static void S9xApplyMidLineBrightness (void)
-{
-	if (!bright_event_count)
-		return;
-
-	const int	xscale = IPPU.DoubleWidthPixels ? 2 : 1;
-
-	for (int i = 0; i < bright_event_count; i++)
-	{
-		const int	line = bright_events[i].line;
-		if (line >= (int) PPU.ScreenHeight)
-			continue;
-
-		const int	renderedB = line_brightness[line];
-
-		// Piecewise true-brightness timeline: before the line's first event
-		// the old value ruled, between events each event's new value does.
-		const bool	firstOnLine = (i == 0 || bright_events[i - 1].line != line);
-		for (int seg = firstOnLine ? 0 : 1; seg < 2; seg++)
-		{
-			int	trueB, x0, x1;
-			if (seg == 0)
-			{
-				trueB = bright_events[i].oldB;
-				x0 = 0;
-				x1 = bright_events[i].x;
-			}
-			else
-			{
-				trueB = bright_events[i].newB;
-				x0 = bright_events[i].x;
-				x1 = (i + 1 < bright_event_count && bright_events[i + 1].line == line)
-						? bright_events[i + 1].x : 256;
-			}
-
-			if (trueB == renderedB || x1 <= x0)
-				continue;
-
-			const int	num = trueB + 1;
-			const int	den = renderedB + 1;
-
-			uint16	*p = GFX.Screen + line * GFX.PPL;
-			if (GFX.DoInterlace && S9xInterlaceField())
-				p += GFX.RealPPL;
-
-			for (int x = x0 * xscale; x < x1 * xscale; x++)
-			{
-				uint32	r, g, b;
-				DECOMPOSE_PIXEL(p[x], r, g, b);
-				r = r * num / den; if (r > 31) r = 31;
-				g = g * num / den; if (g > 31) g = 31;
-				b = b * num / den; if (b > 31) b = 31;
-				p[x] = BUILD_PIXEL(r, g, b);
-			}
-		}
-	}
-}
+static void S9xApplyMidLineBrightness (void);
 
 // Mid-scanline raster spans. A.S.P. also rewrites window-select bytes
 // ($2123/$2125, the pause-map transparency stripes) and BG scroll registers
@@ -342,6 +286,136 @@ static void apply_byte_reg (int reg, uint8 byte)
 static inline uint16 byte_reg_addr (int reg)
 {
 	return (reg == 3) ? 0x2106 : (0x2123 + reg);
+}
+
+// Re-render one line's [x0,x1) span through the normal compositor, using the
+// line's own HDMA-written window positions and backdrop color rather than the
+// frame's last values. The caller swaps in whatever other state the span
+// should render with. Clobbers IPPU.PreviousLine/CurrentLine.
+static void rerender_line_span (int line, int x0, int x1)
+{
+	raster_span_l[0] = (uint16) x0;
+	raster_span_r[0] = (uint16) x1;
+	raster_span_count = 1;
+
+	const uint8	savedWin[4] =
+	{
+		Memory.FillRAM[0x2126], Memory.FillRAM[0x2127],
+		Memory.FillRAM[0x2128], Memory.FillRAM[0x2129],
+	};
+	PPU.Window1Left  = line_windows[line][0];
+	PPU.Window1Right = line_windows[line][1];
+	PPU.Window2Left  = line_windows[line][2];
+	PPU.Window2Right = line_windows[line][3];
+
+	const uint16	savedBackdrop = PPU.CGDATA[0];
+	const uint16	savedScreen0  = IPPU.ScreenColors[0];
+	const uint8	savedR0 = IPPU.Red[0], savedG0 = IPPU.Green[0], savedB0 = IPPU.Blue[0];
+	{
+		const uint16	c = line_backdrop[line];
+		uint8	rr = IPPU.XB[c & 0x1f];
+		uint8	gg = IPPU.XB[(c >> 5) & 0x1f];
+		uint8	bb = IPPU.XB[(c >> 10) & 0x1f];
+		S9xApplyColorAdjustments(rr, gg, bb, 0x1f);
+		PPU.CGDATA[0] = c;
+		IPPU.Red[0]   = rr;
+		IPPU.Green[0] = gg;
+		IPPU.Blue[0]  = bb;
+		IPPU.ScreenColors[0] = (uint16) BUILD_PIXEL(rr, gg, bb);
+	}
+
+	// depth values from the first pass would reject the re-render
+	uint32	zrow = line * GFX.PPL + ((GFX.DoInterlace && S9xInterlaceField()) ? GFX.RealPPL : 0);
+	memset(GFX.ZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
+	memset(GFX.SubZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
+
+	IPPU.PreviousLine = line;
+	IPPU.CurrentLine  = line + 1;
+	PPU.RecomputeClipWindows = TRUE;
+	S9xUpdateScreen();
+	raster_span_count = 0;
+
+	PPU.Window1Left  = savedWin[0];
+	PPU.Window1Right = savedWin[1];
+	PPU.Window2Left  = savedWin[2];
+	PPU.Window2Right = savedWin[3];
+	PPU.CGDATA[0]        = savedBackdrop;
+	IPPU.ScreenColors[0] = savedScreen0;
+	IPPU.Red[0]   = savedR0;
+	IPPU.Green[0] = savedG0;
+	IPPU.Blue[0]  = savedB0;
+}
+
+static void S9xApplyMidLineBrightness (void)
+{
+	if (!bright_event_count)
+		return;
+
+	const uint32	savedPrev = IPPU.PreviousLine;
+	const uint32	savedCur  = IPPU.CurrentLine;
+	const int	xscale = IPPU.DoubleWidthPixels ? 2 : 1;
+
+	for (int i = 0; i < bright_event_count; )
+	{
+		const int	line = bright_events[i].line;
+		int	end = i;
+		while (end < bright_event_count && bright_events[end].line == line)
+			end++;
+
+		if (line >= (int) PPU.ScreenHeight)
+			{ i = end; continue; }
+
+		// the brightness at line start rules outside the raced window
+		const uint8	base = bright_events[i].oldB;
+
+		// If the line latch caught a mid-window value, the whole line was
+		// rendered with it. Re-render at the base brightness rather than
+		// scaling pixels back up - the round trip through the brightness
+		// LUT leaves a visible band across the line otherwise.
+		if (line_brightness[line] != base)
+		{
+			const uint8	savedBright = PPU.Brightness;
+			PPU.Brightness = base;
+			S9xFixColourBrightness();
+			S9xBuildDirectColourMaps();
+			rerender_line_span(line, 0, 256);
+			PPU.Brightness = savedBright;
+			S9xFixColourBrightness();
+			S9xBuildDirectColourMaps();
+		}
+
+		// darken each span whose true brightness differs from the base
+		for (int j = i; j < end; j++)
+		{
+			const int	trueB = bright_events[j].newB;
+			const int	x0 = bright_events[j].x;
+			const int	x1 = (j + 1 < end) ? bright_events[j + 1].x : 256;
+			if (trueB == base || x1 <= x0)
+				continue;
+
+			const int	num = trueB + 1;
+			const int	den = base + 1;
+
+			uint16	*p = GFX.Screen + line * GFX.PPL;
+			if (GFX.DoInterlace && S9xInterlaceField())
+				p += GFX.RealPPL;
+
+			for (int x = x0 * xscale; x < x1 * xscale; x++)
+			{
+				uint32	r, g, b;
+				DECOMPOSE_PIXEL(p[x], r, g, b);
+				r = r * num / den; if (r > 31) r = 31;
+				g = g * num / den; if (g > 31) g = 31;
+				b = b * num / den; if (b > 31) b = 31;
+				p[x] = BUILD_PIXEL(r, g, b);
+			}
+		}
+
+		i = end;
+	}
+
+	IPPU.PreviousLine = savedPrev;
+	IPPU.CurrentLine  = savedCur;
 }
 
 // Intersect every layer's clip segments with the allowed re-render spans.
@@ -497,54 +571,7 @@ static void S9xApplyMidLineRaster (void)
 					}
 				}
 
-				// this line's HDMA-written window positions and backdrop
-				// color, not the frame's last
-				const uint8	savedWin[4] =
-				{
-					Memory.FillRAM[0x2126], Memory.FillRAM[0x2127],
-					Memory.FillRAM[0x2128], Memory.FillRAM[0x2129],
-				};
-				PPU.Window1Left  = line_windows[line][0];
-				PPU.Window1Right = line_windows[line][1];
-				PPU.Window2Left  = line_windows[line][2];
-				PPU.Window2Right = line_windows[line][3];
-
-				const uint16	savedBackdrop = PPU.CGDATA[0];
-				const uint16	savedScreen0  = IPPU.ScreenColors[0];
-				const uint8	savedR0 = IPPU.Red[0], savedG0 = IPPU.Green[0], savedB0 = IPPU.Blue[0];
-				{
-					const uint16	c = line_backdrop[line];
-					uint8	rr = IPPU.XB[c & 0x1f];
-					uint8	gg = IPPU.XB[(c >> 5) & 0x1f];
-					uint8	bb = IPPU.XB[(c >> 10) & 0x1f];
-					S9xApplyColorAdjustments(rr, gg, bb, 0x1f);
-					PPU.CGDATA[0] = c;
-					IPPU.Red[0]   = rr;
-					IPPU.Green[0] = gg;
-					IPPU.Blue[0]  = bb;
-					IPPU.ScreenColors[0] = (uint16) BUILD_PIXEL(rr, gg, bb);
-				}
-
-				// depth values from the first pass would reject the re-render
-				uint32	zrow = line * GFX.PPL + ((GFX.DoInterlace && S9xInterlaceField()) ? GFX.RealPPL : 0);
-				memset(GFX.ZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
-				memset(GFX.SubZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
-
-				IPPU.PreviousLine = line;
-				IPPU.CurrentLine  = line + 1;
-				PPU.RecomputeClipWindows = TRUE;
-				S9xUpdateScreen();
-				raster_span_count = 0;
-
-				PPU.Window1Left  = savedWin[0];
-				PPU.Window1Right = savedWin[1];
-				PPU.Window2Left  = savedWin[2];
-				PPU.Window2Right = savedWin[3];
-				PPU.CGDATA[0]        = savedBackdrop;
-				IPPU.ScreenColors[0] = savedScreen0;
-				IPPU.Red[0]   = savedR0;
-				IPPU.Green[0] = savedG0;
-				IPPU.Blue[0]  = savedB0;
+				rerender_line_span(line, raster_span_l[0], raster_span_r[0]);
 
 				for (int r = 0; r < 8; r++)
 				{

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -430,15 +430,17 @@ static void S9xApplyMidLineRaster (void)
 
 			// True timeline: the raster state is fully in effect once its
 			// last register is set and stops when the first one reverts,
-			// each taking effect ~2 dots after the write. Scroll writes act
-			// through the BG fetch pipeline, so their right boundary gets a
-			// one-tile margin instead.
+			// each taking effect ~2 dots after the write. Scroll restores
+			// act through the BG fetch pipeline: HOFS gets a one-tile
+			// margin, and a VOFS-only raster keeps the line latch on the
+			// right - the game restores within a tile of its last glyph and
+			// IRQ jitter would otherwise expose the raw tilemap there.
 			int	minLastX = 256;
 			for (int r = 0; r < 8; r++)
-				if (touched[r] && lastXPerReg[r] < minLastX)
+				if (touched[r] && (cls == 0 || !(r & 1)) && lastXPerReg[r] < minLastX)
 					minLastX = lastXPerReg[r];
 			const int	leftEnd    = maxFirstX + 2;
-			int			rightStart = minLastX + (cls ? 8 : 2);
+			int			rightStart = (minLastX >= 256) ? 256 : minLastX + (cls ? 8 : 2);
 			if (rightStart < leftEnd)
 				rightStart = leftEnd;
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -122,7 +122,9 @@ void S9xGraphicsScreenResize (void)
 	IPPU.InterlaceOBJ = Memory.FillRAM[0x2133] & 2;
 	IPPU.PseudoHires = Memory.FillRAM[0x2133] & 8;
 
-	if (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires)
+	// Interlaced frames render double-width too: the field-aware tile
+	// renderers live on the 512-wide path (see S9xSelectTileRenderers).
+	if (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires || IPPU.Interlace)
 	{
 		IPPU.DoubleWidthPixels = TRUE;
 		IPPU.RenderedScreenWidth = SNES_WIDTH << 1;
@@ -168,18 +170,20 @@ void S9xBuildDirectColourMaps (void)
 // Mid-scanline INIDISP brightness windows. A.S.P. Air Strike Patrol draws the
 // aircraft shadow by dimming $2100 for ~10 dots in the middle of a scanline
 // and restoring it before HBlank; a line renderer can't split a line, so the
-// events are recorded here and the affected pixel span is re-scaled after the
-// frame is done.
+// events are recorded here and the mismatching pixel spans are re-scaled
+// after the frame is done. RenderLine snapshots the brightness each line was
+// actually drawn with, so the pass is exact for any Timings.RenderPos.
 #define MAX_BRIGHT_EVENTS 64
 static struct
 {
 	uint8	line, x, oldB, newB;
 }	bright_events[MAX_BRIGHT_EVENTS];
-static int	bright_event_count = 0;
+static int		bright_event_count = 0;
+static uint8	line_brightness[240];
 
 void S9xRecordMidLineBrightness (int line, int x, uint8 oldBright, uint8 newBright)
 {
-	if (bright_event_count >= MAX_BRIGHT_EVENTS || line > 255)
+	if (bright_event_count >= MAX_BRIGHT_EVENTS || line > 239)
 		return;
 	bright_events[bright_event_count].line = (uint8) line;
 	bright_events[bright_event_count].x    = (uint8) x;
@@ -201,35 +205,47 @@ static void S9xApplyMidLineBrightness (void)
 		if (line >= (int) PPU.ScreenHeight)
 			continue;
 
-		// The line itself was rendered with the brightness the first event
-		// on it replaced; spans between events use each event's new value.
-		int	renderedB = bright_events[i].oldB;
-		for (int j = i - 1; j >= 0; j--)
-			if (bright_events[j].line == line)
-				{ renderedB = bright_events[j].oldB; break; }
+		const int	renderedB = line_brightness[line];
 
-		int	xend = 256;
-		if (i + 1 < bright_event_count && bright_events[i + 1].line == line)
-			xend = bright_events[i + 1].x;
-
-		if (bright_events[i].newB == renderedB || xend <= bright_events[i].x)
-			continue;
-
-		const int	num = bright_events[i].newB + 1;
-		const int	den = renderedB + 1;
-
-		uint16	*p = GFX.Screen + line * GFX.PPL;
-		if (GFX.DoInterlace && S9xInterlaceField())
-			p += GFX.RealPPL;
-
-		for (int x = bright_events[i].x * xscale; x < xend * xscale; x++)
+		// Piecewise true-brightness timeline: before the line's first event
+		// the old value ruled, between events each event's new value does.
+		const bool	firstOnLine = (i == 0 || bright_events[i - 1].line != line);
+		for (int seg = firstOnLine ? 0 : 1; seg < 2; seg++)
 		{
-			uint32	r, g, b;
-			DECOMPOSE_PIXEL(p[x], r, g, b);
-			r = r * num / den;
-			g = g * num / den;
-			b = b * num / den;
-			p[x] = BUILD_PIXEL(r, g, b);
+			int	trueB, x0, x1;
+			if (seg == 0)
+			{
+				trueB = bright_events[i].oldB;
+				x0 = 0;
+				x1 = bright_events[i].x;
+			}
+			else
+			{
+				trueB = bright_events[i].newB;
+				x0 = bright_events[i].x;
+				x1 = (i + 1 < bright_event_count && bright_events[i + 1].line == line)
+						? bright_events[i + 1].x : 256;
+			}
+
+			if (trueB == renderedB || x1 <= x0)
+				continue;
+
+			const int	num = trueB + 1;
+			const int	den = renderedB + 1;
+
+			uint16	*p = GFX.Screen + line * GFX.PPL;
+			if (GFX.DoInterlace && S9xInterlaceField())
+				p += GFX.RealPPL;
+
+			for (int x = x0 * xscale; x < x1 * xscale; x++)
+			{
+				uint32	r, g, b;
+				DECOMPOSE_PIXEL(p[x], r, g, b);
+				r = r * num / den; if (r > 31) r = 31;
+				g = g * num / den; if (g > 31) g = 31;
+				b = b * num / den; if (b > 31) b = 31;
+				p[x] = BUILD_PIXEL(r, g, b);
+			}
 		}
 	}
 }
@@ -664,6 +680,9 @@ void RenderLine (uint8 C)
 {
 	if (IPPU.RenderThisFrame)
 	{
+		if (C < 240)
+			line_brightness[C] = PPU.Brightness;
+
 		LineData[C].BG[0].VOffset = PPU.BG[0].VOffset + 1;
 		LineData[C].BG[0].HOffset = PPU.BG[0].HOffset;
 		LineData[C].BG[1].VOffset = PPU.BG[1].VOffset + 1;
@@ -852,7 +871,7 @@ void S9xUpdateScreen (void)
 			PPU.RecomputeClipWindows = FALSE;
 		}
 
-		if (!IPPU.DoubleWidthPixels && (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires))
+		if (!IPPU.DoubleWidthPixels && (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires || IPPU.Interlace))
 		{
 			// Have to back out of the regular speed hack
 			for (uint32 y = 0; y < GFX.StartY; y++)
@@ -868,7 +887,7 @@ void S9xUpdateScreen (void)
 			IPPU.RenderedScreenWidth = 512;
 		}
 
-		if (!IPPU.DoubleHeightPixels && IPPU.Interlace && (PPU.BGMode == 5 || PPU.BGMode == 6))
+		if (!IPPU.DoubleHeightPixels && IPPU.Interlace)
 		{
 			IPPU.DoubleHeightPixels = TRUE;
 			IPPU.RenderedScreenHeight = PPU.ScreenHeight << 1;

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -268,10 +268,12 @@ static int	raster_event_count = 0;
 static int		raster_span_count = 0;   // re-render clip restriction, consumed by S9xUpdateScreen
 static uint16	raster_span_l[2], raster_span_r[2];
 
-// Window positions are HDMA-driven per line (gauge shapes, the radar sweep),
-// so the end-of-frame values are wrong for a re-render; RenderLine snapshots
+// Window positions and the backdrop color are HDMA-driven per line (gauge
+// shapes, the radar sweep, the ambient-light gradient on CGRAM entry 0), so
+// the end-of-frame values are wrong for a re-render; RenderLine snapshots
 // what each line actually latched.
 static uint8	line_windows[240][4];
+static uint16	line_backdrop[240];
 
 static bool mid_line_event_pos (int &line, int &x)
 {
@@ -465,7 +467,8 @@ static void S9xApplyMidLineRaster (void)
 					}
 				}
 
-				// this line's HDMA-written window positions, not the frame's last
+				// this line's HDMA-written window positions and backdrop
+				// color, not the frame's last
 				const uint8	savedWin[4] =
 				{
 					Memory.FillRAM[0x2126], Memory.FillRAM[0x2127],
@@ -475,6 +478,22 @@ static void S9xApplyMidLineRaster (void)
 				PPU.Window1Right = line_windows[line][1];
 				PPU.Window2Left  = line_windows[line][2];
 				PPU.Window2Right = line_windows[line][3];
+
+				const uint16	savedBackdrop = PPU.CGDATA[0];
+				const uint16	savedScreen0  = IPPU.ScreenColors[0];
+				const uint8	savedR0 = IPPU.Red[0], savedG0 = IPPU.Green[0], savedB0 = IPPU.Blue[0];
+				{
+					const uint16	c = line_backdrop[line];
+					uint8	rr = IPPU.XB[c & 0x1f];
+					uint8	gg = IPPU.XB[(c >> 5) & 0x1f];
+					uint8	bb = IPPU.XB[(c >> 10) & 0x1f];
+					S9xApplyColorAdjustments(rr, gg, bb, 0x1f);
+					PPU.CGDATA[0] = c;
+					IPPU.Red[0]   = rr;
+					IPPU.Green[0] = gg;
+					IPPU.Blue[0]  = bb;
+					IPPU.ScreenColors[0] = (uint16) BUILD_PIXEL(rr, gg, bb);
+				}
 
 				// depth values from the first pass would reject the re-render
 				uint32	zrow = line * GFX.PPL + ((GFX.DoInterlace && S9xInterlaceField()) ? GFX.RealPPL : 0);
@@ -491,6 +510,11 @@ static void S9xApplyMidLineRaster (void)
 				PPU.Window1Right = savedWin[1];
 				PPU.Window2Left  = savedWin[2];
 				PPU.Window2Right = savedWin[3];
+				PPU.CGDATA[0]        = savedBackdrop;
+				IPPU.ScreenColors[0] = savedScreen0;
+				IPPU.Red[0]   = savedR0;
+				IPPU.Green[0] = savedG0;
+				IPPU.Blue[0]  = savedB0;
 
 				for (int r = 0; r < 8; r++)
 				{
@@ -953,6 +977,7 @@ void RenderLine (uint8 C)
 			line_windows[C][1] = Memory.FillRAM[0x2127];
 			line_windows[C][2] = Memory.FillRAM[0x2128];
 			line_windows[C][3] = Memory.FillRAM[0x2129];
+			line_backdrop[C]   = PPU.CGDATA[0];
 		}
 
 		LineData[C].BG[0].VOffset = PPU.BG[0].VOffset + 1;

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -250,6 +250,215 @@ static void S9xApplyMidLineBrightness (void)
 	}
 }
 
+// Mid-scanline raster spans. A.S.P. also rewrites window-select bytes
+// ($2123/$2125, the pause-map transparency stripes) and BG scroll registers
+// ($2112, the GOOD LUCK wave) inside the visible line and restores them
+// before HBlank, bounding the effect horizontally by write timing. The
+// per-line latch applies the rastered value to the whole line, so the events
+// are recorded here and the outer spans are re-rendered with the pre-raster
+// state after the frame, clipped through the normal window-segment lists.
+#define MAX_RASTER_EVENTS 512
+static struct
+{
+	uint8	line, x, cls, reg;   // cls 0 = $2123+reg window byte, 1 = $210d+reg scroll
+	uint16	oldV, newV;
+}	raster_events[MAX_RASTER_EVENTS];
+static int	raster_event_count = 0;
+
+static int		raster_span_count = 0;   // re-render clip restriction, consumed by S9xUpdateScreen
+static uint16	raster_span_l[2], raster_span_r[2];
+
+static bool mid_line_event_pos (int &line, int &x)
+{
+	if (!IPPU.RenderThisFrame || raster_event_count >= MAX_RASTER_EVENTS)
+		return (false);
+	if (CPU.V_Counter < FIRST_VISIBLE_LINE || CPU.V_Counter >= PPU.ScreenHeight + FIRST_VISIBLE_LINE)
+		return (false);
+	line = CPU.V_Counter - FIRST_VISIBLE_LINE;
+	x = CPU.Cycles / ONE_DOT_CYCLE - 22;
+	return (x >= 1 && x <= 255 && line <= 239);
+}
+
+void S9xRecordMidLineWindowSel (int reg, uint8 oldVal, uint8 newVal)
+{
+	int	line, x;
+	if (oldVal == newVal || !mid_line_event_pos(line, x))
+		return;
+	raster_events[raster_event_count].line = (uint8) line;
+	raster_events[raster_event_count].x    = (uint8) x;
+	raster_events[raster_event_count].cls  = 0;
+	raster_events[raster_event_count].reg  = (uint8) reg;
+	raster_events[raster_event_count].oldV = oldVal;
+	raster_events[raster_event_count].newV = newVal;
+	raster_event_count++;
+}
+
+void S9xRecordMidLineScroll (int reg, uint16 oldVal, uint16 newVal)
+{
+	int	line, x;
+	if (oldVal == newVal || PPU.BGMode == 7 || !mid_line_event_pos(line, x))
+		return;
+	raster_events[raster_event_count].line = (uint8) line;
+	raster_events[raster_event_count].x    = (uint8) x;
+	raster_events[raster_event_count].cls  = 1;
+	raster_events[raster_event_count].reg  = (uint8) reg;
+	raster_events[raster_event_count].oldV = oldVal;
+	raster_events[raster_event_count].newV = newVal;
+	raster_event_count++;
+}
+
+// Same field decode as the $2123-$2125 handlers, without flush/record.
+static void apply_window_sel (int reg, uint8 byte)
+{
+	const int	n = reg * 2;
+	PPU.ClipWindow1Enable[n]     = !!(byte & 0x02);
+	PPU.ClipWindow1Enable[n + 1] = !!(byte & 0x20);
+	PPU.ClipWindow2Enable[n]     = !!(byte & 0x08);
+	PPU.ClipWindow2Enable[n + 1] = !!(byte & 0x80);
+	PPU.ClipWindow1Inside[n]     = !(byte & 0x01);
+	PPU.ClipWindow1Inside[n + 1] = !(byte & 0x10);
+	PPU.ClipWindow2Inside[n]     = !(byte & 0x04);
+	PPU.ClipWindow2Inside[n + 1] = !(byte & 0x40);
+}
+
+// Intersect every layer's clip segments with the allowed re-render spans.
+static void RestrictClipWindows (void)
+{
+	for (int s = 0; s <= 1; s++)
+	{
+		for (int l = 0; l < 6; l++)
+		{
+			struct ClipData	*c = &IPPU.Clip[s][l];
+			if (!c->Count)
+				continue;
+
+			uint16	L[6], R[6];
+			uint8	M[6];
+			int		n = 0;
+
+			for (int sp = 0; sp < raster_span_count; sp++)
+			{
+				for (int k = 0; k < c->Count && n < 6; k++)
+				{
+					uint16	a = c->Left[k]  > raster_span_l[sp] ? c->Left[k]  : raster_span_l[sp];
+					uint16	b = c->Right[k] < raster_span_r[sp] ? c->Right[k] : raster_span_r[sp];
+					if (a < b)
+					{
+						L[n] = a;
+						R[n] = b;
+						M[n] = c->DrawMode[k];
+						n++;
+					}
+				}
+			}
+
+			c->Count = (uint8) n;
+			for (int k = 0; k < n; k++)
+			{
+				c->Left[k] = L[k];
+				c->Right[k] = R[k];
+				c->DrawMode[k] = M[k];
+			}
+		}
+	}
+}
+
+static void S9xApplyMidLineRaster (void)
+{
+	if (!raster_event_count)
+		return;
+
+	const uint32	savedPrev = IPPU.PreviousLine;
+	const uint32	savedCur  = IPPU.CurrentLine;
+
+	for (int i = 0; i < raster_event_count; )
+	{
+		const int	line = raster_events[i].line;
+		int	end = i;
+		while (end < raster_event_count && raster_events[end].line == line)
+			end++;
+
+		for (int cls = 0; line < (int) PPU.ScreenHeight && cls < 2; cls++)
+		{
+			uint16	firstOld[8], lastNew[8], savedOfs[8];
+			bool	touched[8] = { false };
+			int		firstX = 256, lastX = 0;
+			bool	any = false, restored = true;
+
+			for (int j = i; j < end; j++)
+			{
+				if (raster_events[j].cls != cls)
+					continue;
+				const int	r = raster_events[j].reg;
+				if (!touched[r])
+					{ touched[r] = true; firstOld[r] = raster_events[j].oldV; }
+				lastNew[r] = raster_events[j].newV;
+				if (raster_events[j].x < firstX)	firstX = raster_events[j].x;
+				if (raster_events[j].x > lastX)		lastX  = raster_events[j].x;
+				any = true;
+			}
+
+			for (int r = 0; r < 8; r++)
+				if (touched[r] && lastNew[r] != firstOld[r])
+					restored = false;
+			if (!any || !restored)
+				continue;   // no clean write/restore pair: the whole-line latch stands
+
+			// The pre-raster state rules left of the first write; for window
+			// rasters also right of the restore. Scroll restores land inside
+			// the BG fetch pipeline, so the right side keeps the line latch.
+			raster_span_count = 0;
+			if (firstX > 1)
+				{ raster_span_l[raster_span_count] = 0; raster_span_r[raster_span_count++] = firstX; }
+			if (cls == 0 && lastX < 255)
+				{ raster_span_l[raster_span_count] = lastX; raster_span_r[raster_span_count++] = 256; }
+			if (!raster_span_count)
+				continue;
+
+			for (int r = 0; r < 8; r++)
+			{
+				if (!touched[r])
+					continue;
+				if (cls == 0)
+					apply_window_sel(r, (uint8) firstOld[r]);
+				else if (r & 1)
+					{ savedOfs[r] = LineData[line].BG[r >> 1].VOffset; LineData[line].BG[r >> 1].VOffset = firstOld[r] + 1; }
+				else
+					{ savedOfs[r] = LineData[line].BG[r >> 1].HOffset; LineData[line].BG[r >> 1].HOffset = firstOld[r]; }
+			}
+
+			// depth values from the first pass would reject the re-render
+			uint32	zrow = line * GFX.PPL + ((GFX.DoInterlace && S9xInterlaceField()) ? GFX.RealPPL : 0);
+			memset(GFX.ZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
+			memset(GFX.SubZBuffer + zrow, 0, IPPU.RenderedScreenWidth);
+
+			IPPU.PreviousLine = line;
+			IPPU.CurrentLine  = line + 1;
+			PPU.RecomputeClipWindows = TRUE;
+			S9xUpdateScreen();
+			raster_span_count = 0;
+
+			for (int r = 0; r < 8; r++)
+			{
+				if (!touched[r])
+					continue;
+				if (cls == 0)
+					apply_window_sel(r, Memory.FillRAM[0x2123 + r]);
+				else if (r & 1)
+					LineData[line].BG[r >> 1].VOffset = savedOfs[r];
+				else
+					LineData[line].BG[r >> 1].HOffset = savedOfs[r];
+			}
+			PPU.RecomputeClipWindows = TRUE;
+		}
+
+		i = end;
+	}
+
+	IPPU.PreviousLine = savedPrev;
+	IPPU.CurrentLine  = savedCur;
+}
+
 void S9xStartScreenRefresh (void)
 {
 	if (GFX.DoInterlace)
@@ -274,6 +483,7 @@ void S9xStartScreenRefresh (void)
 		PPU.RecomputeClipWindows = TRUE;
 		IPPU.PreviousLine = IPPU.CurrentLine = 0;
 		bright_event_count = 0;
+		raster_event_count = 0;
 
 		memset(GFX.ZBuffer, 0, GFX.ScreenSize);
 		memset(GFX.SubZBuffer, 0, GFX.ScreenSize);
@@ -571,6 +781,7 @@ void S9xEndScreenRefresh (void)
 	{
 		FLUSH_REDRAW();
 
+		S9xApplyMidLineRaster();
 		S9xApplyMidLineBrightness();
 
 		// SGB BIOS-mode custom-border overlay. FLUSH_REDRAW above
@@ -870,6 +1081,9 @@ void S9xUpdateScreen (void)
 			S9xComputeClipWindows();
 			PPU.RecomputeClipWindows = FALSE;
 		}
+
+		if (raster_span_count)
+			RestrictClipWindows();
 
 		if (!IPPU.DoubleWidthPixels && (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires || IPPU.Interlace))
 		{

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -165,6 +165,75 @@ void S9xBuildDirectColourMaps (void)
 	}
 }
 
+// Mid-scanline INIDISP brightness windows. A.S.P. Air Strike Patrol draws the
+// aircraft shadow by dimming $2100 for ~10 dots in the middle of a scanline
+// and restoring it before HBlank; a line renderer can't split a line, so the
+// events are recorded here and the affected pixel span is re-scaled after the
+// frame is done.
+#define MAX_BRIGHT_EVENTS 64
+static struct
+{
+	uint8	line, x, oldB, newB;
+}	bright_events[MAX_BRIGHT_EVENTS];
+static int	bright_event_count = 0;
+
+void S9xRecordMidLineBrightness (int line, int x, uint8 oldBright, uint8 newBright)
+{
+	if (bright_event_count >= MAX_BRIGHT_EVENTS || line > 255)
+		return;
+	bright_events[bright_event_count].line = (uint8) line;
+	bright_events[bright_event_count].x    = (uint8) x;
+	bright_events[bright_event_count].oldB = oldBright;
+	bright_events[bright_event_count].newB = newBright;
+	bright_event_count++;
+}
+
+static void S9xApplyMidLineBrightness (void)
+{
+	if (!bright_event_count)
+		return;
+
+	const int	xscale = IPPU.DoubleWidthPixels ? 2 : 1;
+
+	for (int i = 0; i < bright_event_count; i++)
+	{
+		const int	line = bright_events[i].line;
+		if (line >= (int) PPU.ScreenHeight)
+			continue;
+
+		// The line itself was rendered with the brightness the first event
+		// on it replaced; spans between events use each event's new value.
+		int	renderedB = bright_events[i].oldB;
+		for (int j = i - 1; j >= 0; j--)
+			if (bright_events[j].line == line)
+				{ renderedB = bright_events[j].oldB; break; }
+
+		int	xend = 256;
+		if (i + 1 < bright_event_count && bright_events[i + 1].line == line)
+			xend = bright_events[i + 1].x;
+
+		if (bright_events[i].newB == renderedB || xend <= bright_events[i].x)
+			continue;
+
+		const int	num = bright_events[i].newB + 1;
+		const int	den = renderedB + 1;
+
+		uint16	*p = GFX.Screen + line * GFX.PPL;
+		if (GFX.DoInterlace && S9xInterlaceField())
+			p += GFX.RealPPL;
+
+		for (int x = bright_events[i].x * xscale; x < xend * xscale; x++)
+		{
+			uint32	r, g, b;
+			DECOMPOSE_PIXEL(p[x], r, g, b);
+			r = r * num / den;
+			g = g * num / den;
+			b = b * num / den;
+			p[x] = BUILD_PIXEL(r, g, b);
+		}
+	}
+}
+
 void S9xStartScreenRefresh (void)
 {
 	if (GFX.DoInterlace)
@@ -188,6 +257,7 @@ void S9xStartScreenRefresh (void)
 		PPU.MosaicStart = 0;
 		PPU.RecomputeClipWindows = TRUE;
 		IPPU.PreviousLine = IPPU.CurrentLine = 0;
+		bright_event_count = 0;
 
 		memset(GFX.ZBuffer, 0, GFX.ScreenSize);
 		memset(GFX.SubZBuffer, 0, GFX.ScreenSize);
@@ -484,6 +554,8 @@ void S9xEndScreenRefresh (void)
 	if (IPPU.RenderThisFrame)
 	{
 		FLUSH_REDRAW();
+
+		S9xApplyMidLineBrightness();
 
 		// SGB BIOS-mode custom-border overlay. FLUSH_REDRAW above
 		// finalized the SNES PPU output (including the SGB2 BIOS's

--- a/gfx.h
+++ b/gfx.h
@@ -202,6 +202,7 @@ struct COLOR_SUB
 
 void S9xStartScreenRefresh (void);
 void S9xEndScreenRefresh (void);
+void S9xRecordMidLineBrightness (int line, int x, uint8 oldBright, uint8 newBright);
 void S9xBuildDirectColourMaps (void);
 void RenderLine (uint8);
 void S9xComputeClipWindows (void);

--- a/gfx.h
+++ b/gfx.h
@@ -203,6 +203,8 @@ struct COLOR_SUB
 void S9xStartScreenRefresh (void);
 void S9xEndScreenRefresh (void);
 void S9xRecordMidLineBrightness (int line, int x, uint8 oldBright, uint8 newBright);
+void S9xRecordMidLineWindowSel (int reg, uint8 oldVal, uint8 newVal);
+void S9xRecordMidLineScroll (int reg, uint16 oldVal, uint16 newVal);
 void S9xBuildDirectColourMaps (void);
 void RenderLine (uint8);
 void S9xComputeClipWindows (void);

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -5108,8 +5108,6 @@ void CMemory::ApplyROMFixes (void)
 		Timings.RenderPos = 32;
 	else if (match_na("DERBY STALLION 98"))
 		Timings.RenderPos = 128;
-	else if (match_na("AIR STRIKE PATROL") || match_na("DESERT FIGHTER"))
-		Timings.RenderPos = 128; // latch before the shadow IRQ window; the mid-line INIDISP pass draws it
 	else if (match_na("FULL THROTTLE RACING"))
 		Timings.RenderPos = 128;
 	// From bsnes

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -5109,7 +5109,7 @@ void CMemory::ApplyROMFixes (void)
 	else if (match_na("DERBY STALLION 98"))
 		Timings.RenderPos = 128;
 	else if (match_na("AIR STRIKE PATROL") || match_na("DESERT FIGHTER"))
-		Timings.RenderPos = 128; // Just hides shadow
+		Timings.RenderPos = 128; // latch before the shadow IRQ window; the mid-line INIDISP pass draws it
 	else if (match_na("FULL THROTTLE RACING"))
 		Timings.RenderPos = 128;
 	// From bsnes

--- a/ppu.cpp
+++ b/ppu.cpp
@@ -334,6 +334,22 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 				{
 					FLUSH_REDRAW();
 
+					// Brightness-only change in the middle of a visible line,
+					// after this line's render latch: the line is already drawn
+					// with the old value, so log a span for the post-pass
+					// (A.S.P.'s mid-scanline aircraft shadow).
+					if (!(Byte & 0x80) && !((Memory.FillRAM[0x2100] ^ Byte) & 0x80) &&
+						PPU.Brightness != (Byte & 0xf) &&
+						CPU.V_Counter >= FIRST_VISIBLE_LINE &&
+						CPU.V_Counter < PPU.ScreenHeight + FIRST_VISIBLE_LINE &&
+						CPU.Cycles > Timings.RenderPos)
+					{
+						int x = CPU.Cycles / ONE_DOT_CYCLE - 22;
+						if (x >= 1 && x <= 255)
+							S9xRecordMidLineBrightness(CPU.V_Counter - FIRST_VISIBLE_LINE, x,
+									PPU.Brightness, Byte & 0xf);
+					}
+
 					if (PPU.Brightness != (Byte & 0xf))
 					{
 						IPPU.ColorsChanged = TRUE;

--- a/ppu.cpp
+++ b/ppu.cpp
@@ -552,48 +552,80 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 				break;
 
 			case 0x210d: // BG1HOFS, M7HOFS
+			{
+				uint16 old = PPU.BG[0].HOffset;
 				PPU.BG[0].HOffset = (Byte << 8) | (PPU.BGnxOFSbyte & ~7) | ((PPU.BG[0].HOffset >> 8) & 7);
 				PPU.M7HOFS = (Byte << 8) | PPU.M7byte;
 				PPU.BGnxOFSbyte = Byte;
 				PPU.M7byte = Byte;
+				S9xRecordMidLineScroll(0, old, PPU.BG[0].HOffset);
 				break;
+			}
 
 			case 0x210e: // BG1VOFS, M7VOFS
+			{
+				uint16 old = PPU.BG[0].VOffset;
 				PPU.BG[0].VOffset = (Byte << 8) | PPU.BGnxOFSbyte;
 				PPU.M7VOFS = (Byte << 8) | PPU.M7byte;
 				PPU.BGnxOFSbyte = Byte;
 				PPU.M7byte = Byte;
+				S9xRecordMidLineScroll(1, old, PPU.BG[0].VOffset);
 				break;
+			}
 
 			case 0x210f: // BG2HOFS
+			{
+				uint16 old = PPU.BG[1].HOffset;
 				PPU.BG[1].HOffset = (Byte << 8) | (PPU.BGnxOFSbyte & ~7) | ((PPU.BG[1].HOffset >> 8) & 7);
 				PPU.BGnxOFSbyte = Byte;
+				S9xRecordMidLineScroll(2, old, PPU.BG[1].HOffset);
 				break;
+			}
 
 			case 0x2110: // BG2VOFS
+			{
+				uint16 old = PPU.BG[1].VOffset;
 				PPU.BG[1].VOffset = (Byte << 8) | PPU.BGnxOFSbyte;
 				PPU.BGnxOFSbyte = Byte;
+				S9xRecordMidLineScroll(3, old, PPU.BG[1].VOffset);
 				break;
+			}
 
 			case 0x2111: // BG3HOFS
+			{
+				uint16 old = PPU.BG[2].HOffset;
 				PPU.BG[2].HOffset = (Byte << 8) | (PPU.BGnxOFSbyte & ~7) | ((PPU.BG[2].HOffset >> 8) & 7);
 				PPU.BGnxOFSbyte = Byte;
+				S9xRecordMidLineScroll(4, old, PPU.BG[2].HOffset);
 				break;
+			}
 
 			case 0x2112: // BG3VOFS
+			{
+				uint16 old = PPU.BG[2].VOffset;
 				PPU.BG[2].VOffset = (Byte << 8) | PPU.BGnxOFSbyte;
 				PPU.BGnxOFSbyte = Byte;
+				S9xRecordMidLineScroll(5, old, PPU.BG[2].VOffset);
 				break;
+			}
 
 			case 0x2113: // BG4HOFS
+			{
+				uint16 old = PPU.BG[3].HOffset;
 				PPU.BG[3].HOffset = (Byte << 8) | (PPU.BGnxOFSbyte & ~7) | ((PPU.BG[3].HOffset >> 8) & 7);
 				PPU.BGnxOFSbyte = Byte;
+				S9xRecordMidLineScroll(6, old, PPU.BG[3].HOffset);
 				break;
+			}
 
 			case 0x2114: // BG4VOFS
+			{
+				uint16 old = PPU.BG[3].VOffset;
 				PPU.BG[3].VOffset = (Byte << 8) | PPU.BGnxOFSbyte;
 				PPU.BGnxOFSbyte = Byte;
+				S9xRecordMidLineScroll(7, old, PPU.BG[3].VOffset);
 				break;
+			}
 
 			case 0x2115: // VMAIN
 				PPU.VMA.High = (Byte & 0x80) == 0 ? FALSE : TRUE;
@@ -709,6 +741,7 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 				if (Byte != Memory.FillRAM[0x2123])
 				{
 					FLUSH_REDRAW();
+					S9xRecordMidLineWindowSel(0, Memory.FillRAM[0x2123], Byte);
 					PPU.ClipWindow1Enable[0] = !!(Byte & 0x02);
 					PPU.ClipWindow1Enable[1] = !!(Byte & 0x20);
 					PPU.ClipWindow2Enable[0] = !!(Byte & 0x08);
@@ -736,6 +769,7 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 				if (Byte != Memory.FillRAM[0x2124])
 				{
 					FLUSH_REDRAW();
+					S9xRecordMidLineWindowSel(1, Memory.FillRAM[0x2124], Byte);
 					PPU.ClipWindow1Enable[2] = !!(Byte & 0x02);
 					PPU.ClipWindow1Enable[3] = !!(Byte & 0x20);
 					PPU.ClipWindow2Enable[2] = !!(Byte & 0x08);
@@ -763,6 +797,7 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 				if (Byte != Memory.FillRAM[0x2125])
 				{
 					FLUSH_REDRAW();
+					S9xRecordMidLineWindowSel(2, Memory.FillRAM[0x2125], Byte);
 					PPU.ClipWindow1Enable[4] = !!(Byte & 0x02);
 					PPU.ClipWindow1Enable[5] = !!(Byte & 0x20);
 					PPU.ClipWindow2Enable[4] = !!(Byte & 0x08);

--- a/ppu.cpp
+++ b/ppu.cpp
@@ -342,7 +342,8 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 					if (!(Byte & 0x80) && !((Memory.FillRAM[0x2100] ^ Byte) & 0x80) &&
 						PPU.Brightness != (Byte & 0xf) &&
 						CPU.V_Counter >= FIRST_VISIBLE_LINE &&
-						CPU.V_Counter < PPU.ScreenHeight + FIRST_VISIBLE_LINE)
+						CPU.V_Counter < PPU.ScreenHeight + FIRST_VISIBLE_LINE &&
+						CPU.Cycles < Timings.HBlankStart)
 					{
 						int x = CPU.Cycles / ONE_DOT_CYCLE - 22;
 						if (x >= 1 && x <= 255)

--- a/ppu.cpp
+++ b/ppu.cpp
@@ -475,6 +475,7 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 				if (Byte != Memory.FillRAM[0x2106])
 				{
 					FLUSH_REDRAW();
+					S9xRecordMidLineWindowSel(3, Memory.FillRAM[0x2106], Byte);
 					PPU.MosaicStart = CPU.V_Counter;
 					if (PPU.MosaicStart > PPU.ScreenHeight)
 						PPU.MosaicStart = 0;

--- a/ppu.cpp
+++ b/ppu.cpp
@@ -334,15 +334,15 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 				{
 					FLUSH_REDRAW();
 
-					// Brightness-only change in the middle of a visible line,
-					// after this line's render latch: the line is already drawn
-					// with the old value, so log a span for the post-pass
+					// Brightness-only change in the middle of a visible line:
+					// a scanline renderer draws the whole line with one value,
+					// so log the event; the post-pass re-scales whatever span
+					// disagrees with the brightness the line was rendered with
 					// (A.S.P.'s mid-scanline aircraft shadow).
 					if (!(Byte & 0x80) && !((Memory.FillRAM[0x2100] ^ Byte) & 0x80) &&
 						PPU.Brightness != (Byte & 0xf) &&
 						CPU.V_Counter >= FIRST_VISIBLE_LINE &&
-						CPU.V_Counter < PPU.ScreenHeight + FIRST_VISIBLE_LINE &&
-						CPU.Cycles > Timings.RenderPos)
+						CPU.V_Counter < PPU.ScreenHeight + FIRST_VISIBLE_LINE)
 					{
 						int x = CPU.Cycles / ONE_DOT_CYCLE - 22;
 						if (x >= 1 && x <= 255)


### PR DESCRIPTION
Fixes all four reported A.S.P. Air Strike Patrol issues by handling the game's per-line IRQ beam racing (upstream snes9xgit#53, snes9xgit#524, snes9xgit#747):

- **aircraft shadow** — mid-scanline INIDISP dim window (~10 dots, alternate frames; the 30Hz blink is authentic hardware behavior)
- **GOOD LUCK message** — per-line BG3VOFS raster: rotation animation restored, single message instead of the frozen duplicate, HUD untouched
- **pause-map 'interlaced transparency'** — W12SEL/WOBJSEL inversion raster: stripes bounded exactly to the map box
- **map grow-in** — per-line MOSAIC raster with animating block size, box border kept clean
- **mode-5 front-end** — SETINI interlace honored in every BG mode again for the $2133 HDMA banding

Mechanism: the `Timings.RenderPos = 128` game hack latched every line before the IRQ writes landed, so lines rendered the end-of-line restore values. The hack is removed; mid-visible-line writes to INIDISP, window-select, MOSAIC and BG scroll registers are recorded with their dot positions, and each affected line's outer spans are re-rendered post-frame through the normal compositor (clip-segment restriction, per-line HDMA window positions and backdrop color, Z-buffer cleared). HBlank-onward writes — ordinary IRQ splits and HDMA — are excluded, so the machinery is inert for every other game.

This is the 12-commit series preserving the investigation history; the squashed 2-commit version is upstream as snes9xgit#1079. Verified against bsnes-plus and Mesen references; ~90-ROM visual regression sweep clean (the A.S.P. baseline is now blessed on snes_gb_debugger); SMW / Star Fox / SF2 Turbo bit-identical.