### PR TITLE
Add RunAhead support to the Linux Qt and GTK GUIs

### DIFF
--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -167,6 +167,8 @@ int Snes9xConfig::load_defaults()
     rewind_granularity = 5;
     rewind_buffer_size = 0;
     Settings.Rewinding = false;
+    Settings.RunAhead = 0;
+    Settings.InRunAhead = false;
 
     sync_to_vblank = true;
     use_shaders = false;
@@ -380,6 +382,7 @@ int Snes9xConfig::save_config_file()
     outint("SaveSRAMEveryNSeconds", Settings.AutoSaveDelay, "Auto-write the battery save this many seconds after the game changes it (0: only on exit/reset)");
     outbool("BlockInvalidVRAMAccess", Settings.BlockInvalidVRAMAccessMaster, "Emulate the real hardware's VRAM access restrictions (on for accuracy; off only for a few broken ROMs/hacks)");
     outbool("AllowDPadContradictions", Settings.UpAndDown, "Allow the D-Pad to press both up + down at the same time, or left + right");
+    outint("RunAhead", Settings.RunAhead, "Number of frames to run ahead for reduced input latency (0 = off, 1-4)");
 
     section = "Hacks";
     outint("SuperFXClockMultiplier", Settings.SuperFXClockMultiplier, "SuperFX (GSU) chip speed as a percentage of normal (50-400; 100 = accurate). Higher reduces slowdown in Star Fox and other SuperFX games");
@@ -632,6 +635,11 @@ int Snes9xConfig::load_config_file()
     inbool("BlockInvalidVRAMAccess", Settings.BlockInvalidVRAMAccessMaster);
     inbool("AllowDPadContradictions", Settings.UpAndDown);
     inbool("DisplayIndicators", Settings.DisplayIndicators);
+    inint("RunAhead", Settings.RunAhead);
+    if (Settings.RunAhead < 0)
+        Settings.RunAhead = 0;
+    if (Settings.RunAhead > 4)
+        Settings.RunAhead = 4;
 
     section = "Hacks";
     inint("SuperFXClockMultiplier", Settings.SuperFXClockMultiplier);

--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -656,6 +656,7 @@ void Snes9xPreferences::move_settings_to_dialog()
     set_spin  ("dynamic_rate_limit",        Settings.DynamicRateLimit / 1000.0);
     set_spin  ("rewind_buffer_size",        config->rewind_buffer_size);
     set_spin  ("rewind_granularity",        config->rewind_granularity);
+    set_spin  ("run_ahead_frames",          Settings.RunAhead);
     set_spin  ("superfx_multiplier",        Settings.SuperFXClockMultiplier);
     set_combo ("splash_background",         config->splash_image);
     set_check ("force_enable_icons",        config->enable_icons);
@@ -841,6 +842,7 @@ void Snes9xPreferences::get_settings_from_dialog()
     config->prevent_screensaver       = get_check("prevent_screensaver");
     config->rewind_buffer_size        = get_spin("rewind_buffer_size");
     config->rewind_granularity        = get_spin("rewind_granularity");
+    Settings.RunAhead                 = get_spin("run_ahead_frames");
     config->joystick_threshold        = get_spin("joystick_threshold");
 
 #ifdef ALLOW_CPU_OVERCLOCK

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -34,6 +34,10 @@ static void check_pointer_timer();
 static bool idle_func();
 static bool screen_saver_check_func();
 
+// Savestate scratch buffer for run-ahead. Sized per ROM (freeze size depends
+// on which special chips the cart uses), so S9xROMLoaded clears it.
+static std::vector<uint8> run_ahead_buffer;
+
 Snes9xWindow *top_level = nullptr;
 Snes9xConfig *gui_config = nullptr;
 StateManager state_manager;
