### PR TITLE
macOS support: Qt .app bundle and universal libretro core, both self-signed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -508,12 +508,19 @@ profile
 /win32/super-snes9x.conf
 
 # --- Super Snes9x: build artifacts and local data ---
+libretro/dist/
 libretro/jni/dist/
 libretro/linux/dist/
+libretro/macos/dist/
+libretro/macos/build/
 libretro/libs/
 qt/build-appimage/
 qt/build-appimage-x86/
+qt/build-macos/
 gtk/build-appimage-x86/
 *.AppImage
+*.dylib
+*.app/
+*.dmg
 Roms/
 Bios/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ cd libretro
 ./build-all.sh
 ```
 
+## macOS
+
+The Qt GUI and the libretro core both build on macOS, self-signed so they run
+without a paid Apple Developer account:
+
+```bash
+# Qt GUI -> qt/build-macos/super-snes9x-qt.app
+cmake -S qt -B qt/build-macos -G Ninja -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH="$(brew --prefix qt)"
+cmake --build qt/build-macos -j"$(sysctl -n hw.ncpu)"
+qt/scripts/makeapp-macos.sh
+
+# libretro core -> libretro/macos/dist/ (universal x86_64 + arm64)
+libretro/macos/build-macos.sh
+```
+
+Or build both at once with `cd libretro && ./build-all.sh --osx`. That flag
+selects the macOS artifacts *instead of* the Linux and Android ones — the
+Linux AppImages are native builds and the macOS ones need Xcode, so a single
+host can't produce both.
+
+The macOS GUI uses the Qt Software or OpenGL display driver; Vulkan is not
+available on the platform. Because the builds are ad-hoc signed rather than
+notarized, a copy that arrives over the network needs its quarantine flag
+cleared: `xattr -dr com.apple.quarantine <path>`.
+
+See [qt/docs/README-macos.md](qt/docs/README-macos.md) for details.
+
 ## Upstream builds (plain snes9x, not SuperSnes9x)
 
 Official upstream snes9x builds, for reference:

--- a/common/video/opengl/mac_opengl_context.hpp
+++ b/common/video/opengl/mac_opengl_context.hpp
@@ -1,0 +1,46 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#include "opengl_context.hpp"
+
+// NSOpenGL-backed OpenGL context for macOS.
+//
+// The AppKit objects are held as void* so this header stays includable from
+// plain C++ translation units; the implementation is Objective-C++
+// (mac_opengl_context.mm).
+//
+// Threading: macOS requires -[NSOpenGLContext setView:] and -update to happen
+// on the main (AppKit) thread, while snes9x renders from the emulation
+// thread. attach()/create_context()/resize() are therefore main-thread only,
+// and every context operation takes the CGL context lock so the two threads
+// cannot be inside the context at once.
+//
+// macOS only exposes a 4.1 core profile (the legacy profile stops at 2.1),
+// and its GLSL compiler rejects `#version 140` in a core profile, so callers
+// must feed it `#version 150` or newer shader sources.
+class MacOpenGLContext : public OpenGLContext
+{
+  public:
+    MacOpenGLContext();
+    ~MacOpenGLContext() override;
+
+    // view is the NSView* that QWidget::winId() returns. Main thread only.
+    bool attach(void *view);
+
+    bool create_context() override;
+    void resize() override;
+    void swap_buffers() override;
+    void swap_interval(int frames) override;
+    void make_current() override;
+    bool ready() override;
+    void deinit();
+
+  private:
+    void *view = nullptr;        // NSView *
+    void *gl_context = nullptr;  // NSOpenGLContext *
+};

--- a/common/video/opengl/mac_opengl_context.mm
+++ b/common/video/opengl/mac_opengl_context.mm
@@ -1,0 +1,202 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "mac_opengl_context.hpp"
+
+#import <Cocoa/Cocoa.h>
+#import <OpenGL/OpenGL.h>
+
+#include <cstdio>
+
+// OpenGL is deprecated on macOS but still the only cross-vendor 3D API
+// available without dragging in MoltenVK. Silence the deprecation spam so
+// real warnings stay visible.
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+namespace
+{
+
+NSOpenGLContext *as_context(void *p)
+{
+    return (__bridge NSOpenGLContext *)p;
+}
+
+NSView *as_view(void *p)
+{
+    return (__bridge NSView *)p;
+}
+
+// RAII wrapper for the CGL context lock. The emulation thread renders while
+// the main thread may be servicing a resize, and NSOpenGLContext is not safe
+// to touch from both at once.
+class ContextLock
+{
+  public:
+    explicit ContextLock(void *ctx) : cgl(nullptr)
+    {
+        if (!ctx)
+            return;
+        cgl = [as_context(ctx) CGLContextObj];
+        if (cgl)
+            CGLLockContext(cgl);
+    }
+
+    ~ContextLock()
+    {
+        if (cgl)
+            CGLUnlockContext(cgl);
+    }
+
+    ContextLock(const ContextLock &) = delete;
+    ContextLock &operator=(const ContextLock &) = delete;
+
+  private:
+    CGLContextObj cgl;
+};
+
+} // namespace
+
+MacOpenGLContext::MacOpenGLContext()
+{
+}
+
+MacOpenGLContext::~MacOpenGLContext()
+{
+    deinit();
+}
+
+bool MacOpenGLContext::attach(void *view_)
+{
+    if (!view_)
+        return false;
+
+    view = view_;
+
+    NSView *v = as_view(view);
+    // The layer backing is what actually gets composited; without it the
+    // context draws into a surface the window server never shows.
+    [v setWantsBestResolutionOpenGLSurface:YES];
+
+    return true;
+}
+
+bool MacOpenGLContext::create_context()
+{
+    if (gl_context)
+        return true;
+
+    if (!view)
+        return false;
+
+    // 4.1 is the highest macOS ever shipped, and only in a core profile.
+    NSOpenGLPixelFormatAttribute attributes[] = {
+        NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion4_1Core,
+        NSOpenGLPFAColorSize,     24,
+        NSOpenGLPFAAlphaSize,     8,
+        NSOpenGLPFADepthSize,     0,
+        NSOpenGLPFADoubleBuffer,
+        NSOpenGLPFAAccelerated,
+        // Lets the context survive an eGPU/discrete GPU going away, and
+        // allows software fallback rather than failing outright.
+        NSOpenGLPFAAllowOfflineRenderers,
+        0
+    };
+
+    NSOpenGLPixelFormat *format =
+        [[NSOpenGLPixelFormat alloc] initWithAttributes:attributes];
+
+    if (!format)
+    {
+        printf("Couldn't find a suitable NSOpenGL pixel format.\n");
+        return false;
+    }
+
+    NSOpenGLContext *context = [[NSOpenGLContext alloc] initWithFormat:format
+                                                         shareContext:nil];
+    if (!context)
+    {
+        printf("Couldn't create an NSOpenGLContext.\n");
+        return false;
+    }
+
+    gl_context = (__bridge_retained void *)context;
+
+    NSView *v = as_view(view);
+    [context setView:v];
+    [context makeCurrentContext];
+
+    NSRect backing = [v convertRectToBacking:[v bounds]];
+    width = backing.size.width;
+    height = backing.size.height;
+
+    return true;
+}
+
+void MacOpenGLContext::resize()
+{
+    if (!gl_context || !view)
+        return;
+
+    ContextLock lock(gl_context);
+
+    NSView *v = as_view(view);
+    NSRect backing = [v convertRectToBacking:[v bounds]];
+    width = backing.size.width;
+    height = backing.size.height;
+
+    // -update re-reads the view geometry; it is the NSOpenGL equivalent of
+    // glXWaitX()/wglMakeCurrent after a resize.
+    [as_context(gl_context) update];
+}
+
+void MacOpenGLContext::swap_buffers()
+{
+    if (!gl_context)
+        return;
+
+    ContextLock lock(gl_context);
+    [as_context(gl_context) flushBuffer];
+}
+
+void MacOpenGLContext::swap_interval(int frames)
+{
+    if (!gl_context)
+        return;
+
+    ContextLock lock(gl_context);
+    GLint interval = frames;
+    [as_context(gl_context) setValues:&interval
+                         forParameter:NSOpenGLContextParameterSwapInterval];
+}
+
+void MacOpenGLContext::make_current()
+{
+    if (!gl_context)
+        return;
+
+    [as_context(gl_context) makeCurrentContext];
+}
+
+bool MacOpenGLContext::ready()
+{
+    return gl_context != nullptr;
+}
+
+void MacOpenGLContext::deinit()
+{
+    if (!gl_context)
+        return;
+
+    NSOpenGLContext *context = (__bridge_transfer NSOpenGLContext *)gl_context;
+    gl_context = nullptr;
+
+    if ([NSOpenGLContext currentContext] == context)
+        [NSOpenGLContext clearCurrentContext];
+
+    [context clearDrawable];
+
+    view = nullptr;
+}

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -87,7 +87,10 @@ ifneq (,$(findstring unix,$(platform)))
 # OS X
 else ifeq ($(platform), osx)
    CFLAGS += $(LTO)
-   CXXFLAGS += -std=c++14 $(LTO)
+   # -std=c++17 is required (the core uses std::string_view); pin it for the
+   # same reason the unix branch does, rather than relying on the compiler's
+   # default standard.
+   CXXFLAGS += -std=c++17 $(LTO)
    LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC
@@ -99,11 +102,26 @@ else ifeq ($(platform), osx)
    ifeq ($(arch),ppc)
       CXXFLAGS += -DBLARGG_BIG_ENDIAN=1 -D__ppc__
    endif
-   OSXVER = $(shell sw_vers -productVersion | cut -d. -f 2)
-   OSX_GT_MOJAVE = $(shell (( $(OSXVER) >= 14)) && echo "YES")
-   ifneq ($(OSX_GT_MOJAVE),YES)
-	#this breaks compiling on Mac OS Mojave
-      fpic += -mmacosx-version-min=10.1
+
+   # Deployment target. The previous code read the *minor* field of
+   # `sw_vers -productVersion`, which was written for the 10.x scheme. On
+   # macOS 11+ that parses "14.3" as "3", always takes the pre-Mojave branch
+   # and passes -mmacosx-version-min=10.1 -- which makes the modern linker
+   # abort with "Assertion failed: (targetAtom != NULL)". Pick a sane floor
+   # instead and let the caller override it.
+   #
+   # 10.13 is the oldest target current Xcode still links x86_64 against.
+   # arm64 does not exist before 11.0, so arm64 builds must raise this
+   # (macos/build-macos.sh does).
+   OSX_MIN_VERSION ?= 10.13
+   fpic += -mmacosx-version-min=$(OSX_MIN_VERSION)
+
+   # Target architecture(s). Defaults to whatever the host compiler picks.
+   # Set OSX_ARCHS to cross-compile, e.g. OSX_ARCHS=arm64. Universal binaries
+   # are produced by building each arch separately and lipo'ing them together
+   # (see macos/build-macos.sh) so that -flto stays single-arch per link.
+   ifneq ($(OSX_ARCHS),)
+      fpic += $(addprefix -arch ,$(OSX_ARCHS))
    endif
 
 # Nintendo Switch (libnx)

--- a/libretro/build-all.sh
+++ b/libretro/build-all.sh
@@ -1,21 +1,29 @@
 #!/usr/bin/env bash
 #
 # Master build: Qt GUI, GTK GUI, Linux libretro core, Android libretro core.
+# With --osx instead: the macOS Qt .app bundle and the universal
+# (x86_64 + arm64) macOS libretro core, and nothing else.
 #
 # Cleans every executable/.so first so stale artifacts can never be copied,
 # then rebuilds everything and prints the full path of each fresh file.
 #
 # Usage:
 #   ./build-all.sh                # Android cores for arm64-v8a + armeabi-v7a
