### PR TITLE
conffile: default program name to "SuperSnes9x" (fix win32 config header)

### DIFF
--- a/conffile.cpp
+++ b/conffile.cpp
@@ -22,7 +22,7 @@ using namespace std;
 bool ConfigFile::defaultAutoAdd = false;
 bool ConfigFile::niceAlignment = false;
 bool ConfigFile::showComments = true;
-std::string ConfigFile::programName = "snes9x";
+std::string ConfigFile::programName = "SuperSnes9x";
 bool ConfigFile::alphaSort = true;
 bool ConfigFile::timeSort = false;
 static ConfigFile* curConfigFile = NULL; // for section_then_key_less
@@ -479,7 +479,7 @@ void ConfigFile::SetShowComments(bool show)
 }
 void ConfigFile::SetProgramName(const char *name)
 {
-	programName = (name && *name) ? name : "snes9x";
+	programName = (name && *name) ? name : "SuperSnes9x";
 }
 void ConfigFile::SetAlphaSort(bool sort)
 {

--- a/conffile.h
+++ b/conffile.h
@@ -73,7 +73,7 @@ class ConfigFile {
     static void SetDefaultAutoAdd(bool autoAdd);
     static void SetNiceAlignment(bool align);
     static void SetShowComments(bool show);
-    static void SetProgramName(const char *name); // program name shown in the config file's header comment (default "snes9x")
+    static void SetProgramName(const char *name); // program name shown in the config file's header comment (default "SuperSnes9x")
     static void SetAlphaSort(bool sort);
     static void SetTimeSort(bool sort);
 


### PR DESCRIPTION
## What & why

Follow-up to #209 / #210. Those PRs added `ConfigFile::SetProgramName` (used to write the `# Config file output by <name>` header) with a `"snes9x"` default, and had the GTK and Qt ports override it to `SuperSnes9x`.

**win32** is the only other `SaveTo` caller and never calls `SetProgramName`, so it kept emitting `# Config file output by snes9x` — even though win32 is already branded **SuperSnes9x** everywhere else (title bar `WINDOW_TITLE`, RetroAchievements emulator name, file-association strings). The header was just a straggler left in shared core code.

## Change

Flip the default (and the null/empty fallback) in `conffile.cpp` from `"snes9x"` to `"SuperSnes9x"`:

- **win32** now emits `# Config file output by SuperSnes9x` automatically.
- The GTK/Qt `SetProgramName("SuperSnes9x")` calls are now redundant but harmless (left in place as explicit intent).
- The unix/CLI port never writes a config file, so it's unaffected.