@@ -222,6 +226,7 @@ int S9xOpenROM(const char *rom_filename)
 void S9xROMLoaded()
 {
     gui_config->rom_loaded = true;
+    run_ahead_buffer.clear();
     top_level->configure_widgets();
 
 #ifdef RETROACHIEVEMENTS_SUPPORT
@@ -351,7 +356,86 @@ static void game_loop()
         else
             Settings.Mute &= ~0x80;
 
-        S9xMainLoop();
+        // Never run ahead during netplay — the frame exchange assumes one
+        // emulated frame per iteration, and hidden frames would desync us.
+        if (Settings.RunAhead > 0 && !Settings.Rewinding && !Settings.TurboMode &&
+            !Settings.NetPlay && !Settings.NetPlayServer)
+        {
+            // Run-ahead: commit 1 hidden frame, save state, run N-1 more hidden
+            // frames to "look into the future", then run the displayed frame as
+            // a preview, and finally restore to the committed state. The
+            // displayed frame shows what the game will look like N frames in
+            // the future given the current input, reducing apparent input
+            // latency by N frames.
+            int num_ahead_frames = Settings.RunAhead;
+            if (num_ahead_frames > 4)
+                num_ahead_frames = 4;
+
+            // Minimize per-frame overhead:
+            // - drop the ~500KB screenshot from the state
+            // - enable fast path (skips screen memset + memory zeroing on load)
+            // - detach the sample-available callback during hidden frames so
+            //   their audio never reaches the OS buffer; otherwise we push
+            //   multiple frames of audio per iteration and the buffer fills
+            //   faster than it drains
+            bool8 saved_screenshots = Settings.SnapshotScreenshots;
+            bool8 saved_fast = Settings.FastSavestates;
+            Settings.SnapshotScreenshots = false;
+            Settings.FastSavestates = true;
+
+            // S9xFreezeSize() is expensive (it does a full dry-run
+            // serialization), so cache the buffer until the next ROM load.
+            if (run_ahead_buffer.empty())
+                run_ahead_buffer.resize(S9xFreezeSize());
+
+            // Suppress audio output for the hidden frames
+            S9xSetSamplesAvailableCallback(nullptr, nullptr);
+
+            // Snapshot the resampler so we can undo the hidden frames' effect
+            // on it (preserves filter continuity across iterations)
+            S9xRunAheadSaveAudio();
+
+            Settings.InRunAhead = true;
+
+            // First hidden frame: the "commit" frame — its state gets saved
+            // and becomes the starting point of the next iteration
+            IPPU.RenderThisFrame = false;
+            S9xMainLoop();
+
+            // Save state at end of the committed frame
+            S9xFreezeGameMem(run_ahead_buffer.data(), run_ahead_buffer.size());
+
+            // Additional hidden frames (peek further into the future)
+            for (int i = 1; i < num_ahead_frames; i++)
+            {
+                IPPU.RenderThisFrame = false;
+                S9xMainLoop();
+            }
+
+            Settings.InRunAhead = false;
+
+            // Restore resampler state so the displayed frame's output flows
+            // on directly from the previous displayed frame's output
+            S9xRunAheadLoadAudio();
+
+            // Re-enable audio output for the displayed frame
+            S9xSetSamplesAvailableCallback(S9xSamplesAvailable, nullptr);
+
+            // Displayed "preview" frame: renders and throttles normally
+            IPPU.RenderThisFrame = true;
+            S9xMainLoop();
+
+            // Restore to end-of-committed-frame so the next iteration starts
+            // from there
+            S9xUnfreezeGameMem(run_ahead_buffer.data(), run_ahead_buffer.size());
+
+            Settings.SnapshotScreenshots = saved_screenshots;
+            Settings.FastSavestates = saved_fast;
+        }
+        else
+        {
+            S9xMainLoop();
+        }
 
 #ifdef RETROACHIEVEMENTS_SUPPORT
         // Suspend achievement processing during netplay so remote players'

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -205,6 +205,26 @@ void Snes9xWindow::connect_signals()
             reload_with_bios_pref(2);
     });
 
+    for (int i = 0; i <= 4; i++)
+    {
+        std::string name = "run_ahead_" + std::to_string(i) + "_item";
+        get_object<Gtk::RadioMenuItem>(name.c_str())->signal_toggled().connect([&, name, i] {
+            if (refreshing_runahead_menu)
+                return;
+            if (get_object<Gtk::RadioMenuItem>(name.c_str())->get_active())
+                Settings.RunAhead = i;
+        });
+    }
+    // The preferences dialog can also change Settings.RunAhead, so sync the
+    // radio state whenever the menu opens.
+    get_object<Gtk::Menu>("emulation_menu_item_menu")->signal_show().connect([&] {
+        int clamped = Settings.RunAhead < 0 ? 0 : (Settings.RunAhead > 4 ? 4 : Settings.RunAhead);
+        std::string name = "run_ahead_" + std::to_string(clamped) + "_item";
+        refreshing_runahead_menu = true;
+        get_object<Gtk::RadioMenuItem>(name.c_str())->set_active(true);
+        refreshing_runahead_menu = false;
+    });
+
     get_object<Gtk::MenuItem>("shader_parameters_item")->signal_activate().connect([&] {
         gtk_shader_parameters_dialog(get_window());
     });

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -1111,7 +1111,8 @@ void Snes9xWindow::configure_widgets()
         "open_movie_item",
         "jump_to_frame_item",
         "cheats_item",