-#   ./build-all.sh --copy         # also copy artifacts to the VMware share
+#   ./build-all.sh --osx          # build ONLY the macOS .app + macOS core
+#   ./build-all.sh --copy         # also collect artifacts into libretro/dist
+#   ./build-all.sh --copy /path   # ... into /path instead
 #   ./build-all.sh --compress     # zip each core with its .info
 #   ANDROID_ABI=all ./build-all.sh
 #
-# --copy copies every artifact (AppImages, cores, .info files) flat into
-# SHARE_DIR (default /mnt/hgfs/Shared) after a fully successful build.
-# --compress zips each core (.so) together with its matching .info next to
-# the .so; AppImages are never compressed. With --copy, the share receives
-# the zips instead of the bare .so/.info files.
+# --copy gathers every artifact (AppImages/.app, cores, .info files) flat
+# into one directory after a fully successful build. It defaults to
+# libretro/dist next to this script; pass a path (--copy /path, or
+# --copy=/path) or set SHARE_DIR to send them elsewhere, e.g. a VM share:
+#   ./build-all.sh --copy /mnt/hgfs/Shared
+# The directory is created if missing.
+# --compress zips each core together with its matching .info next to the
+# core; AppImages are never compressed. With --copy, the destination
+# receives the zips instead of the bare core/.info files.
 #
 # Notes:
 # - The Linux core is built with linux/build-portable.sh (needs docker):
@@ -26,24 +34,62 @@
 #   22.04 baseline).
 # - The x86 (32-bit) GUI AppImages are docker builds against Debian 12,
 #   the only current i386 archive that ships Qt 6.
+# - --osx is a separate mode rather than an addition, because the two halves
+#   cannot be crossed: the Linux GUI AppImages are native builds, and the
+#   macOS artifacts need Xcode and codesign. It must be run on macOS.
+#   The docker-based Linux and Android cores do work on macOS -- run
+#   linux/build-portable.sh and jni/build-android.sh directly for those.
+# - The macOS artifacts are ad-hoc signed, not notarized. See
+#   qt/docs/README-macos.md for the quarantine caveat.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 ANDROID_ABI="${ANDROID_ABI:-arm64-v8a armeabi-v7a}"
-JOBS="$(nproc)"
-SHARE_DIR="${SHARE_DIR:-/mnt/hgfs/Shared}"
+# Default destination for --copy: a dist/ directory beside this script. The
+# environment can override it, and an explicit --copy <path> beats both.
+SHARE_DIR="${SHARE_DIR:-${SCRIPT_DIR}/dist}"
+
+# macOS has no nproc, so resolve the job count portably.
+if command -v nproc >/dev/null 2>&1; then
+    JOBS="$(nproc)"
+else
+    JOBS="$(sysctl -n hw.ncpu)"
+fi
 
 COPY_TO_SHARE=0
 COMPRESS=0
-for arg in "$@"; do
-    case "$arg" in
-        --copy) COPY_TO_SHARE=1 ;;
+BUILD_OSX=0
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --copy)
+            COPY_TO_SHARE=1
+            # The destination is optional, so only swallow the next argument
+            # when there is one and it is not itself a flag. Guarding on $#
+            # first keeps `set -u` from tripping over an unset $2.
+            if [ "$#" -gt 1 ] && [ "${2#-}" = "$2" ]; then
+                SHARE_DIR="$2"
+                shift
+            fi
+            ;;
+        --copy=*)
+            COPY_TO_SHARE=1
+            SHARE_DIR="${1#--copy=}"
+            ;;
         --compress) COMPRESS=1 ;;
-        *) echo "unknown option: $arg" >&2; exit 2 ;;
+        --osx) BUILD_OSX=1 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
     esac
+    shift
 done
+
+# The macOS artifacts need clang, the macOS SDK and codesign, none of which
+# exist off Darwin -- fail early rather than midway through a long build.
+if [ "${BUILD_OSX}" -eq 1 ] && [ "$(uname -s)" != "Darwin" ]; then
+    echo "error: --osx must be run on macOS (this host is $(uname -s))" >&2
+    exit 2
+fi
 
 QT_BIN="${REPO_DIR}/qt/build/super-snes9x-qt"
 GTK_BIN="${REPO_DIR}/gtk/build/super-snes9x-gtk"
@@ -55,6 +101,10 @@ LINUX_SO="${SCRIPT_DIR}/linux/dist/x86_64/supersnes9x_libretro-x64.so"
 LINUX_SO_X86="${SCRIPT_DIR}/linux/dist/x86/supersnes9x_libretro.so"
 ANDROID_DIST="${SCRIPT_DIR}/jni/dist"
 
+MACOS_BUILD_DIR="${REPO_DIR}/qt/build-macos"
+MACOS_APP="${MACOS_BUILD_DIR}/super-snes9x-qt.app"
+MACOS_DYLIB="${SCRIPT_DIR}/macos/dist/supersnes9x_libretro.dylib"
+
 # Run the AppImage tools without FUSE (works everywhere, incl. containers).
 export APPIMAGE_EXTRACT_AND_RUN=1
 
@@ -63,16 +113,62 @@ step() { echo; echo "==> $*"; }
 # ---- Clean old artifacts -------------------------------------------------
 
 step "Cleaning old executables and cores"
-rm -f "${QT_BIN}" "${GTK_BIN}" "${QT_APPIMAGE}" "${GTK_APPIMAGE}" \
-      "${QT_APPIMAGE_X86}" "${GTK_APPIMAGE_X86}" \
-      "${LINUX_SO}" "${LINUX_SO_X86}" \
-      "${SCRIPT_DIR}/linux/dist/x86_64/supersnes9x_libretro.so" \
-      "${SCRIPT_DIR}/supersnes9x_libretro.so"
-rm -rf "${REPO_DIR}/qt/build/AppDir" "${REPO_DIR}/gtk/build/AppDir"
-rm -rf "${ANDROID_DIST}" "${SCRIPT_DIR}/libs" "${SCRIPT_DIR}/obj"
+if [ "${BUILD_OSX}" -eq 1 ]; then
+    rm -rf "${MACOS_APP}"
+    rm -f "${MACOS_DYLIB}" "${MACOS_DYLIB%.dylib}.info" \
+          "${MACOS_DYLIB%.dylib}.zip" \
+          "${MACOS_BUILD_DIR}/super-snes9x-qt.dmg" \
+          "${SCRIPT_DIR}/supersnes9x_libretro.dylib"
+else
+    rm -f "${QT_BIN}" "${GTK_BIN}" "${QT_APPIMAGE}" "${GTK_APPIMAGE}" \
+          "${QT_APPIMAGE_X86}" "${GTK_APPIMAGE_X86}" \
+          "${LINUX_SO}" "${LINUX_SO_X86}" \
+          "${SCRIPT_DIR}/linux/dist/x86_64/supersnes9x_libretro.so" \
+          "${SCRIPT_DIR}/supersnes9x_libretro.so"
+    rm -rf "${REPO_DIR}/qt/build/AppDir" "${REPO_DIR}/gtk/build/AppDir"
+    rm -rf "${ANDROID_DIST}" "${SCRIPT_DIR}/libs" "${SCRIPT_DIR}/obj"
+fi
 # Libretro objects live in the repo root and are shared with other Makefile
 # builds; a clean here guarantees the core is rebuilt from current sources.
 make -C "${SCRIPT_DIR}" clean >/dev/null 2>&1 || true
+
+if [ "${BUILD_OSX}" -eq 1 ]; then
+
+# ---- macOS Qt .app -------------------------------------------------------
+
+step "Building Qt GUI (macOS .app)"
+if [ ! -f "${MACOS_BUILD_DIR}/CMakeCache.txt" ]; then
+    # Homebrew keeps qt keg-only, and libpng's .pc can sit outside the
+    # default search path, so point CMake and pkg-config at them explicitly.
+    # Written without arrays: macOS ships bash 3.2, where expanding an empty
+    # array under `set -u` aborts the script.
+    QT_PREFIX=""
+    if command -v brew >/dev/null 2>&1; then
+        QT_PREFIX="$(brew --prefix qt 2>/dev/null || true)"
+        LIBPNG_PREFIX="$(brew --prefix libpng 2>/dev/null || true)"
+        if [ -n "${LIBPNG_PREFIX}" ]; then
+            export PKG_CONFIG_PATH="${LIBPNG_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+        fi
+    fi
+    if [ -n "${QT_PREFIX}" ]; then
+        cmake -S "${REPO_DIR}/qt" -B "${MACOS_BUILD_DIR}" -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${QT_PREFIX}"
+    else
+        cmake -S "${REPO_DIR}/qt" -B "${MACOS_BUILD_DIR}" -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release
+    fi
+fi
+cmake --build "${MACOS_BUILD_DIR}" -j"${JOBS}"
+
+step "Packaging and signing the .app (macdeployqt + ad-hoc codesign)"
+"${REPO_DIR}/qt/scripts/makeapp-macos.sh" "${MACOS_BUILD_DIR}"
+
+# ---- macOS libretro core -------------------------------------------------
+
+step "Building macOS libretro core (universal: x86_64 + arm64)"
+"${SCRIPT_DIR}/macos/build-macos.sh"
+
+else
 
 # ---- Qt GUI --------------------------------------------------------------
 
@@ -114,34 +210,42 @@ step "Building Linux libretro cores (portable, Ubuntu 18.04 baseline: x86_64 + x
 step "Building Android libretro core (${ANDROID_ABI})"
 bash "${SCRIPT_DIR}/jni/build-android.sh" "${ANDROID_ABI}"
 
+fi
+
 # ---- Summary -------------------------------------------------------------
 
 echo
 echo "================ Build artifacts ================"
 missing=0
+# -e rather than -f: the macOS artifact is an .app bundle, i.e. a directory.
 show() {
-    if [ -f "$1" ]; then
+    if [ -e "$1" ]; then
         echo "  $1"
     else
         echo "  MISSING: $1"
         missing=1
     fi
 }
-show "${QT_BIN}"
-show "${GTK_BIN}"
-show "${QT_APPIMAGE}"
-show "${GTK_APPIMAGE}"
-show "${QT_APPIMAGE_X86}"
-show "${GTK_APPIMAGE_X86}"
-show "${LINUX_SO}"
-show "${LINUX_SO_X86}"
-found_android=0
-for so in "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.so; do
-    [ -f "$so" ] && { echo "  $so"; found_android=1; }
-done
-if [ "${found_android}" -eq 0 ]; then
-    echo "  MISSING: ${ANDROID_DIST}/<abi>/supersnes9x_libretro_android*.so"
-    missing=1
+if [ "${BUILD_OSX}" -eq 1 ]; then
+    show "${MACOS_APP}"
+    show "${MACOS_DYLIB}"
+else
+    show "${QT_BIN}"
+    show "${GTK_BIN}"
+    show "${QT_APPIMAGE}"
+    show "${GTK_APPIMAGE}"
+    show "${QT_APPIMAGE_X86}"
+    show "${GTK_APPIMAGE_X86}"
+    show "${LINUX_SO}"
+    show "${LINUX_SO_X86}"
+    found_android=0
+    for so in "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.so; do
+        [ -f "$so" ] && { echo "  $so"; found_android=1; }
+    done
+    if [ "${found_android}" -eq 0 ]; then
+        echo "  MISSING: ${ANDROID_DIST}/<abi>/supersnes9x_libretro_android*.so"
+        missing=1
+    fi
 fi
 echo "================================================="
 
@@ -156,17 +260,24 @@ if [ "${COMPRESS}" -eq 1 ]; then
         echo "error: zip is required for --compress (sudo apt install zip)" >&2
         exit 1
     fi
-    step "Compressing cores (.so + .info)"
-    for so in "${LINUX_SO}" "${LINUX_SO_X86}" \
-              "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.so; do
-        zipf="${so%.so}.zip"
+    step "Compressing cores (core + .info)"
+    if [ "${BUILD_OSX}" -eq 1 ]; then
+        zipf="${MACOS_DYLIB%.dylib}.zip"
         rm -f "${zipf}"
