### PR TITLE
gtk/qt: persist SGB BIOS preference in the config file (fixes #207)

### DIFF
--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -388,6 +388,11 @@ int Snes9xConfig::save_config_file()
     outbool("OverclockCPU", Settings.OneClockCycle != 6, "Speed up the emulated CPU to cut in-game slowdown (inaccurate; can break some games)");
     outbool("EchoBufferHack", Settings.SeparateEchoBuffer, "Prevents echo buffer from overwriting APU RAM");
 
+    // Key path "SGB::BIOSPreference" matches the win32 config (wconfig.cpp) and
+    // the CLI (snes9x.cpp) so every port reads/writes the same entry.
+    section = "SGB";
+    outint("BIOSPreference", Settings.SGB_BIOSPreference, "BIOS mode for GB/GBC ROMs: 0=No BIOS (BIOS-less), 1=SGB1, 2=SGB2 (default)");
+
     section = "Input";
     controllers controller = CTL_NONE;
     int8 id[4];
@@ -637,6 +642,11 @@ int Snes9xConfig::load_config_file()
     bool OverclockCPU = false;
     inbool("OverclockCPU", OverclockCPU);
     inbool("EchoBufferHack", Settings.SeparateEchoBuffer);
+
+    section = "SGB";
+    inint("BIOSPreference", Settings.SGB_BIOSPreference);
+    if (Settings.SGB_BIOSPreference > 2)
+        Settings.SGB_BIOSPreference = 2;
 
     section = "Input";
 

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -301,6 +301,7 @@ bool EmuConfig::setDefaults(int section)
         enable_shadow_buffer = false;
         superfx_clock_multiplier = 100;
         sound_filter = eGaussian;
+        sgb_bios_preference = 2;
     }
 
     if (section == -1 || section == 4)
@@ -561,6 +562,12 @@ void EmuConfig::config(const std::string &filename, bool write)
         const std::vector<const char *> legacy_sound_filter_map = { "Gaussian", "Nearest", "Linear", "Cubic", "Sinc" };
         Enum("SoundFilter", sound_filter, legacy_sound_filter_map);
     }
+    EndSection();
+
+    // Key path "SGB::BIOSPreference" matches the win32 config (wconfig.cpp) and
+    // the CLI (snes9x.cpp) so every port reads/writes the same entry.
+    BeginSection("SGB");
+    Int("BIOSPreference", sgb_bios_preference, "BIOS mode for GB/GBC ROMs: 0=No BIOS (BIOS-less), 1=SGB1, 2=SGB2 (default)");
     EndSection();
 
     BeginSection("Ports");

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -178,6 +178,11 @@ struct EmuConfig
     };
     int sound_filter;
 
+    // SGB BIOS mode for GB/GBC ROMs: 0=No BIOS (BIOS-less), 1=SGB1, 2=SGB2 (default).
+    // Persisted under [SGB] BIOSPreference to match win32/GTK/CLI, applied to
+    // Settings.SGB_BIOSPreference; the BIOS menu keeps this in sync.
+    int sgb_bios_preference;
+
     // Files
     enum FileLocation
     {

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -429,6 +429,7 @@ void EmuMainWindow::createWidgets()
     }
     auto reload_with_pref = [this](uint8_t pref) {
         Settings.SGB_BIOSPreference = pref;
+        app->config->sgb_bios_preference = pref; // persist the choice to the config file
         if (Settings.GBRomPath[0])
             openFile(std::string(Settings.GBRomPath));
     };

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -200,6 +200,12 @@ void Snes9xController::updateSettings(EmuConfig *config)
     // but never applied here.
     Settings.SeparateEchoBuffer = config->enable_shadow_buffer;
 
+    // SGB BIOS mode preference for GB/GBC ROMs (0=No BIOS, 1=SGB1, 2=SGB2). The
+    // BIOS menu also writes this back into config so the choice persists.
+    Settings.SGB_BIOSPreference = (config->sgb_bios_preference < 0 || config->sgb_bios_preference > 2)
+                                      ? 2
+                                      : (uint8)config->sgb_bios_preference;
+
     if (rewind_buffer_size != config->rewind_buffer_size && active)
     {
         g_state_manager.init(config->rewind_buffer_size * 1048576);


### PR DESCRIPTION
## What & why

Fixes #207. win32's config lets you pick the SGB BIOS mode for GB/GBC ROMs (`SGB::BIOSPreference` = 0 No BIOS / 1 SGB1 / 2 SGB2), but the Linux `.conf` files did not — so the selection couldn't be set from the file and reset on every launch.

Both Linux ports actually already have a runtime **BIOS** menu (No BIOS / SGB1 / SGB2) that sets `Settings.SGB_BIOSPreference`; the gap was purely that neither **persisted** it. This adds that persistence under the same `SGB::BIOSPreference` key win32 and the CLI (`snes9x.cpp`) already use, so all ports agree on the entry.

## Changes

- **GTK** (`gtk_config.cpp`): read/write `[SGB] BIOSPreference` in `load_config_file`/`save_config_file`, clamped to 0-2. The existing menu already drives `Settings.SGB_BIOSPreference`, so the saved value is the menu choice and the loaded value applies on the next GB ROM open — no menu changes needed.
- **Qt**: add `config->sgb_bios_preference` (default 2), read/write it under `[SGB]`, apply it in `Snes9xController::updateSettings`, and have the BIOS menu write the choice back into config so it survives a restart.

Written entry:
```
[SGB]
BIOSPreference = 2  # BIOS mode for GB/GBC ROMs: 0=No BIOS (BIOS-less), 1=SGB1, 2=SGB2 (default)
```

## Testing

Both ports build clean (`ninja snes9x-gtk`, `ninja snes9x-qt`).