-        "rom_info_item"
+        "rom_info_item",
+        "run_ahead_item"
     };
     for (auto &widget : enable_when_rom_loaded)
         enable_widget(widget, config->rom_loaded);

--- a/gtk/src/gtk_s9xwindow.h
+++ b/gtk/src/gtk_s9xwindow.h
@@ -85,6 +85,7 @@ class Snes9xWindow : public GtkBuilderWindow
 
     Snes9xConfig *config;
     bool refreshing_bios_menu = false;
+    bool refreshing_runahead_menu = false;
     int user_pause, sys_pause;
     int last_width, last_height;
     int mouse_region_x, mouse_region_y;

--- a/gtk/src/gtk_sound.h
+++ b/gtk/src/gtk_sound.h
@@ -13,5 +13,6 @@ void S9xPortSoundDeinit();
 void S9xPortSoundReinit();
 void S9xSoundStart();
 void S9xSoundStop();
+void S9xSamplesAvailable(void *userdata);
 
 std::vector<std::string> S9xGetSoundDriverNames();

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -305,6 +305,13 @@
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
   </object>
+  <object class="GtkAdjustment" id="run_ahead_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">4</property>
+    <property name="value">0</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment7">
     <property name="lower">-1</property>
     <property name="upper">1</property>
@@ -5327,6 +5334,86 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="runaheadsettingsframe">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="border_width">5</property>
+                                <property name="label_xalign">0</property>
+                                <property name="shadow_type">none</property>
+                                <child>
+                                  <object class="GtkAlignment" id="alignmentrunaheadsettings">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
+                                    <child>
+                                      <object class="GtkVBox" id="vboxrunaheadsettings">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="border_width">5</property>
+                                        <property name="spacing">5</property>
+                                        <child>
+                                          <object class="GtkHBox" id="run_ahead_hbox">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="spacing">10</property>
+                                            <child>
+                                              <object class="GtkLabel" id="run_ahead_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Frames to run ahead to reduce input latency (0 to disable):</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="run_ahead_frames">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="tooltip_text" translatable="yes">Emulates the selected number of frames ahead of the displayed one so input appears to take effect sooner. Uses more CPU time. One frame is safe for most games; higher values can glitch games that poll input mid-frame.</property>
+                                                <property name="primary_icon_activatable">False</property>
+                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="primary_icon_sensitive">True</property>
+                                                <property name="secondary_icon_sensitive">True</property>
+                                                <property name="adjustment">run_ahead_adjustment</property>
+                                                <property name="snap_to_ticks">True</property>
+                                                <property name="numeric">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="labelrunaheadsettingsframe">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">&lt;b&gt;Run Ahead&lt;/b&gt;</property>
+                                    <property name="use_markup">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="hacksettingsframe">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -5518,7 +5605,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">2</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                           </object>

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1790,6 +1790,75 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkSeparatorMenuItem" id="run_ahead_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="run_ahead_item">
+                        <property name="label" translatable="yes">Run _Ahead</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_underline">True</property>
+                        <child type="submenu">
+                          <object class="GtkMenu" id="run_ahead_menu">
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkRadioMenuItem" id="run_ahead_0_item">
+                                <property name="label" translatable="yes">_0 (off)</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_as_radio">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkRadioMenuItem" id="run_ahead_1_item">
+                                <property name="label" translatable="yes">_1 frame</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_as_radio">True</property>
+                                <property name="group">run_ahead_0_item</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkRadioMenuItem" id="run_ahead_2_item">
+                                <property name="label" translatable="yes">_2 frames</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_as_radio">True</property>
+                                <property name="group">run_ahead_0_item</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkRadioMenuItem" id="run_ahead_3_item">
+                                <property name="label" translatable="yes">_3 frames</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_as_radio">True</property>
+                                <property name="group">run_ahead_0_item</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkRadioMenuItem" id="run_ahead_4_item">
+                                <property name="label" translatable="yes">_4 frames</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_as_radio">True</property>
+                                <property name="group">run_ahead_0_item</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem" id="bios_separator">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/qt/src/EmuCanvasOpenGL.cpp
+++ b/qt/src/EmuCanvasOpenGL.cpp
@@ -157,6 +157,11 @@ bool EmuCanvasOpenGL::createContext()
     if (platform == "wayland")
     {
         auto iface = app->nativeInterface<QNativeInterface::QWaylandApplication>();
+        if (!iface)
+        {
+            printf("Couldn't get a Wayland interface from Qt.\n");
+            return false;
+        }
         auto display = iface->display();
         auto surface = (wl_surface *)main_window->winId();
         auto wayland_egl_context = new WaylandEGLContext();
@@ -176,6 +181,11 @@ bool EmuCanvasOpenGL::createContext()
     if (platform == "xcb")
     {
         auto iface = app->nativeInterface<QNativeInterface::QX11Application>();
+        if (!iface)
+        {
+            printf("Couldn't get an X11 interface from Qt.\n");
+            return false;
+        }
         auto display = iface->display();
         auto xid = (Window)winId();
 
@@ -201,9 +211,22 @@ bool EmuCanvasOpenGL::createContext()
     context.reset(wgl_context);
 #endif
 
+    // A platform none of the branches above handled leaves context null — in
+    // particular a Wayland session on Qt builds older than 6.5, which have no
+    // QWaylandApplication native interface. Fail so the caller can fall back
+    // to another display driver instead of crashing on a null context.
+    if (!context)
+    {
+        printf("No OpenGL context available for platform \"%s\".\n",
+               platform.toUtf8().constData());
+        return false;
+    }
+
     if (!context->create_context())
     {
         printf("Couldn't create OpenGL context.\n");
+        context.reset();
+        return false;
     }
 
     context->make_current();

--- a/qt/src/EmuCanvasVulkan.cpp
+++ b/qt/src/EmuCanvasVulkan.cpp
@@ -107,6 +107,12 @@ bool EmuCanvasVulkan::createContext()
     if (platform == "wayland")
     {
         auto iface = app->nativeInterface<QNativeInterface::QWaylandApplication>();
+        if (!iface)
+        {
+            printf("Couldn't get a Wayland interface from Qt.\n");
+            context.reset();
+            return false;
+        }
         auto display = iface->display();
         auto surface = (wl_surface *)main_window->winId();
         wayland_surface = std::make_unique<WaylandSurface>();
@@ -127,6 +133,12 @@ bool EmuCanvasVulkan::createContext()
     if (platform == "xcb")
     {
         auto iface = app->nativeInterface<QNativeInterface::QX11Application>();
+        if (!iface)
+        {
+            printf("Couldn't get an X11 interface from Qt.\n");
+            context.reset();
+            return false;
+        }
         auto display = iface->display();
         auto xid = (Window)winId();
 
@@ -137,6 +149,17 @@ bool EmuCanvasVulkan::createContext()
             context.reset();
             return false;
         }
+    }
+    else
+    {
+        // No branch above handled this platform — notably a Wayland session
+        // on Qt builds older than 6.5, which have no QWaylandApplication
+        // native interface. Without a surface the context is unusable, so
+        // fail and let the caller fall back to another display driver.
+        printf("No Vulkan surface available for platform \"%s\".\n",
+               platform.toUtf8().constData());
+        context.reset();
+        return false;
     }
 #endif
 

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -294,6 +294,8 @@ bool EmuConfig::setDefaults(int section)
         rewind_buffer_size = 0;
         rewind_frame_interval = 5;
 
+        run_ahead_frames = 0;
+
         allow_invalid_vram_access = false;
         allow_opposing_dpad_directions = false;
         overclock = eNoOverclock;
@@ -534,6 +536,7 @@ void EmuConfig::config(const std::string &filename, bool write)
     Int("FastForwardSkipFrames", fast_forward_skip_frames, "How many frames to skip drawing while fast-forwarding (higher is faster)");
     Int("RewindBufferSize", rewind_buffer_size, "Memory (in MB) reserved for rewind; 0 disables rewind");
     Int("RewindFrameInterval", rewind_frame_interval, "Save a rewind snapshot every N frames");
+    Int("RunAhead", run_ahead_frames, "Number of frames to run ahead for reduced input latency (0 = off, 1-4)");
     Bool("AllowInvalidVRAMAccess", allow_invalid_vram_access, "Let games make the VRAM accesses real hardware blocks (off for accuracy; on only for a few broken hacks)");
     Bool("AllowOpposingDpadDirections", allow_opposing_dpad_directions, "Allow the D-Pad to press both left+right or up+down at once");
     Int("Overclock", overclock, "CPU overclock: 0 none, 1 auto-FastROM, 2 low, 3 high (reduces slowdown; inaccurate, can break games)");

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -153,6 +153,8 @@ struct EmuConfig
     int rewind_buffer_size;
     int rewind_frame_interval;
 
+    int run_ahead_frames;
+
     // Emulation/Hacks
 
     bool allow_invalid_vram_access;

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -454,7 +454,7 @@ void EmuMainWindow::createWidgets()
         });
         run_ahead_actions.push_back(action);
     }