-        zip -j -q "${zipf}" "${so}" "${so%.so}.info"
+        zip -j -q "${zipf}" "${MACOS_DYLIB}" "${MACOS_DYLIB%.dylib}.info"
         echo "  ${zipf}"
-    done
+    else
+        for so in "${LINUX_SO}" "${LINUX_SO_X86}" \
+                  "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.so; do
+            zipf="${so%.so}.zip"
+            rm -f "${zipf}"
+            zip -j -q "${zipf}" "${so}" "${so%.so}.info"
+            echo "  ${zipf}"
+        done
+    fi
 fi
 
-# ---- Copy to the VMware shared folder ------------------------------------
+# ---- Collect artifacts into one directory --------------------------------
 
 if [ "${COPY_TO_SHARE}" -eq 1 ]; then
     if [ "${missing}" -ne 0 ]; then
@@ -174,25 +285,47 @@ if [ "${COPY_TO_SHARE}" -eq 1 ]; then
         exit 1
     fi
     step "Copying artifacts to ${SHARE_DIR}"
-    # An unmounted /mnt/hgfs silently accepts writes onto the local disk,
-    # so refuse to copy unless the target really is an hgfs mount.
-    if ! df -PT "${SHARE_DIR}" 2>/dev/null | grep -q hgfs; then
-        echo "error: ${SHARE_DIR} is not on a mounted hgfs share" >&2
-        echo "       (mount it with: sudo mount -t fuse.vmhgfs-fuse .host:/ /mnt/hgfs -o allow_other)" >&2
-        exit 1
-    fi
-    if [ "${COMPRESS}" -eq 1 ]; then
-        cp -v "${QT_APPIMAGE}" "${GTK_APPIMAGE}" "${QT_APPIMAGE_X86}" "${GTK_APPIMAGE_X86}" \
-              "${LINUX_SO%.so}.zip" "${LINUX_SO_X86%.so}.zip" \
-              "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.zip \
-              "${SHARE_DIR}/"
+
+    # A VM share that is not mounted silently accepts writes onto the local
+    # disk, so when the destination looks like one, insist it really is
+    # mounted. Ordinary directories just get created.
+    case "${SHARE_DIR}" in
+        /mnt/hgfs|/mnt/hgfs/*)
+            if ! df -PT "${SHARE_DIR}" 2>/dev/null | grep -q hgfs; then
+                echo "error: ${SHARE_DIR} is not on a mounted hgfs share" >&2
+                echo "       (mount it with: sudo mount -t fuse.vmhgfs-fuse .host:/ /mnt/hgfs -o allow_other)" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            mkdir -p "${SHARE_DIR}"
+            ;;
+    esac
+
+    if [ "${BUILD_OSX}" -eq 1 ]; then
+        # -R because the .app is a directory tree. Remove any previous copy
+        # first, or cp -R nests the new bundle inside the old one.
+        rm -rf "${SHARE_DIR}/$(basename "${MACOS_APP}")"
+        cp -Rv "${MACOS_APP}" "${SHARE_DIR}/"
+        if [ "${COMPRESS}" -eq 1 ]; then
+            cp -v "${MACOS_DYLIB%.dylib}.zip" "${SHARE_DIR}/"
+        else
+            cp -v "${MACOS_DYLIB}" "${MACOS_DYLIB%.dylib}.info" "${SHARE_DIR}/"
+        fi
     else
-        cp -v "${QT_APPIMAGE}" "${GTK_APPIMAGE}" "${QT_APPIMAGE_X86}" "${GTK_APPIMAGE_X86}" \
-              "${LINUX_SO}" "${LINUX_SO%.so}.info" \
-              "${LINUX_SO_X86}" "${LINUX_SO_X86%.so}.info" \
-              "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.so \
-              "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.info \
-              "${SHARE_DIR}/"
+        if [ "${COMPRESS}" -eq 1 ]; then
+            cp -v "${QT_APPIMAGE}" "${GTK_APPIMAGE}" "${QT_APPIMAGE_X86}" "${GTK_APPIMAGE_X86}" \
+                  "${LINUX_SO%.so}.zip" "${LINUX_SO_X86%.so}.zip" \
+                  "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.zip \
+                  "${SHARE_DIR}/"
+        else
+            cp -v "${QT_APPIMAGE}" "${GTK_APPIMAGE}" "${QT_APPIMAGE_X86}" "${GTK_APPIMAGE_X86}" \
+                  "${LINUX_SO}" "${LINUX_SO%.so}.info" \
+                  "${LINUX_SO_X86}" "${LINUX_SO_X86%.so}.info" \
+                  "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.so \
+                  "${ANDROID_DIST}"/*/supersnes9x_libretro_android*.info \
+                  "${SHARE_DIR}/"
+        fi
     fi
 fi
 

--- a/libretro/build-all.sh
+++ b/libretro/build-all.sh
@@ -157,6 +157,13 @@ if [ ! -f "${MACOS_BUILD_DIR}/CMakeCache.txt" ]; then
         cmake -S "${REPO_DIR}/qt" -B "${MACOS_BUILD_DIR}" -G Ninja \
               -DCMAKE_BUILD_TYPE=Release
     fi
+else
+    # CMake writes Contents/Info.plist at *generate* time; there is no build
+    # rule for it. The clean step above deletes the .app, so `cmake --build`
+    # alone would relink the executable into a bundle with no Info.plist at
+    # all -- no identifier, no icon, no Retina flag. Re-generate from the
+    # existing cache to put it back.
+    cmake -S "${REPO_DIR}/qt" -B "${MACOS_BUILD_DIR}" >/dev/null
 fi
 cmake --build "${MACOS_BUILD_DIR}" -j"${JOBS}"
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -825,10 +825,11 @@ void retro_get_system_info(struct retro_system_info *info)
     memset(info,0,sizeof(retro_system_info));
 
     info->library_name = "SuperSnes9x";
-#ifndef GIT_VERSION
-#define GIT_VERSION ""
-#endif
-    info->library_version = VERSION GIT_VERSION;
+    // VERSION_DISPLAY (VERSION "." PATCH_VERSION) rather than the bare
+    // VERSION plus the git hash, so the core reports the same 1.63.29 the
+    // GUIs show. RetroArch also treats library_version as a single token,
+    // and the old string embedded a space.
+    info->library_version = VERSION_DISPLAY;
     info->valid_extensions = "smc|sfc|swc|fig|bs|st|gb|gbc|dmg|sgb";
     info->need_fullpath = false;
     info->block_extract = false;

--- a/libretro/macos/.gitignore
+++ b/libretro/macos/.gitignore
@@ -1,0 +1,3 @@
+# Build output from build-macos.sh
+dist/
+build/

--- a/libretro/macos/build-macos.sh
+++ b/libretro/macos/build-macos.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Build a redistributable snes9x libretro core for macOS.
+#
+# Each architecture is built separately (a clean object tree per arch, since
+# the Makefile drops .o files next to the sources) and the slices are then
+# merged with lipo. Building per-arch rather than passing several -arch flags
+# to one clang invocation keeps -flto working on a single-arch link, which is
+# the only configuration Apple's linker reliably handles.
+#
+# The result is ad-hoc signed (`codesign -s -`). That is what an Apple ID
+# without a $99/yr Developer Program membership can produce: it satisfies the
+# arm64 requirement that all code be signed, and it lets RetroArch load the
+# core locally. It is NOT notarized, so a core downloaded from the internet
+# still carries the com.apple.quarantine attribute -- see README-macos.md.
+#
+# Usage:
+#   ./build-macos.sh                 # universal: x86_64 + arm64
+#   ./build-macos.sh x86_64          # single arch
+#   ./build-macos.sh x86_64 arm64    # same as the default
+#
+# Requirements: Xcode command line tools (clang, lipo, codesign).
+# Output: libretro/macos/dist/supersnes9x_libretro.dylib + matching .info
+
+set -euo pipefail
+
+# Repo layout: this script lives in libretro/macos/.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIBRETRO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DIST_DIR="${SCRIPT_DIR}/dist"
+BUILD_DIR="${SCRIPT_DIR}/build"
+
+TARGET_DYLIB="supersnes9x_libretro.dylib"
+JOBS="$(sysctl -n hw.ncpu)"
+
+# Deployment target per arch. arm64 did not exist before macOS 11.0, so a
+# lower floor there is silently clamped (and warned about) by the linker.
+min_version() {
+  case "$1" in
+    arm64) echo "11.0" ;;
+    *)     echo "10.13" ;;
+  esac
+}
+
+build_arch() {
+  local arch="$1" minver
+  minver="$(min_version "${arch}")"
+
+  echo ">>> Building ${TARGET_DYLIB} for ${arch} (macOS ${minver} floor) ..."
+
+  # Objects live next to the sources in the repo root and are shared with the
+  # other Makefile builds, so a clean between arches is mandatory -- otherwise
+  # the second link picks up the first arch's objects and fails.
+  make -C "${LIBRETRO_DIR}" clean >/dev/null 2>&1 || true
+  make -C "${LIBRETRO_DIR}" -j"${JOBS}" \
+    platform=osx \
+    OSX_ARCHS="${arch}" \
+    OSX_MIN_VERSION="${minver}"
+
+  mkdir -p "${BUILD_DIR}"
+  mv "${LIBRETRO_DIR}/${TARGET_DYLIB}" "${BUILD_DIR}/${TARGET_DYLIB}.${arch}"
+  echo "    $(file -b "${BUILD_DIR}/${TARGET_DYLIB}.${arch}")"
+}
+
+main() {
+  if ! command -v clang >/dev/null 2>&1; then
+    echo "error: clang not found -- install the Xcode command line tools:" >&2
+    echo "       xcode-select --install" >&2
+    exit 1
+  fi
+
+  local -a archs=("$@")
+  if [ "${#archs[@]}" -eq 0 ]; then
+    archs=("x86_64" "arm64")
+  fi
+
+  rm -rf "${BUILD_DIR}"
+  mkdir -p "${DIST_DIR}" "${BUILD_DIR}"
+
+  local -a slices=()
+  for arch in "${archs[@]}"; do
+    build_arch "${arch}"
+    slices+=("${BUILD_DIR}/${TARGET_DYLIB}.${arch}")
+  done
+
+  echo ">>> Merging ${#slices[@]} slice(s) with lipo ..."
+  lipo -create "${slices[@]}" -output "${DIST_DIR}/${TARGET_DYLIB}"
+
+  # Ad-hoc signature. Re-signing after lipo is required: lipo rewrites the
+  # Mach-O headers and invalidates any signature the individual slices had.
+  echo ">>> Ad-hoc signing ..."
+  codesign --force --sign - --timestamp=none "${DIST_DIR}/${TARGET_DYLIB}"
+  codesign --verify --verbose=2 "${DIST_DIR}/${TARGET_DYLIB}"
+
+  # RetroArch matches a core to its .info by filename, so ship them together.
+  cp "${LIBRETRO_DIR}/${TARGET_DYLIB%.dylib}.info" "${DIST_DIR}/"
+
+  rm -rf "${BUILD_DIR}"
+  make -C "${LIBRETRO_DIR}" clean >/dev/null 2>&1 || true
+
+  echo
+  echo ">>> Wrote ${DIST_DIR}/${TARGET_DYLIB}"
+  lipo -info "${DIST_DIR}/${TARGET_DYLIB}"
+}
+
+main "$@"

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -1,4 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
+
+# Must be set before project(), which is where CMake bakes it into the
+# compiler/linker probes.
+#
+# The floor is dictated by whichever Qt you link against: Homebrew's qt
+# bottles are built for the host OS (currently macOS 14.0), so linking a
+# lower target against them only produces "built for newer macOS version"
+# warnings. Override on the command line when using a Qt that supports
+# older systems, e.g. the official online-installer builds:
+#   cmake -S qt -B qt/build -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+if(APPLE AND NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0" CACHE STRING "Minimum macOS version")
+endif()
+
 project(snes9x-qt VERSION 1.63)
 
 include(GNUInstallDirs)