-    emulation_menu->addMenu(run_ahead_menu);
+    core_actions.push_back(emulation_menu->addMenu(run_ahead_menu));
     // The Emulation settings panel can also change the value, so sync the
     // check state whenever the menu opens.
     connect(emulation_menu, &QMenu::aboutToShow, this, [this, run_ahead_actions] {

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -149,7 +149,17 @@ bool EmuMainWindow::createCanvas()
             return fallback();
         }
 #else
-        app->emu_thread->runOnThread([&] { canvas->createContext(); }, true);
+        // The call blocks, so context_created is safely written before the
+        // check below runs. A false result (e.g. Wayland on a Qt build older
+        // than 6.5, or broken GL drivers) falls back to the software driver
+        // instead of leaving a dead canvas that crashes on first use.
+        bool context_created = false;
+        app->emu_thread->runOnThread([&] { context_created = canvas->createContext(); }, true);
+        if (!context_created)
+        {
+            delete canvas;
+            return fallback();
+        }
 #endif
     }
     else

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -436,6 +436,33 @@ void EmuMainWindow::createWidgets()
 
     emulation_menu->addSeparator();
 
+    auto run_ahead_menu = new QMenu(tr("Run &Ahead"));
+    auto run_ahead_group = new QActionGroup(this);
+    run_ahead_group->setExclusive(true);
+    std::vector<QAction *> run_ahead_actions;
+    for (int i = 0; i <= 4; i++)
+    {
+        auto action = run_ahead_menu->addAction(
+            i == 0 ? tr("&0 (off)") :
+            i == 1 ? tr("&1 frame") :
+                     tr("&%1 frames").arg(i));
+        action->setCheckable(true);
+        run_ahead_group->addAction(action);
+        connect(action, &QAction::triggered, [&, i] {
+            app->config->run_ahead_frames = i;
+            app->updateSettings();
+        });
+        run_ahead_actions.push_back(action);
+    }
+    emulation_menu->addMenu(run_ahead_menu);
+    // The Emulation settings panel can also change the value, so sync the
+    // check state whenever the menu opens.
+    connect(emulation_menu, &QMenu::aboutToShow, this, [this, run_ahead_actions] {
+        int n = app->config->run_ahead_frames;
+        n = n < 0 ? 0 : (n > 4 ? 4 : n);
+        run_ahead_actions[n]->setChecked(true);
+    });
+
     bios_menu = new QMenu(tr("&BIOS"));
     auto bios_group = new QActionGroup(this);
     bios_group->setExclusive(true);

--- a/qt/src/EmulationPanel.cpp
+++ b/qt/src/EmulationPanel.cpp
@@ -34,6 +34,7 @@ EmulationPanel::EmulationPanel(EmuApplication *app_)
 
     connect_spin(spinBox_rewind_buffer_size, &app->config->rewind_buffer_size);
     connect_spin(spinBox_rewind_frames, &app->config->rewind_frame_interval);
+    connect_spin(spinBox_run_ahead_frames, &app->config->run_ahead_frames);
     connect_spin(spinBox_fast_forward_skip_frames, &app->config->fast_forward_skip_frames);
 
     connect_checkbox(checkBox_allow_invalid_vram_access, &app->config->allow_invalid_vram_access);
@@ -54,6 +55,7 @@ void EmulationPanel::showEvent(QShowEvent *event)
 
     spinBox_rewind_buffer_size->setValue(config->rewind_buffer_size);
     spinBox_rewind_frames->setValue(config->rewind_frame_interval);
+    spinBox_run_ahead_frames->setValue(config->run_ahead_frames);
 
     // A game on the allow-invalid-VRAM list overrides the preference for
     // itself; show that and disable the box so the automatic choice is visible

--- a/qt/src/EmulationPanel.ui
+++ b/qt/src/EmulationPanel.ui
@@ -231,6 +231,68 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Run Ahead</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLabel" name="label_10">
+          <property name="text">
+           <string>Run ahead (0 to disable):</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBox_run_ahead_frames">
+          <property name="whatsThis">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Emulates the selected number of frames ahead of the displayed frame, so your input appears to take effect sooner. Reduces input latency at the cost of extra processing every frame.&lt;/p&gt;&lt;p&gt;One frame is safe for most games; higher values can cause glitches in games that poll input mid-frame.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="suffix">
+           <string> frames</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>4</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>Reduces input latency by emulating frames ahead of the visible one. Uses more CPU time.</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Hacks</string>

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -92,6 +92,8 @@ void Snes9xController::init()
 
     rewind_buffer_size = 0;
     rewind_frame_interval = 5;