@@ -12,6 +26,15 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_GLOBAL_AUTOGEN_TARGET ON)
+
+# AUTOMOC above applies to the FetchContent'd SDL3 too, and Ninja + PCH +
+# AUTOMOC hit a CMake ordering bug where SDL3's mocs_compilation.cpp is
+# scheduled against a cmake_pch.hxx.pch that nothing generates. The Linux
+# AppImage scripts pass -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON for the same
+# reason; do it by default on macOS, where Ninja is the usual generator.
+if(APPLE AND NOT DEFINED CMAKE_DISABLE_PRECOMPILE_HEADERS)
+    set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON CACHE BOOL "" FORCE)
+endif()
 
 set(DEFINES SNES9X_QT)
 set(SNES9X_CORE_SOURCES
@@ -115,12 +138,24 @@ endif()
 find_package(Qt6 REQUIRED COMPONENTS Widgets Gui)
 list(APPEND LIBS Qt6::Widgets Qt6::Gui)
 
-pkg_check_modules(CURL REQUIRED libcurl)
-list(APPEND INCLUDES ${CURL_INCLUDE_DIRS})
-list(APPEND LIBS ${CURL_LIBRARIES})
+# Must come before the first pkg_check_modules() call below. It used to sit
+# after the libcurl lookup and only worked because something else in the
+# Linux configure had already pulled FindPkgConfig in.
+find_package(PkgConfig REQUIRED)
+
+if(APPLE)
+    # The libcurl in the macOS SDK ships no pkg-config file, so go through
+    # CMake's own finder rather than requiring a Homebrew curl.
+    find_package(CURL REQUIRED)
+    list(APPEND INCLUDES ${CURL_INCLUDE_DIRS})
+    list(APPEND LIBS CURL::libcurl)
+else()
+    pkg_check_modules(CURL REQUIRED libcurl)
+    list(APPEND INCLUDES ${CURL_INCLUDE_DIRS})
+    list(APPEND LIBS ${CURL_LIBRARIES})
+endif()
 list(APPEND INCLUDES ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
 
-find_package(PkgConfig REQUIRED)
 pkg_check_modules(ZLIB REQUIRED IMPORTED_TARGET zlib)
 pkg_check_modules(PNG REQUIRED IMPORTED_TARGET libpng)
 list(APPEND INCLUDES ${ZLIB_INCLUDE_DIRS})
@@ -140,6 +175,35 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         ../common/video/opengl/wgl_context.cpp
         ../external/glad/src/wgl.c
         src/resources/snes9x_win32.rc)
+elseif(APPLE)
+
+    enable_language(OBJCXX)
+
+    # See the Windows note below: screenshot.cpp inside snes9x-core calls
+    # libpng directly, so png/zlib have to hang off the core target to land
+    # after the archive on the link line.
+    target_link_libraries(snes9x-core PUBLIC PkgConfig::PNG PkgConfig::ZLIB)
+
+    # OpenGL is deprecated on macOS but is the only 3D API available without
+    # bringing in MoltenVK. It tops out at a 4.1 core profile.
+    find_library(COCOA_LIBRARY Cocoa REQUIRED)
+    find_library(OPENGL_FRAMEWORK OpenGL REQUIRED)
+    list(APPEND LIBS ${COCOA_LIBRARY} ${OPENGL_FRAMEWORK})
+
+    list(APPEND PLATFORM_SOURCES
+        ../common/video/opengl/mac_opengl_context.mm
+        ../common/video/opengl/mac_opengl_context.hpp)
+
+    # The context implementation uses __bridge_retained/__bridge_transfer to
+    # hand the NSOpenGLContext across the C++ boundary, which clang only
+    # accepts under ARC. Nothing else in the project is Objective-C, so scope
+    # the flag to this one file.
+    set_source_files_properties(../common/video/opengl/mac_opengl_context.mm
+        PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
+
+    # cubeb's CoreAudio backend covers macOS, so no PulseAudio equivalent is
+    # needed here.
+
 else()
 
     pkg_check_modules(WAYLAND REQUIRED wayland-client wayland-egl)
@@ -245,7 +309,6 @@ list(APPEND QT_GUI_SOURCES
     src/SoftwareScalers.cpp
     src/EmuCanvasQt.cpp
     src/EmuCanvasOpenGL.cpp
-    src/EmuCanvasVulkan.cpp
     ../external/glad/src/gl.c
     ../common/audio/s9x_sound_driver_sdl3.cpp
     ../common/audio/s9x_sound_driver_sdl3.hpp
@@ -259,6 +322,10 @@ list(APPEND QT_GUI_SOURCES
     ../filter/snes_ntsc.h
     ../filter/snes_ntsc_impl.h
     ../filter/snes_ntsc.c)
+
+if(NOT APPLE)
+    list(APPEND QT_GUI_SOURCES src/EmuCanvasVulkan.cpp)
+endif()
 
 # RetroAchievements support
 list(APPEND DEFINES RETROACHIEVEMENTS_SUPPORT RC_DISABLE_LUA RC_CLIENT_SUPPORTS_HASH)
@@ -343,47 +410,39 @@ list(APPEND LIBS
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     list(APPEND DEFINES "VK_USE_PLATFORM_WIN32_KHR")
-else()
+elseif(NOT APPLE)
     list(APPEND DEFINES
         "VK_USE_PLATFORM_XLIB_KHR"
         "VK_USE_PLATFORM_WAYLAND_KHR")
 endif()
 
-list(APPEND DEFINES
-    "VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1"
-    "VULKAN_HPP_NO_NODISCARD_WARNINGS=1"
-    "VULKAN_HPP_NO_EXCEPTIONS=1"
-    "VMA_DYNAMIC_VULKAN_FUNCTIONS=1"
-    "VMA_STATIC_VULKAN_FUNCTIONS=0"
-    "USE_SLANG")
+if(NOT APPLE)
+    list(APPEND DEFINES
+        "VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1"
+        "VULKAN_HPP_NO_NODISCARD_WARNINGS=1"
+        "VULKAN_HPP_NO_EXCEPTIONS=1"
+        "VMA_DYNAMIC_VULKAN_FUNCTIONS=1"
+        "VMA_STATIC_VULKAN_FUNCTIONS=0")
+    list(APPEND INCLUDES
+        ../external/vulkan-headers/include
+        ../external/VulkanMemoryAllocator-Hpp/include)
+endif()
+
+list(APPEND DEFINES "USE_SLANG")
 list(APPEND INCLUDES
-    ../external/vulkan-headers/include
-    ../external/VulkanMemoryAllocator-Hpp/include
     ../external/stb
     "../external/glad/include")
+
+# The slang_* files under common/video/vulkan/ are preset/shader *parsing*
+# only -- they pull in glslang and SPIRV-Cross but no Vulkan API -- and the
+# OpenGL shader stack (glsl.cpp, slang.cpp) depends on them. They are built
+# on every platform; only the files that actually call Vulkan are skipped on
+# macOS, which has no native Vulkan driver.
 list(APPEND SOURCES
     ../common/video/vulkan/slang_shader.cpp
     ../common/video/vulkan/slang_shader.hpp
     ../common/video/vulkan/slang_preset.cpp
     ../common/video/vulkan/slang_preset.hpp
-    ../common/video/vulkan/vulkan_hpp_storage.cpp
-    ../common/video/vulkan/vk_mem_alloc_implementation.cpp
-    ../common/video/vulkan/vulkan_context.cpp
-    ../common/video/vulkan/vulkan_context.hpp
-    ../common/video/vulkan/vulkan_common.cpp
-    ../common/video/vulkan/vulkan_common.hpp
-    ../common/video/vulkan/vulkan_texture.cpp
-    ../common/video/vulkan/vulkan_texture.hpp
-    ../common/video/vulkan/vulkan_swapchain.cpp
-    ../common/video/vulkan/vulkan_swapchain.hpp
-    ../common/video/vulkan/vulkan_slang_pipeline.cpp
-    ../common/video/vulkan/vulkan_slang_pipeline.hpp
-    ../common/video/vulkan/vulkan_pipeline_image.cpp
-    ../common/video/vulkan/vulkan_pipeline_image.hpp
-    ../common/video/vulkan/vulkan_shader_chain.cpp
-    ../common/video/vulkan/vulkan_shader_chain.hpp
-    ../common/video/vulkan/vulkan_simple_output.hpp
-    ../common/video/vulkan/vulkan_simple_output.cpp
     ../common/video/std_chrono_throttle.cpp
     ../common/video/std_chrono_throttle.hpp
     ../common/video/vulkan/slang_helpers.cpp
@@ -395,16 +454,80 @@ list(APPEND SOURCES
     ../common/video/opengl/shaders/slang.cpp
     ../common/video/opengl/shaders/shader_helpers.cpp)
 
-list(APPEND DEFINES "IMGUI_IMPL_VULKAN_NO_PROTOTYPES")
+if(NOT APPLE)
+    list(APPEND SOURCES
+        ../common/video/vulkan/vulkan_hpp_storage.cpp
+        ../common/video/vulkan/vk_mem_alloc_implementation.cpp
+        ../common/video/vulkan/vulkan_context.cpp
+        ../common/video/vulkan/vulkan_context.hpp
+        ../common/video/vulkan/vulkan_common.cpp
+        ../common/video/vulkan/vulkan_common.hpp
+        ../common/video/vulkan/vulkan_texture.cpp
+        ../common/video/vulkan/vulkan_texture.hpp
+        ../common/video/vulkan/vulkan_swapchain.cpp
+        ../common/video/vulkan/vulkan_swapchain.hpp
+        ../common/video/vulkan/vulkan_slang_pipeline.cpp
+        ../common/video/vulkan/vulkan_slang_pipeline.hpp
+        ../common/video/vulkan/vulkan_pipeline_image.cpp
+        ../common/video/vulkan/vulkan_pipeline_image.hpp
+        ../common/video/vulkan/vulkan_shader_chain.cpp
+        ../common/video/vulkan/vulkan_shader_chain.hpp
+        ../common/video/vulkan/vulkan_simple_output.hpp
+        ../common/video/vulkan/vulkan_simple_output.cpp)
+endif()
+
 list(APPEND SOURCES ../external/imgui/imgui.cpp
     ../external/imgui/imgui_demo.cpp
     ../external/imgui/imgui_draw.cpp
     ../external/imgui/imgui_tables.cpp
     ../external/imgui/imgui_widgets.cpp
     ../external/imgui/imgui_impl_opengl3.cpp
-    ../external/imgui/imgui_impl_vulkan.cpp
     ../external/imgui/snes9x_imgui.cpp)
+if(NOT APPLE)
+    list(APPEND DEFINES "IMGUI_IMPL_VULKAN_NO_PROTOTYPES")
+    list(APPEND SOURCES ../external/imgui/imgui_impl_vulkan.cpp)
+endif()
 list(APPEND INCLUDES ../external/imgui)
+
+if(APPLE)
+    # Build the .icns from the icon the fork already ships, so the bundle
+    # never depends on a checked-in binary that can drift from the Windows
+    # and Linux artwork. sips/iconutil are part of the base system.
+    set(MACOS_ICONSET "${CMAKE_CURRENT_BINARY_DIR}/super-snes9x-qt.iconset")
+    set(MACOS_ICNS "${CMAKE_CURRENT_BINARY_DIR}/super-snes9x-qt.icns")
+    set(MACOS_ICON_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/src/resources/snes9x.ico")
+
+    # The source art is 256x256, so the largest honest entry is
+    # icon_128x128@2x. Anything above that would just be an upscale.
+    add_custom_command(
+        OUTPUT ${MACOS_ICNS}
+        COMMAND ${CMAKE_COMMAND} -E rm -rf ${MACOS_ICONSET}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${MACOS_ICONSET}
+        COMMAND sips -s format png ${MACOS_ICON_SOURCE} --out ${MACOS_ICONSET}/base.png > /dev/null
+        COMMAND sips -z 16 16     ${MACOS_ICONSET}/base.png --out ${MACOS_ICONSET}/icon_16x16.png > /dev/null
+        COMMAND sips -z 32 32     ${MACOS_ICONSET}/base.png --out ${MACOS_ICONSET}/icon_16x16@2x.png > /dev/null
+        COMMAND sips -z 32 32     ${MACOS_ICONSET}/base.png --out ${MACOS_ICONSET}/icon_32x32.png > /dev/null
+        COMMAND sips -z 64 64     ${MACOS_ICONSET}/base.png --out ${MACOS_ICONSET}/icon_32x32@2x.png > /dev/null
+        COMMAND sips -z 128 128   ${MACOS_ICONSET}/base.png --out ${MACOS_ICONSET}/icon_128x128.png > /dev/null
+        COMMAND sips -z 256 256   ${MACOS_ICONSET}/base.png --out ${MACOS_ICONSET}/icon_128x128@2x.png > /dev/null
+        COMMAND ${CMAKE_COMMAND} -E rm -f ${MACOS_ICONSET}/base.png
+        COMMAND iconutil -c icns ${MACOS_ICONSET} -o ${MACOS_ICNS}
+        DEPENDS ${MACOS_ICON_SOURCE}
+        COMMENT "Generating super-snes9x-qt.icns"
+        VERBATIM)
+
+    # Listing the .icns as a source with MACOSX_PACKAGE_LOCATION is what gets
+    # it copied into Contents/Resources.
+    set_source_files_properties(${MACOS_ICNS} PROPERTIES
+        MACOSX_PACKAGE_LOCATION "Resources")
+    list(APPEND PLATFORM_SOURCES ${MACOS_ICNS})
+
+    # Ship the cheat database inside the bundle as well -- an .app has no
+    # /usr/share to fall back on.
+    set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/../data/cheats.bml"
+        PROPERTIES MACOSX_PACKAGE_LOCATION "Resources" HEADER_FILE_ONLY ON)
+    list(APPEND PLATFORM_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../data/cheats.bml")
+endif()
 
 add_executable(snes9x-qt ${QT_GUI_SOURCES} ${SOURCES} ${PLATFORM_SOURCES} src/resources/snes9x.qrc)
 set_target_properties(snes9x-qt PROPERTIES OUTPUT_NAME super-snes9x-qt)
@@ -412,13 +535,32 @@ set_target_properties(snes9x-qt PROPERTIES OUTPUT_NAME super-snes9x-qt)
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     set_target_properties(snes9x-qt PROPERTIES WIN32_EXECUTABLE True)
 endif()
+
+if(APPLE)
+    set_target_properties(snes9x-qt PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/src/resources/Info.plist.in"
+        MACOSX_BUNDLE_EXECUTABLE_NAME "super-snes9x-qt"
+        MACOSX_BUNDLE_BUNDLE_NAME "Super Snes9x"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.snes9x.super-snes9x-qt"
+        MACOSX_BUNDLE_ICON_FILE "super-snes9x-qt.icns"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
+        MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+        MACOSX_BUNDLE_COPYRIGHT "Licensed under the Snes9x License.")
+endif()
 target_link_libraries(snes9x-qt PRIVATE snes9x-core ${LIBS})
 target_compile_definitions(snes9x-qt PRIVATE ${DEFINES})
 target_compile_options(snes9x-qt PRIVATE ${FLAGS})
 target_include_directories(snes9x-qt PRIVATE "../" ${INCLUDES})
 
-install(TARGETS snes9x-qt)
-install(FILES ../data/cheats.bml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/snes9x)
+if(APPLE)
+    # cheats.bml rides inside the bundle (CheatsDialog looks in
+    # Contents/Resources); there is no shared datadir to install it to.
+    install(TARGETS snes9x-qt BUNDLE DESTINATION .)
+else()
+    install(TARGETS snes9x-qt)
+    install(FILES ../data/cheats.bml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/snes9x)
+endif()
 if(UNIX AND NOT APPLE)
     install(FILES src/resources/super-snes9x-qt.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
     install(FILES src/resources/snes9x.svg DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps)

--- a/qt/docs/README-macos.md
+++ b/qt/docs/README-macos.md
@@ -1,0 +1,187 @@
+# Building Super Snes9x on macOS
+
+Covers the Qt GUI (`.app` bundle) and the libretro core (`.dylib`), both
+self-signed with an ad-hoc signature so they run without a paid Apple
+Developer Program membership.
+
+## Requirements
+
+- Xcode command line tools: `xcode-select --install`
+- Homebrew packages: `brew install cmake ninja pkg-config qt libpng`
+- Submodules:
+  ```sh
+  git submodule update --init --recursive \
+      external/cubeb external/glslang external/SPIRV-Cross \
+      external/rcheevos external/vulkan-headers
+  ```
+
+zlib and libcurl come from the macOS SDK. SDL3 is fetched automatically by
+CMake unless you pass `-DUSE_SYSTEM_SDL3=ON`.
+
+## Qt GUI
+
+```sh
+cmake -S qt -B qt/build-macos -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH="$(brew --prefix qt)"
+cmake --build qt/build-macos -j"$(sysctl -n hw.ncpu)"
+qt/scripts/makeapp-macos.sh
+```
+
+The result is `qt/build-macos/super-snes9x-qt.app`, with the Qt frameworks
+copied in by `macdeployqt` and everything ad-hoc signed. Add `MAKE_DMG=1` to
+also produce a `.dmg`.
+
+### Why the packaging script does more than run macdeployqt
+
+Homebrew's `qt` is a meta-formula whose modules live in sibling kegs, and its
+plugins carry a single relative rpath (`@loader_path/../../../../lib`) that
+stops meaning anything once a plugin is copied into a bundle. macdeployqt
+resolves frameworks using only the rpaths of the binary it is scanning —
+`-libpath` does not extend that search — so it skips those modules and still
+exits 0. The visible symptom is subtle: `QtSvg` goes missing while the
+`iconengines/libqsvgicon` plugin that needs it is deployed, so every SVG icon
+silently fails to draw.
+
+`makeapp-macos.sh` therefore also prunes plugins the emulator never uses
+(`QtPdf`, `QtVirtualKeyboard`, webp), copies in whatever is still missing,
+rewrites absolute Homebrew install names to `@rpath`, strips rpaths pointing
+outside the bundle, and then *verifies* that no Mach-O in the bundle
+references either a framework it does not contain or an absolute
+`/usr/local` path. That last check is the real gate — a bundle that fails it
+would still run on the build machine, where the system Qt is present, and
+fail on every other Mac.
+
+`libpng` is keg-only in some Homebrew setups. If `pkg_check_modules` cannot
+find it, prepend it to the search path:
+
+```sh
+export PKG_CONFIG_PATH="$(brew --prefix libpng)/lib/pkgconfig:$PKG_CONFIG_PATH"
+```
+
+### Display drivers on macOS
+
+| Driver | Status |
+| --- | --- |
+| Qt Software | Works. CPU blit, no shaders. |
+| OpenGL | Works, via a `NSOpenGL` 4.1 core profile context. |
+| Vulkan | **Not built.** macOS has no native Vulkan driver. |
+
+The Vulkan canvas and everything under `common/video/vulkan/` that calls the
+Vulkan API are excluded from the macOS build, and the driver is removed from
+the Display settings list. A config file carrying `display_driver = vulkan`
+(copied from a Linux or Windows machine, say) falls back to OpenGL.
+
+Two consequences of macOS only offering OpenGL through a *core* profile,
+capped at 4.1:
+
+- Shader presets must be GLSL 1.50 or newer. Older `.glslp` presets written
+  against `#version 120`/`130` will not compile. `.slangp` presets, which are
+  cross-compiled through glslang/SPIRV-Cross, are unaffected.
+- OpenGL is deprecated by Apple. It still works on macOS 14, but the Qt
+  Software driver is the safe fallback if a future release removes it.
+
+### Deployment target
+
+Homebrew's `qt` bottles are built for the host macOS release, so the app
+inherits that floor — currently **macOS 14.0**, which is what
+`CMAKE_OSX_DEPLOYMENT_TARGET` defaults to in `qt/CMakeLists.txt`.
+
+To support older systems you need a Qt that itself targets them (the official
+online-installer builds target 12.0):
+
+```sh
+cmake -S qt -B qt/build-macos -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 ...
+```
+
+Lowering the target while still linking Homebrew's Qt only produces "built for
+newer macOS version" linker warnings — it does not actually make the app run
+on an older system.
+
+### Architecture
+
+The Qt build is single-architecture: whatever the host is, matching the Qt you
+link against. Homebrew ships a native-only Qt, so a universal `.app` would
+require building Qt from source as a universal binary first. The libretro core
+below has no such constraint and is built universal.
+
+## Both at once
+
+`build-all.sh --osx` builds the .app and the macOS core together, cleaning
+stale artifacts first and printing the path of each result:
+
+```sh
+cd libretro
+./build-all.sh --osx                 # .app + universal core
+./build-all.sh --osx --compress      # also zip the core with its .info
+./build-all.sh --osx --copy          # collect both into libretro/dist
+./build-all.sh --osx --copy /path    # ... into /path instead
+```
+
+`--osx` is a mode, not an addition: with it the script builds *only* the
+macOS artifacts, and without it only the Linux and Android ones. The Linux
+GUI AppImages are native builds and the macOS artifacts need Xcode and
+codesign, so no single host produces both. Passing `--osx` off macOS is
+rejected immediately rather than failing partway through.
+
+## libretro core
+
+```sh
+libretro/macos/build-macos.sh            # universal: x86_64 + arm64
+libretro/macos/build-macos.sh x86_64     # single arch
+```
+
+Output: `libretro/macos/dist/supersnes9x_libretro.dylib` plus its `.info`.
+Drop both into RetroArch's `cores` directory.
+
+Each architecture is compiled separately and merged with `lipo`, because
+passing several `-arch` flags to one `-flto` link is not reliable on Apple's
+toolchain. The script re-signs after `lipo`, since merging rewrites the
+Mach-O headers and invalidates any earlier signature.
+
+You can also drive the Makefile directly:
+
+```sh
+make -C libretro platform=osx OSX_ARCHS=arm64 OSX_MIN_VERSION=11.0
+```
+
+`OSX_MIN_VERSION` defaults to 10.13; arm64 requires at least 11.0.
+
+## Code signing
+
+Everything is signed ad-hoc (`codesign -s -`). Without a $99/yr Apple
+Developer Program membership that is the strongest signature available, and it
+is enough to:
+
+- satisfy the Apple Silicon requirement that all executable code be signed
+- keep the bundle's own integrity seal valid
+- let the app and core run normally on the machine that built them
+
+What it does **not** do is notarize. Anything that arrives over the network —
+downloaded, AirDropped, or copied from a disk image — picks up the
+`com.apple.quarantine` attribute, and Gatekeeper will refuse it, usually with
+the misleading message *"…is damaged and can't be opened."* The fix is to
+strip the attribute after copying:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/super-snes9x-qt.app
+xattr -dr com.apple.quarantine ~/Library/.../supersnes9x_libretro.dylib
+```
+
+Right-click → Open does **not** work around this for ad-hoc signed apps on
+current macOS; the `xattr` command is the reliable route.
+
+A self-signed *certificate* created in Keychain Access is no better than an
+ad-hoc signature here: Gatekeeper only trusts certificates chaining to Apple's
+Developer ID root, which requires the paid membership. The only difference a
+certificate would make is a stable signing identity across builds.
+
+If you do have a Developer ID certificate, both scripts honour it:
+
+```sh
+SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \
+    qt/scripts/makeapp-macos.sh
+```
+
+You would still need `xcrun notarytool submit` and `xcrun stapler staple`
+afterwards for a download that opens without the `xattr` step.

--- a/qt/scripts/makeapp-macos.sh
+++ b/qt/scripts/makeapp-macos.sh
@@ -71,6 +71,18 @@ MACDEPLOYQT="$(find_macdeployqt)" || {
     exit 1
 }
 
+# CMake emits Contents/Info.plist at generate time rather than as a build
+# rule, so deleting the .app and running only `cmake --build` produces a
+# bundle without one. That still launches, which is why it is worth failing
+# on here: the app would have no bundle identifier, no icon and no
+# NSHighResolutionCapable, and macOS would fall back to the executable name.
+if [ ! -f "${APP}/Contents/Info.plist" ]; then
+    echo "error: ${APP_NAME} has no Contents/Info.plist" >&2
+    echo "       re-run cmake to regenerate it:" >&2
+    echo "         cmake -S \"$(dirname "${QT_DIR}")/qt\" -B \"${BUILD_DIR}\"" >&2
+    exit 1
+fi
+
 step "Deploying Qt frameworks into ${APP_NAME}"
 # Homebrew's qt is a meta-formula: the frameworks the app links against
 # resolve through the qtbase keg, but modules like QtSvg and QtPdf live in

--- a/qt/scripts/makeapp-macos.sh
+++ b/qt/scripts/makeapp-macos.sh
@@ -100,11 +100,27 @@ else
 fi
 
 # -always-overwrite keeps repeated runs from mixing an old Qt into the bundle.
+#
+# Output goes to a log rather than the terminal. macdeployqt prints a wall of
+# "ERROR: Cannot resolve rpath ..." for the modules described above and then
+# exits 0; echoing that verbatim reads like a failed build when it is the
+# normal, handled case. Only the summary below is shown -- unless macdeployqt
+# genuinely fails, in which case the whole log is dumped.
 DEPLOY_LOG="$(mktemp -t macdeployqt)"
+deploy_status=0
 if [ -n "${DEPLOY_LIBPATH}" ]; then
-    "${MACDEPLOYQT}" "${APP}" -always-overwrite "${DEPLOY_LIBPATH}" 2>&1 | tee "${DEPLOY_LOG}"
+    "${MACDEPLOYQT}" "${APP}" -always-overwrite "${DEPLOY_LIBPATH}" \
+        > "${DEPLOY_LOG}" 2>&1 || deploy_status=$?
 else
-    "${MACDEPLOYQT}" "${APP}" -always-overwrite 2>&1 | tee "${DEPLOY_LOG}"
+    "${MACDEPLOYQT}" "${APP}" -always-overwrite \
+        > "${DEPLOY_LOG}" 2>&1 || deploy_status=$?
+fi
+
+if [ "${deploy_status}" -ne 0 ]; then
+    echo "error: macdeployqt failed (exit ${deploy_status}):" >&2
+    cat "${DEPLOY_LOG}" >&2
+    rm -f "${DEPLOY_LOG}"
+    exit 1
 fi
 
 # macdeployqt reports unresolved dependencies and still exits 0. These are

--- a/qt/scripts/makeapp-macos.sh
+++ b/qt/scripts/makeapp-macos.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+#
+# Package the Qt GUI as a self-contained, self-signed macOS .app bundle.
+#
+# Runs macdeployqt to copy the Qt frameworks and plugins into the bundle,
+# then code signs everything with an ad-hoc signature.
+#
+# Ad-hoc signing (`codesign -s -`) is what you can produce without a $99/yr
+# Apple Developer Program membership. It is enough to:
+#   - satisfy the hard requirement on Apple Silicon that all code be signed
+#   - keep the bundle's own integrity check valid
+#   - let the app run normally once macOS has been told to trust it
+#
+# It is NOT notarization. A bundle downloaded from the internet still gets
+# the com.apple.quarantine attribute, and Gatekeeper will refuse it with
+# "app is damaged" until the user strips it:
+#
+#     xattr -dr com.apple.quarantine /Applications/super-snes9x-qt.app
+#
+# See qt/docs/README-macos.md for the full story.
+#
+# Usage:
+#   ./makeapp-macos.sh [build-dir]      # default: qt/build-macos
+#   SIGN_IDENTITY="Developer ID Application: ..." ./makeapp-macos.sh
+#   MAKE_DMG=1 ./makeapp-macos.sh
+#
+# Requirements: a completed cmake build, plus macdeployqt from the same Qt.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BUILD_DIR="${1:-${QT_DIR}/build-macos}"
+APP_NAME="super-snes9x-qt.app"
+APP="${BUILD_DIR}/${APP_NAME}"
+
+# "-" means an ad-hoc signature. Override to use a real certificate if you
+# ever get one; the rest of the script is identical either way.
+SIGN_IDENTITY="${SIGN_IDENTITY:--}"
+MAKE_DMG="${MAKE_DMG:-0}"
+
+step() { echo; echo "==> $*"; }
+
+find_macdeployqt() {
+    if command -v macdeployqt >/dev/null 2>&1; then
+        command -v macdeployqt
+        return
+    fi
+    # Homebrew keeps it out of PATH by default (keg-only qt).
+    for prefix in "$(brew --prefix qt 2>/dev/null || true)" \
+                  /usr/local/opt/qt /opt/homebrew/opt/qt; do
+        if [ -n "${prefix}" ] && [ -x "${prefix}/bin/macdeployqt" ]; then
+            echo "${prefix}/bin/macdeployqt"
+            return
+        fi
+    done
+    return 1
+}
+
+if [ ! -d "${APP}" ]; then
+    echo "error: ${APP} not found -- build it first, e.g." >&2
+    echo "  cmake -S qt -B ${BUILD_DIR} -G Ninja -DCMAKE_BUILD_TYPE=Release \\" >&2
+    echo "        -DCMAKE_PREFIX_PATH=\"\$(brew --prefix qt)\"" >&2
+    echo "  cmake --build ${BUILD_DIR} -j\"\$(sysctl -n hw.ncpu)\"" >&2
+    exit 1
+fi
+
+MACDEPLOYQT="$(find_macdeployqt)" || {
+    echo "error: macdeployqt not found (install Qt 6, e.g. brew install qt)" >&2
+    exit 1
+}
+
+step "Deploying Qt frameworks into ${APP_NAME}"
+# Homebrew's qt is a meta-formula: the frameworks the app links against
+# resolve through the qtbase keg, but modules like QtSvg and QtPdf live in
+# kegs of their own, and none of those directories appear in the binary's
+# rpath list. macdeployqt then cannot resolve them, skips them, and -- since
+# it still exits 0 -- would leave a bundle whose iconengines/libqsvgicon
+# plugin has no QtSvg to load, so every SVG icon silently fails to render.
+# <macdeployqt>/../lib is the aggregated prefix holding every framework.
+QT_LIB_DIR="$(cd "$(dirname "${MACDEPLOYQT}")/../lib" 2>/dev/null && pwd || true)"
+if [ -n "${QT_LIB_DIR}" ]; then
+    echo "    searching ${QT_LIB_DIR} for Qt modules"
+    DEPLOY_LIBPATH="-libpath=${QT_LIB_DIR}"
+else
+    DEPLOY_LIBPATH=""
+fi
+
+# -always-overwrite keeps repeated runs from mixing an old Qt into the bundle.
+DEPLOY_LOG="$(mktemp -t macdeployqt)"
+if [ -n "${DEPLOY_LIBPATH}" ]; then
+    "${MACDEPLOYQT}" "${APP}" -always-overwrite "${DEPLOY_LIBPATH}" 2>&1 | tee "${DEPLOY_LOG}"
+else
+    "${MACDEPLOYQT}" "${APP}" -always-overwrite 2>&1 | tee "${DEPLOY_LOG}"
+fi
+
+# macdeployqt reports unresolved dependencies and still exits 0. These are
+# advisory here rather than fatal: the completion pass below fixes the ones
+# that matter, and the self-contained check after it is the real gate. Note
+# them so an unexpected one is still visible.
+if grep -q "^ERROR: Cannot resolve" "${DEPLOY_LOG}"; then
+    echo "    macdeployqt could not resolve the following (handled below):"
+    grep "^ERROR: Cannot resolve" "${DEPLOY_LOG}" \
+        | sed 's/^ERROR: Cannot resolve rpath /      /' | sort -u
+fi
+rm -f "${DEPLOY_LOG}"
+
+step "Pruning plugins this app does not use"
+# Each of these drags in a framework of its own (QtPdf, QtVirtualKeyboard)
+# or extra image codecs. None are reachable from a desktop SNES emulator, and
+# dropping them removes most of what macdeployqt could not resolve.
+for plugin in \
+    "PlugIns/imageformats/libqpdf.dylib" \
+    "PlugIns/platforminputcontexts/libqtvirtualkeyboardplugin.dylib" \
+    "PlugIns/imageformats/libqwebp.dylib"; do
+    if [ -e "${APP}/Contents/${plugin}" ]; then
+        echo "    removing ${plugin}"
+        rm -f "${APP}/Contents/${plugin}"
+    fi
+done
+
+step "Completing the bundle"
+# macdeployqt resolves a framework using only the rpaths of the binary it is
+# scanning, and -libpath does not extend that search. Homebrew's Qt plugins
+# carry a single relative rpath (@loader_path/../../../../lib) which stops
+# meaning anything once the plugin is copied into the bundle, so modules kept
+# in sibling kegs -- QtSvg above all, which the qsvgicon engine needs to draw
+# every toolbar icon -- are silently skipped. Copy in whatever is still
+# missing and repoint it, looping until the dependency graph closes.
+FRAMEWORKS_DIR="${APP}/Contents/Frameworks"
+mkdir -p "${FRAMEWORKS_DIR}"
+
+SEARCH_DIRS="${QT_LIB_DIR:-} /usr/local/lib /usr/local/opt/qt/lib /opt/homebrew/lib"
+
+# Every Mach-O in the bundle, NUL-separated. Selecting on the file's actual
+# type rather than on "executable bit or .dylib suffix" matters: a framework's
+# binary (Frameworks/QtSvg.framework/Versions/A/QtSvg) has neither, so a
+# name-based sweep silently skips exactly the files most likely to still
+# point at Homebrew.
+bundle_machos() {
+    find "${APP}/Contents" -type f -print0 | while IFS= read -r -d '' f; do
+        case "$(file -b "$f" 2>/dev/null)" in
+            *Mach-O*) printf '%s\0' "$f" ;;
+        esac
+    done
+}
+
+# Every @rpath dependency in the bundle that is not satisfied inside it.
+list_missing() {
+    while IFS= read -r -d '' macho; do
+        otool -L "${macho}" 2>/dev/null | awk '/@rpath\//{print $1}'
+    done < <(bundle_machos) \
+    | sed 's|^@rpath/||' | sort -u | while IFS= read -r ref; do
+        case "${ref}" in
+            *.framework/*)
+                fw="${ref%%.framework/*}.framework"
+                [ -d "${FRAMEWORKS_DIR}/${fw}" ] || echo "${fw}"
+                ;;
+            *.dylib)
+                lib="${ref##*/}"
+                [ -f "${FRAMEWORKS_DIR}/${lib}" ] || echo "${lib}"
+                ;;
+        esac
+    done | sort -u
+}
+
+locate_item() {
+    for dir in ${SEARCH_DIRS}; do
+        [ -n "${dir}" ] || continue
+        candidate="${dir}/$1"
+        [ -e "${candidate}" ] || continue
+        if [ -d "${candidate}" ]; then
+            # Homebrew links frameworks into /usr/local/lib as symlinks with
+            # relative targets, which dangle once copied into the bundle.
+            # Resolve to the real directory so cp -R copies the framework
+            # itself -- while still preserving the symlinks *inside* it
+            # (Versions/Current), which codesign requires.
+            (cd "${candidate}" && pwd -P)
+        else
+            real_dir="$(cd "$(dirname "${candidate}")" && pwd -P)"
+            echo "${real_dir}/$(basename "${candidate}")"
+        fi
+        return 0
+    done
+    return 1
+}
+
+for _pass in 1 2 3 4 5; do
+    missing="$(list_missing)"
+    [ -n "${missing}" ] || break
+
+    progressed=0
+    while IFS= read -r item; do
+        [ -n "${item}" ] || continue
+        if src="$(locate_item "${item}")"; then
+            echo "    adding ${item}"
+            if [ -d "${src}" ]; then
+                cp -R "${src}" "${FRAMEWORKS_DIR}/"
+            else
+                # -L: a plain dylib in /usr/local/lib is usually a symlink
+                # into the Cellar, and the link would dangle in the bundle.
+                cp -L "${src}" "${FRAMEWORKS_DIR}/${item}"
+            fi
+            chmod -R u+w "${FRAMEWORKS_DIR}/${item}"
+            case "${item}" in
+                *.framework)
+                    name="${item%.framework}"
+                    binary="${FRAMEWORKS_DIR}/${item}/Versions/A/${name}"
+                    [ -f "${binary}" ] || binary="${FRAMEWORKS_DIR}/${item}/${name}"
+                    # Headers and .prl files are build-time only and upset
+                    # codesign's bundle validation.
+                    rm -rf "${FRAMEWORKS_DIR}/${item}/Headers" \
+                           "${FRAMEWORKS_DIR}/${item}/Versions/A/Headers" \
+                           "${FRAMEWORKS_DIR}/${item}"/*.prl
+                    install_name_tool -id \
+                        "@rpath/${item}/Versions/A/${name}" "${binary}" 2>/dev/null || true
+                    ;;
+                *)
+                    install_name_tool -id \
+                        "@rpath/${item}" "${FRAMEWORKS_DIR}/${item}" 2>/dev/null || true
+                    ;;
+            esac
+            progressed=1
+        else
+            echo "    warning: cannot locate ${item}" >&2
+        fi
+    done <<EOF
+${missing}
+EOF
+
+    [ "${progressed}" -eq 1 ] || break
+done
+
+step "Repointing absolute dependencies at the bundle"
+# macdeployqt rewrites install names only for what it deployed itself, so
+# anything copied in above still refers to Homebrew by absolute path -- e.g.
+# QtSvg links /usr/local/opt/qtbase/lib/QtCore.framework. dyld then loads a
+# second copy of QtCore alongside the bundled one, which means duplicate objc
+# classes and, because each QtCore keeps its own resource registry, every
+# ":/icons/..." lookup failing. Point them back inside the bundle.
+while IFS= read -r -d '' macho; do
+    while IFS= read -r dep; do
+        case "${dep}" in
+            /usr/local/*|/opt/homebrew/*) ;;
+            *) continue ;;
+        esac
+        case "${dep}" in
+            *.framework/*)
+                fw="${dep##*/}"
+                fw="${fw}.framework"
+                rel="${dep#*"${fw}"/}"
+                if [ -d "${FRAMEWORKS_DIR}/${fw}" ]; then
+                    install_name_tool -change "${dep}" \
+                        "@rpath/${fw}/${rel}" "${macho}" 2>/dev/null || true
+                fi
+                ;;
+            *.dylib)
+                lib="${dep##*/}"
+                # Skip the library's own id, which legitimately names itself.
+                if [ -f "${FRAMEWORKS_DIR}/${lib}" ] && \
+                   [ "${macho##*/}" != "${lib}" ]; then
+                    install_name_tool -change "${dep}" \
+                        "@rpath/${lib}" "${macho}" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    done < <(otool -L "${macho}" 2>/dev/null | awk 'NR>1{print $1}')
+done < <(bundle_machos)
+
+step "Checking the bundle is self-contained"
+# Belt and braces: whatever the reason, every @rpath framework referenced by
+# anything in the bundle must actually be inside it. A missing one loads fine
+# on this machine (the system Qt is still on disk) and fails on any other, so
+# it has to be caught here rather than by a user.
+unresolved=0
+while IFS= read -r -d '' macho; do
+    # Any @rpath framework must actually be inside the bundle.
+    while IFS= read -r dep; do
+        fw="${dep#@rpath/}"
+        fw="${fw%%/*}"
+        case "${fw}" in
+            *.framework)
+                if [ ! -d "${FRAMEWORKS_DIR}/${fw}" ]; then
+                    echo "  missing ${fw} (needed by ${macho#"${APP}/"})" >&2
+                    unresolved=1
+                fi
+                ;;
+        esac
+    done < <(otool -L "${macho}" 2>/dev/null | awk '/@rpath\/.*\.framework/{print $1}')
+
+    # And nothing may still link Homebrew by absolute path: it would load a
+    # second Qt on this machine and simply be absent on any other.
+    while IFS= read -r dep; do
+        case "${dep}" in
+            /usr/local/*|/opt/homebrew/*)
+                [ "${dep##*/}" = "${macho##*/}" ] && continue  # its own id
+                echo "  absolute dep ${dep} (in ${macho#"${APP}/"})" >&2
+                unresolved=1
+                ;;
+        esac
+    done < <(otool -L "${macho}" 2>/dev/null | awk 'NR>1{print $1}')
+done < <(bundle_machos)
+
+if [ "${unresolved}" -ne 0 ]; then
+    echo >&2
+    echo "error: bundle is not self-contained" >&2
+    exit 1
+fi
+echo "    all dependencies resolve inside the bundle"
+
+step "Stripping external rpaths"
+# macdeployqt copies Qt in and rewrites the install names, but leaves the
+# original LC_RPATH (e.g. /usr/local/opt/qt/lib) in place. dyld then loads
+# BOTH the bundled and the system Qt: the objc runtime warns about duplicate
+# classes, and -- worse -- each QtCore gets its own resource registry, so the
+# qrc icons registered in one are invisible to the other and every
+# ":/icons/..." lookup fails. Drop any rpath that points outside the bundle.
+# Applied to every Mach-O in the bundle, not just the main executable: the
+# frameworks copied in above carry their own absolute rpaths too.
+while IFS= read -r -d '' macho; do
+    while IFS= read -r rpath; do
+        case "${rpath}" in
+            @*) ;;  # @executable_path/... etc. stay
+            *)  echo "    removing ${rpath} from ${macho#"${APP}/"}"
+                install_name_tool -delete_rpath "${rpath}" "${macho}" 2>/dev/null || true ;;
+        esac
+    done < <(otool -l "${macho}" 2>/dev/null | awk '/LC_RPATH/{f=1} f&&/path /{print $2; f=0}')
+done < <(bundle_machos)
+
+step "Signing (identity: ${SIGN_IDENTITY})"
+# Sign inside-out. `codesign --deep` is deprecated and signs nested code with
+# the *outer* options, which silently produces bundles that fail --strict
+# verification, so walk the nested Mach-O files explicitly instead.
+while IFS= read -r -d '' item; do
+    codesign --force --sign "${SIGN_IDENTITY}" --timestamp=none "${item}"
+done < <(find "${APP}/Contents" \
+              \( -name "*.dylib" -o -name "*.so" \) -type f -print0)
+
+# Frameworks are signed as bundles, not as bare Mach-O files.
+if [ -d "${APP}/Contents/Frameworks" ]; then
+    while IFS= read -r -d '' framework; do
+        codesign --force --sign "${SIGN_IDENTITY}" --timestamp=none "${framework}"
+    done < <(find "${APP}/Contents/Frameworks" -name "*.framework" -maxdepth 1 -print0)
+fi
+
+# Finally the bundle itself, which seals everything above.
+codesign --force --sign "${SIGN_IDENTITY}" --timestamp=none "${APP}"
+
+step "Verifying signature"
+codesign --verify --deep --strict --verbose=2 "${APP}"
+
+# Gatekeeper assessment is expected to FAIL for an ad-hoc signature -- it is
+# reported here for transparency, not treated as an error.
+echo
+echo "Gatekeeper assessment (an ad-hoc signature is expected to be rejected):"
+spctl --assess --type execute --verbose=4 "${APP}" 2>&1 || true
+
+if [ "${MAKE_DMG}" -eq 1 ]; then
+    step "Building DMG"
+    DMG="${BUILD_DIR}/super-snes9x-qt.dmg"
+    rm -f "${DMG}"
+    hdiutil create -volname "Super Snes9x" -srcfolder "${APP}" \
+        -ov -format UDZO "${DMG}" >/dev/null
+    codesign --force --sign "${SIGN_IDENTITY}" --timestamp=none "${DMG}"
+    echo "    ${DMG}"
+fi
+
+echo
+echo "================ Build artifacts ================"
+echo "  ${APP}"
+[ "${MAKE_DMG}" -eq 1 ] && echo "  ${BUILD_DIR}/super-snes9x-qt.dmg"
+echo "================================================="
+echo
+echo "The bundle is self-signed, not notarized. On another Mac, strip the"
+echo "quarantine attribute after copying it over:"
+echo "  xattr -dr com.apple.quarantine /Applications/${APP_NAME}"

--- a/qt/src/CheatsDialog.cpp
+++ b/qt/src/CheatsDialog.cpp
@@ -101,6 +101,12 @@ void CheatsDialog::searchDatabase()
     {
         EmuConfig::findConfigDir(),
         QGuiApplication::applicationDirPath().toStdString(),
+#ifdef __APPLE__
+        // Inside a bundle applicationDirPath() is Contents/MacOS, and the
+        // database is installed alongside the other bundle resources.
+        QDir(QGuiApplication::applicationDirPath())
+            .absoluteFilePath("../Resources").toStdString(),
+#endif
         S9xGetDirectory(CHEAT_DIR),
         "/usr/share/snes9x",
         "/usr/local/share/snes9x"

--- a/qt/src/DisplayPanel.cpp
+++ b/qt/src/DisplayPanel.cpp
@@ -183,12 +183,16 @@ void DisplayPanel::showEvent(QShowEvent *event)
     comboBox_driver->clear();
     comboBox_driver->addItem("Qt Software");
     comboBox_driver->addItem("OpenGL");
-    comboBox_driver->addItem("Vulkan");
 
     driver_list.clear();
     driver_list.emplace_back(driver_list.size(), "qt");
     driver_list.emplace_back(driver_list.size(), "opengl");
+
+#ifndef __APPLE__
+    // macOS has no native Vulkan, so the driver is not built there.
+    comboBox_driver->addItem("Vulkan");
     driver_list.emplace_back(driver_list.size(), "vulkan");
+#endif
 
     for (auto &[index, driver] : driver_list)
         if (config->display_driver == driver)

--- a/qt/src/EmuCanvasOpenGL.cpp
+++ b/qt/src/EmuCanvasOpenGL.cpp
@@ -3,7 +3,9 @@
 #include <QMessageBox>
 #include "common/video/opengl/opengl_context.hpp"
 
-#ifndef _WIN32
+#if defined(__APPLE__)
+#include "common/video/opengl/mac_opengl_context.hpp"
+#elif !defined(_WIN32)
 #include "common/video/opengl/glx_context.hpp"
 #include "common/video/opengl/wayland_egl_context.hpp"
 using namespace QNativeInterface;
@@ -17,9 +19,16 @@ using namespace QNativeInterface;
 #include "imgui_impl_opengl3.h"
 #include <clocale>
 
-static const char *stock_vertex_shader_140 = R"(
-#version 140
+// macOS only exposes OpenGL through a core profile, and its GLSL compiler
+// rejects `#version 140` in one -- 150 is the lowest a core profile accepts.
+// The shader bodies below are valid unchanged under both versions.
+#ifdef __APPLE__
+#define STOCK_SHADER_VERSION "#version 150\n"
+#else
+#define STOCK_SHADER_VERSION "#version 140\n"
+#endif
 
+static const char *stock_vertex_shader_140 = STOCK_SHADER_VERSION R"(
 in vec2 in_position;
 in vec2 in_texcoord;
 out vec2 texcoord;
@@ -31,9 +40,7 @@ void main()
 }
 )";
 
-static const char *stock_fragment_shader_140 = R"(
-#version 140
-
+static const char *stock_fragment_shader_140 = STOCK_SHADER_VERSION R"(
 uniform sampler2D texmap;
 out vec4 fragcolor;
 in vec2 texcoord;
@@ -131,7 +138,21 @@ bool EmuCanvasOpenGL::createContext()
     auto platform = QGuiApplication::platformName();
     auto app = reinterpret_cast<QGuiApplication *>(QGuiApplication::instance());
     QGuiApplication::sync();
-#ifndef _WIN32
+#if defined(__APPLE__)
+    // On macOS winId() is the NSView* backing this widget. AppKit requires
+    // -[NSOpenGLContext setView:] to run on the main thread, so unlike the
+    // other platforms EmuMainWindow creates this context there rather than
+    // on the emulation thread.
+    auto mac_context = new MacOpenGLContext();
+    if (!mac_context->attach((void *)winId()))
+    {
+        printf("Couldn't attach to NSView.\n");
+        delete mac_context;
+        context.reset();
+        return false;
+    }
+    context.reset(mac_context);
+#elif !defined(_WIN32)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     if (platform == "wayland")
     {
@@ -313,7 +334,11 @@ void EmuCanvasOpenGL::resizeEvent(QResizeEvent *event)
 
     int s = devicePixelRatio();
     auto platform = QGuiApplication::platformName();
-#ifndef _WIN32
+#if defined(__APPLE__)
+    (void)s;
+    (void)platform;
+    ((MacOpenGLContext *)context.get())->resize();
+#elif !defined(_WIN32)
     if (QGuiApplication::platformName() == "wayland")
         ((WaylandEGLContext *)context.get())->resize({ x() - main_window->x(), y() - main_window->y(), width(), height(), s });
     else if (platform == "xcb")
@@ -337,6 +362,13 @@ void EmuCanvasOpenGL::paintEvent(QPaintEvent *event)
     }
 
     context->resize();
+
+#ifdef __APPLE__
+    // This runs on the main thread while the emulation thread owns the
+    // context. NSOpenGL current-context state is per-thread, so the clear
+    // below would otherwise be issued with no context bound at all.
+    context->make_current();
+#endif
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT);

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -26,7 +26,9 @@
 #include "EmuBinding.hpp"
 #include "EmuCanvasOpenGL.hpp"
 #include "EmuCanvasQt.hpp"
+#ifndef __APPLE__
 #include "EmuCanvasVulkan.hpp"
+#endif
 #include "EmuMainWindow.hpp"
 #include "EmuPoTranslator.hpp"
 #include "EmuSettingsWindow.hpp"
@@ -116,8 +118,15 @@ bool EmuMainWindow::createCanvas()
         app->config->display_driver != "qt")
         app->config->display_driver = "qt";
 
+#ifdef __APPLE__
+    // macOS has no native Vulkan; the driver is not built on this platform.
+    if (app->config->display_driver == "vulkan")
+        app->config->display_driver = "opengl";
+#endif
+
     if (app->config->display_driver == "vulkan")
     {
+#ifndef __APPLE__
         canvas = new EmuCanvasVulkan(app->config.get(), this);
         QGuiApplication::processEvents();
         if (!canvas->createContext())
@@ -125,12 +134,23 @@ bool EmuMainWindow::createCanvas()
             delete canvas;
             return fallback();
         }
+#endif
     }
     else if (app->config->display_driver == "opengl")
     {
         canvas = new EmuCanvasOpenGL(app->config.get(), this);
         QGuiApplication::processEvents();
+#ifdef __APPLE__
+        // -[NSOpenGLContext setView:] is main-thread only, so the context is
+        // built here and simply made current on the emulation thread later.
+        if (!canvas->createContext())
+        {
+            delete canvas;
+            return fallback();
+        }
+#else
         app->emu_thread->runOnThread([&] { canvas->createContext(); }, true);
+#endif
     }
     else
         canvas = new EmuCanvasQt(app->config.get(), this);
@@ -650,7 +670,9 @@ void EmuMainWindow::resizeToMultiple(int multiple)
 
 void EmuMainWindow::setBypassCompositor(bool bypass)
 {
-#ifndef _WIN32
+    // _NET_WM_BYPASS_COMPOSITOR is an X11 EWMH hint; macOS and Windows have
+    // no equivalent, and the Quartz compositor cannot be bypassed at all.
+#if !defined(_WIN32) && !defined(__APPLE__)
     if (QGuiApplication::platformName() == "xcb")
     {
         uint32_t value = bypass;

--- a/qt/src/SDLInputManager.cpp
+++ b/qt/src/SDLInputManager.cpp
@@ -65,7 +65,12 @@ SDLInputManager::discretizeHatEvent(SDL_Event &event)
     for (auto &s : { SDL_HAT_UP, SDL_HAT_DOWN, SDL_HAT_LEFT, SDL_HAT_RIGHT })
         if ((old_state & s) != (new_state & s))
         {
-            events.emplace_back(device.index, hat, s, new_state & s);
+            // Braced push_back rather than emplace_back: these structs are
+            // aggregates with no constructor, and emplace_back on an
+            // aggregate needs C++20 parenthesized aggregate initialization
+            // (P0960), which libc++ does not implement.
+            events.push_back({ device.index, hat, static_cast<int>(s),
+                               (new_state & s) != 0 });
         }
 
     old_state = new_state;
@@ -102,11 +107,11 @@ SDLInputManager::discretizeJoyAxisEvent(SDL_Event &event, int threshold_percent)
 
     if (previous_direction == -1 || current_direction == -1)
     {
-        events.emplace_back(device.index, axis, -1, (current_direction == -1));
+        events.push_back({ device.index, axis, -1, (current_direction == -1) });
     }
     if (previous_direction == 1 || current_direction == 1)
     {
-        events.emplace_back(device.index, axis, 1, (current_direction == 1));
+        events.push_back({ device.index, axis, 1, (current_direction == 1) });
     }
 
     then = now;

--- a/qt/src/resources/Info.plist.in
+++ b/qt/src/resources/Info.plist.in
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundleDisplayName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
+	<!-- Without this the window server hands the app a 1x backing store and
+	     the emulator output is upscaled and blurry on Retina displays. -->
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Super Nintendo ROM</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>smc</string>
+				<string>sfc</string>
+				<string>swc</string>
+				<string>fig</string>
+				<string>bs</string>
+				<string>st</string>
+				<string>gb</string>
+				<string>gbc</string>
+				<string>zip</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Adds macOS support for the Qt GUI and fixes the libretro core's existing but
broken macOS path. Both artifacts are ad-hoc signed, so they run without a paid
Apple Developer Program membership.

## libretro core

The `osx` branch existed but could not build. The deployment-target check parsed
the *minor* field of `sw_vers -productVersion` (written for the 10.x scheme), so
on macOS 11+ it read "14.3" as "3", always took the pre-Mojave branch and passed
`-mmacosx-version-min=10.1`, making the modern linker abort with
`Assertion failed: (targetAtom != NULL)`. Replaced with an overridable
`OSX_MIN_VERSION` floor, pinned `-std=c++17` (the branch still asked for c++14
while the core requires `string_view`), and added `OSX_ARCHS` plus
`macos/build-macos.sh`, which builds each arch separately and lipos them into a
universal binary. Per-arch builds keep `-flto` on a single-arch link, and the
result is re-signed after lipo since merging invalidates the slices' signatures.

Also: `retro_get_system_info` returned `VERSION GIT_VERSION`, so RetroArch showed
`1.63 589875a3` while both GUIs showed `1.63.29`. It now uses `VERSION_DISPLAY`,
so every front end reports the same version and `library_version` stops embedding
a space, which RetroArch treats as a single token.

## Qt GUI

There was no macOS support at all — the CMake platform logic was
`if(Windows)/else`, with the `else` hard-requiring Wayland and X11.

- New `MacOpenGLContext`, an NSOpenGL 4.1 core-profile context. AppKit requires
  `-[NSOpenGLContext setView:]` on the main thread, so the context is created
  there rather than on the emulation thread, and every operation takes the CGL
  lock. Built with `-fobjc-arc`, without which the bridge casts silently no-op
  and leak the context.
- Stock shaders emit `#version 150` on Apple; macOS rejects 140 in a core profile.
- `paintEvent` makes the context current: it runs on the main thread while the
  emulation thread owns the context, and NSOpenGL current-context state is
  per-thread.
- Vulkan is excluded on Apple (no native driver) and dropped from the driver
  list; a config naming it falls back to OpenGL. The `slang_*` parsing helpers
  stay, since the OpenGL shader stack needs them.
- `.app` bundle: generated `.icns`, `Info.plist`, bundled `cheats.bml`, and
  `makeapp-macos.sh`.

Producing a self-contained bundle needs more than `macdeployqt`. Homebrew's `qt`
is a meta-formula whose modules sit in sibling kegs, and its plugins carry one
relative rpath (`@loader_path/../../../../lib`) that stops resolving once a
plugin is copied into a bundle. `macdeployqt` resolves frameworks from the
scanned binary's rpaths only — `-libpath` does not extend that search — so it
skips those modules and still exits 0. The symptom is quiet: QtSvg is left out
while the `iconengines/libqsvgicon` plugin needing it is deployed, so every SVG
icon fails to draw. The script now prunes unused plugins (QtPdf,
QtVirtualKeyboard, webp), copies in what is missing, rewrites absolute Homebrew
install names to `@rpath`, strips rpaths pointing outside the bundle, and
verifies no Mach-O references a framework the bundle lacks or an absolute
`/usr/local` path. Without that last step dyld loaded a second QtCore, which
meant duplicate objc classes and — since each QtCore has its own resource
registry — every `":/icons/..."` lookup failing. Enumeration is by file type
rather than by executable bit or `.dylib` suffix, since a framework's binary has
neither and was being skipped by exactly the checks meant to catch this.

Two follow-up fixes to the packaging path: `build-all.sh --osx` deletes the
bundle before rebuilding, but CMake writes `Contents/Info.plist` at *generate*
time, so `cmake --build` alone relinked the executable into a bundle with no
`Info.plist` — the app still launched, so the menu bar read `super-snes9x-qt`
and the bundle had no identifier, icon or `NSHighResolutionCapable`. And
`macdeployqt`'s block of handled `Cannot resolve rpath` errors is now sent to a
log rather than the terminal, so a successful build stops looking like a failed
one.

## Portability fixes that also apply elsewhere

- `SDLInputManager` used `emplace_back` on aggregates, which needs C++20
  parenthesized aggregate initialization (P0960) that libc++ lacks. Braced
  `push_back` works on both, and exposed a real unsigned→int narrowing that
  libstdc++ had been accepting silently.
- `setBypassCompositor` called `XInternAtom` unguarded outside the canvas.
- `find_package(PkgConfig)` hoisted above its first use; it previously ran after
  `pkg_check_modules(CURL)` and only worked by luck.

## Build script

`build-all.sh` gains `--osx`, which builds only the macOS artifacts — the Linux
GUI AppImages are native builds and the macOS ones need Xcode, so no single host
produces both. `--copy` now defaults to `libretro/dist` instead of the
VMware-specific `/mnt/hgfs/Shared` and accepts an explicit destination, keeping
the hgfs mount check only for `/mnt/hgfs` paths.

## Verification

Qt and both libretro targets build clean in an Ubuntu 22.04 container, with the
Vulkan, GLX and Wayland sources still compiled in. The macOS app runs with no
duplicate-Qt warnings and no missing resources. The core was verified by
`dlopen`ing it and calling `retro_get_system_info`: `library_version = 1.63.29`.
Android is untouched — `jni/Android.mk` includes `Makefile.common`, not
`libretro/Makefile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