+    Settings.RunAhead = 0;
+    Settings.InRunAhead = false;
 
     Memory.Init();
     S9xInitAPU();
@@ -213,6 +215,8 @@ void Snes9xController::updateSettings(EmuConfig *config)
     rewind_buffer_size = config->rewind_buffer_size;
     rewind_frame_interval = config->rewind_frame_interval;
 
+    Settings.RunAhead = config->run_ahead_frames < 0 ? 0 : (config->run_ahead_frames > 4 ? 4 : config->run_ahead_frames);
+
     if (config->remove_sprite_limit)
         Settings.MaxSpriteTilesPerLine = 128;
     else
@@ -273,8 +277,82 @@ bool Snes9xController::openFile(const std::string &filename)
     {
         active = true;
         Memory.LoadSRAM(S9xGetFilename(".srm", SRAM_DIR).c_str());
+        run_ahead_buffer.clear();
     }
     return active;
+}
+
+void Snes9xController::mainLoopWithRunAhead()
+{
+    // Run-ahead: commit 1 hidden frame, save state, run N-1 more hidden frames
+    // to "look into the future", then run the displayed frame as a preview, and
+    // finally restore to the committed state. The displayed frame shows what
+    // the game will look like N frames in the future given the current input,
+    // reducing apparent input latency by N frames.
+    int numAheadFrames = Settings.RunAhead;
+    if (numAheadFrames > 4)
+        numAheadFrames = 4;
+
+    // Minimize per-frame overhead:
+    // - drop the ~500KB screenshot from the state
+    // - enable fast path (skips 512KB screen memset + memory zeroing on load)
+    // - detach the sample-available callback during hidden frames so their
+    //   audio never reaches the OS buffer; otherwise we push multiple frames
+    //   of audio per iteration and the buffer fills faster than it drains
+    bool8 savedScreenshots = Settings.SnapshotScreenshots;
+    bool8 savedFast = Settings.FastSavestates;
+    Settings.SnapshotScreenshots = false;
+    Settings.FastSavestates = true;
+
+    // S9xFreezeSize() is expensive (it does a full dry-run serialization), so
+    // cache the buffer until the next ROM load.
+    if (run_ahead_buffer.empty())
+        run_ahead_buffer.resize(S9xFreezeSize());
+
+    // Suppress audio output for the hidden frames
+    S9xSetSamplesAvailableCallback(nullptr, nullptr);
+
+    // Snapshot the resampler so we can undo the hidden frames' effect on it
+    // (preserves filter continuity across iterations)
+    S9xRunAheadSaveAudio();
+
+    Settings.InRunAhead = true;
+
+    // First hidden frame: the "commit" frame — its state gets saved and
+    // becomes the starting point of the next iteration
+    IPPU.RenderThisFrame = false;
+    S9xMainLoop();
+
+    // Save state at end of the committed frame
+    S9xFreezeGameMem(run_ahead_buffer.data(), run_ahead_buffer.size());
+
+    // Additional hidden frames (peek further into the future)
+    for (int i = 1; i < numAheadFrames; i++)
+    {
+        IPPU.RenderThisFrame = false;
+        S9xMainLoop();
+    }
+
+    Settings.InRunAhead = false;
+
+    // Restore resampler state so the displayed frame's output flows on
+    // directly from the previous displayed frame's output
+    S9xRunAheadLoadAudio();
+
+    // Re-enable audio output for the displayed frame
+    S9xSetSamplesAvailableCallback([](void *data) {
+        ((Snes9xController *)data)->SamplesAvailable();
+    }, this);
+
+    // Displayed "preview" frame: renders and throttles normally
+    IPPU.RenderThisFrame = true;
+    S9xMainLoop();
+
+    // Restore to end-of-committed-frame so next iteration starts from there
+    S9xUnfreezeGameMem(run_ahead_buffer.data(), run_ahead_buffer.size());
+
+    Settings.SnapshotScreenshots = savedScreenshots;
+    Settings.FastSavestates = savedFast;
 }
 
 void Snes9xController::mainLoop()
@@ -343,7 +421,18 @@ void Snes9xController::mainLoop()
     }
 #endif
 
-    S9xMainLoop();
+    bool use_run_ahead = Settings.RunAhead > 0 && !rewinding && !Settings.TurboMode;
+#ifdef KAILLERA_SUPPORT
+    // Never run ahead during netplay — the input exchange is once per call,
+    // and hidden frames would desync us from the remote players.
+    if (KailleraClientIsPlaying())
+        use_run_ahead = false;
+#endif
+
+    if (use_run_ahead)
+        mainLoopWithRunAhead();
+    else
+        S9xMainLoop();
 }
 
 void Snes9xController::setPaused(bool paused)

--- a/qt/src/Snes9xController.hpp
+++ b/qt/src/Snes9xController.hpp
@@ -74,6 +74,11 @@ class Snes9xController
 
   private:
     void SamplesAvailable();
+    void mainLoopWithRunAhead();
+
+    // Savestate scratch buffer for run-ahead. Sized per ROM (freeze size
+    // depends on which special chips the cart uses), so openFile clears it.
+    std::vector<uint8_t> run_ahead_buffer;
 
 };
 


### PR DESCRIPTION
## Summary

The RunAhead option existed only in the Win32 build; the Linux Qt and GTK frontends had no way to enable it, in the GUI or the .conf. This ports the feature to both, mirroring the win32 behavior and menu layout, and fixes a pre-existing Qt crash found while testing.

- **Run-ahead frame loop** in both frontends, same scheme as win32 (`wsnes9x.cpp`): commit one hidden frame, save state, run N-1 more hidden frames, render the displayed "future" frame, restore. Hidden frames detach the audio callback and snapshot/restore the resampler so output stays continuous. Skipped during rewind, turbo, and netplay (Kaillera on Qt, built-in netplay on GTK), which would desync. Unlike win32's once-per-session buffer, the freeze buffer is re-sized on every ROM load since freeze size varies with the cart's special chips.
- **Settings UI + persistence**: Qt gets a Run Ahead group in Settings → Emulation and an `Emulation::RunAhead` conf key; GTK gets a Run Ahead frame in Preferences → Emulation and the same conf key, so it's also settable directly in the .conf now.
- **Emulation menu**, matching win32's layout: a Run Ahead submenu (0 (off) … 4 frames, exclusive radio items) placed before the BIOS submenu, enabled only while a ROM is loaded, kept in sync with the settings UI.
- **Qt Wayland crash fix**: on a Wayland session with Qt < 6.5, `EmuCanvas{OpenGL,Vulkan}::createContext` compiled out the wayland branch (no `QWaylandApplication` native interface before 6.5), fell through both platform branches, and crashed on a null context on every ROM load. Both now fail cleanly (including on GL context-creation failure and null native interfaces), and `EmuMainWindow` now checks the previously ignored threaded `createContext` result so failures fall back through the driver chain to the software canvas.

## Testing

- Both `snes9x-qt` and `snes9x-gtk` build cleanly; `snes9x.ui` passes `gtk-builder-tool validate`.
- Qt: SNES ROM loads and runs with RunAhead 0 and 2 (verified via isolated config); ROM-load segfault on Wayland/Qt 6.4.2 reproduced 100% before the canvas fix, gone after, with the fallback dialog + software renderer taking over; unchanged behavior confirmed under `QT_QPA_PLATFORM=xcb`.
- Menu/panel round-trip: menu selection persists to the conf and re-checks correctly on reopen.