### PR TITLE
qt/gtk: add save state banks and the win32 state hotkeys

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -310,6 +310,8 @@ list(APPEND SOURCES
     src/gtk_display_driver_gtk.h
     src/gtk_display_driver.h
     src/gtk_display.h
+    src/gtk_state_preview_dialog.cpp
+    src/gtk_state_preview_dialog.h
     src/threadpool.cpp
     src/threadpool.h
     src/gtk_file.cpp

--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -163,6 +163,7 @@ int Snes9xConfig::load_defaults()
     config_show_comments = true;
     config_nice_alignment = true;
     current_save_slot = 0;
+    current_save_bank = 0;
     S9xCheatsEnable();
 
     rewind_granularity = 5;
@@ -188,6 +189,9 @@ int Snes9xConfig::load_defaults()
     Settings.DisplayTime = false;
     Settings.DisplayFrameRate = false;
     Settings.DisplayIndicators = false;
+    /* Embed a screenshot in each snapshot so the save/load-with-preview
+     * dialog has something to show, as win32 does by default. */
+    Settings.SnapshotScreenshots = true;
     Settings.SixteenBitSound = true;
     Settings.Stereo = true;
     Settings.ReverseStereo = false;
@@ -372,7 +376,8 @@ int Snes9xConfig::save_config_file()
     outbool("UseModalDialogs", modal_dialogs, "Make dialogs block the main window instead of floating independently");
     outint("RewindBufferSize", rewind_buffer_size, "Amount of memory (in MB) to use for rewinding; 0 disables rewind");
     outint("RewindGranularity", rewind_granularity, "Only save rewind snapshots every N frames");
-    outint("CurrentSaveSlot", current_save_slot, "Currently selected save-state slot (remembered automatically)");
+    outint("CurrentSaveSlot", current_save_slot, "Currently selected save-state slot within the bank (remembered automatically)");
+    outint("CurrentSaveBank", current_save_bank, "Currently selected save-state bank (remembered automatically)");
 
     section = "Emulation";
     outbool("EmulateTransparency", Settings.Transparency, "Render the SNES color/transparency effects (turn off only for troubleshooting)");
@@ -380,6 +385,7 @@ int Snes9xConfig::save_config_file()
     outbool("DisplayFrameRate", Settings.DisplayFrameRate, "Show the frames-per-second counter on screen");
     outbool("DisplayPressedKeys", Settings.DisplayPressedKeys, "Show the controller buttons being pressed on screen");
     outbool("DisplayIndicators", Settings.DisplayIndicators, "Show on-screen indicators for turbo, pause, rewind, etc.");
+    outbool("SnapshotScreenshots", Settings.SnapshotScreenshots, "Store a screenshot inside each save state, for the save/load-with-preview dialog");
     outint("SpeedControlMethod", Settings.SkipFrames, "0: Time the frames to 50 or 60Hz, 1: Same, but skip frames if too slow, 2: Synchronize to the sound buffer, 3: Unlimited, except potentially by vsync");
     outint("SaveSRAMEveryNSeconds", Settings.AutoSaveDelay, "Auto-write the battery save this many seconds after the game changes it (0: only on exit/reset)");
     outbool("BlockInvalidVRAMAccess", Settings.BlockInvalidVRAMAccessMaster, "Emulate the real hardware's VRAM access restrictions (on for accuracy; off only for a few broken ROMs/hacks)");
@@ -627,6 +633,19 @@ int Snes9xConfig::load_config_file()
     inint("RewindBufferSize", rewind_buffer_size);
     inint("RewindGranularity", rewind_granularity);
     inint("CurrentSaveSlot", current_save_slot);
+    inint("CurrentSaveBank", current_save_bank);
+
+    /* Older configs stored a flat 0-999 slot index. Split it into a bank and
+     * an in-bank slot so the selection survives the upgrade. */
+    if (current_save_slot >= SAVE_SLOTS_PER_BANK)
+    {
+        current_save_bank = current_save_slot / SAVE_SLOTS_PER_BANK;
+        current_save_slot %= SAVE_SLOTS_PER_BANK;
+    }
+    if (current_save_slot < 0)
+        current_save_slot = 0;
+    if (current_save_bank < 0 || current_save_bank >= NUM_SAVE_BANKS)
+        current_save_bank = 0;
 
     section = "Emulation";
     inbool("EmulateTransparency", Settings.Transparency);
@@ -638,6 +657,7 @@ int Snes9xConfig::load_config_file()
     inbool("BlockInvalidVRAMAccess", Settings.BlockInvalidVRAMAccessMaster);
     inbool("AllowDPadContradictions", Settings.UpAndDown);
     inbool("DisplayIndicators", Settings.DisplayIndicators);
+    inbool("SnapshotScreenshots", Settings.SnapshotScreenshots);
     inint("RunAhead", Settings.RunAhead);
     if (Settings.RunAhead < 0)
         Settings.RunAhead = 0;

--- a/gtk/src/gtk_config.h
+++ b/gtk/src/gtk_config.h
@@ -171,6 +171,7 @@ class Snes9xConfig
     unsigned int rewind_buffer_size;
 
     int current_save_slot;
+    int current_save_bank;
 
     XRRScreenResources *xrr_screen_resources;
     XRRCrtcInfo *xrr_crtc_info;

--- a/gtk/src/gtk_control.cpp
+++ b/gtk/src/gtk_control.cpp
@@ -76,6 +76,8 @@ const BindingLink b_links[] =
         { "b_state_decrement_load","GTK_state_decrement_load" },
         { "b_state_increment",     "GTK_state_increment" },
         { "b_state_decrement",     "GTK_state_decrement" },
+        { "b_state_bank_increment","GTK_state_bank_increment" },
+        { "b_state_bank_decrement","GTK_state_bank_decrement" },
         { "b_save_0",              "QuickSave000"      },
         { "b_save_1",              "QuickSave001"      },
         { "b_save_2",              "QuickSave002"      },
@@ -96,6 +98,20 @@ const BindingLink b_links[] =
         { "b_load_7",              "QuickLoad007"      },
         { "b_load_8",              "QuickLoad008"      },
         { "b_load_9",              "QuickLoad009"      },
+        { "b_select_slot_0",       "GTK_state_select_0" },
+        { "b_select_slot_1",       "GTK_state_select_1" },
+        { "b_select_slot_2",       "GTK_state_select_2" },
+        { "b_select_slot_3",       "GTK_state_select_3" },
+        { "b_select_slot_4",       "GTK_state_select_4" },
+        { "b_select_slot_5",       "GTK_state_select_5" },
+        { "b_select_slot_6",       "GTK_state_select_6" },
+        { "b_select_slot_7",       "GTK_state_select_7" },
+        { "b_select_slot_8",       "GTK_state_select_8" },
+        { "b_select_slot_9",       "GTK_state_select_9" },
+        { "b_state_dialog_save",   "GTK_state_dialog_save" },
+        { "b_state_dialog_load",   "GTK_state_dialog_load" },
+        { "b_state_file_save",     "GTK_state_file_save" },
+        { "b_state_file_load",     "GTK_state_file_load" },
         { "b_sound_channel_0",     "SoundChannel0"     },
         { "b_sound_channel_1",     "SoundChannel1"     },
         { "b_sound_channel_2",     "SoundChannel2"     },
@@ -124,9 +140,9 @@ const int b_breaks[] =
         24, /* End of turbo/sticky buttons */
         35, /* End of base emulator buttons */
         43, /* End of Graphic options */
-        69, /* End of save/load states */
-        78, /* End of sound buttons */
-        86, /* End of miscellaneous buttons */
+        85, /* End of save/load states */
+        94, /* End of sound buttons */
+        102, /* End of miscellaneous buttons */
         -1
 };
 
@@ -209,26 +225,54 @@ static void swap_controllers_1_2()
     gui_config->rebind_keys();
 }
 
-static void change_slot(int difference)
+/* Flat state index of the currently selected bank/slot pair. */
+int S9xCurrentSaveSlot()
 {
-    gui_config->current_save_slot += difference;
-    gui_config->current_save_slot %= 1000;
-    if (gui_config->current_save_slot < 0)
-        gui_config->current_save_slot += 1000;
+    return gui_config->current_save_bank * SAVE_SLOTS_PER_BANK +
+           gui_config->current_save_slot;
+}
+
+static void show_slot_info()
+{
     if (!gui_config->rom_loaded)
         return;
 
     char extension_string[5];
-    snprintf(extension_string, 5, ".%03d", gui_config->current_save_slot);
+    snprintf(extension_string, 5, ".%03d", S9xCurrentSaveSlot());
     auto filename = S9xGetFilename(extension_string, SNAPSHOT_DIR);
     struct stat info{};
     std::string exists = "empty";
     if (stat(filename.c_str(), &info) == 0)
         exists = "used";
 
-    auto info_string = "State Slot: " + std::to_string(gui_config->current_save_slot) + " [" + exists + "]";
+    auto info_string = "State Slot: " + std::to_string(gui_config->current_save_slot) +
+                       ", Bank: " + std::to_string(gui_config->current_save_bank) +
+                       " [" + exists + "]";
     S9xSetInfoString(info_string.c_str());
     GFX.InfoStringTimeout = 60;
+}
+
+/* Slots wrap inside the current bank; the bank is only changed explicitly. */
+static void change_slot(int difference)
+{
+    gui_config->current_save_slot += difference;
+    gui_config->current_save_slot %= SAVE_SLOTS_PER_BANK;
+    if (gui_config->current_save_slot < 0)
+        gui_config->current_save_slot += SAVE_SLOTS_PER_BANK;
+
+    show_slot_info();
+}
+
+static void change_bank(int difference)
+{
+    gui_config->current_save_bank += difference;
+    gui_config->current_save_bank %= NUM_SAVE_BANKS;
+    if (gui_config->current_save_bank < 0)
+        gui_config->current_save_bank += NUM_SAVE_BANKS;
+
+    top_level->update_accelerators();
+
+    show_slot_info();
 }
 
 void S9xHandlePortCommand(s9xcommand_t cmd, int16 data1, int16 data2)
@@ -294,25 +338,33 @@ void S9xHandlePortCommand(s9xcommand_t cmd, int16 data1, int16 data2)
         }
         else if (cmd.port[0] >= PORT_QUICKLOAD0 && cmd.port[0] <= PORT_QUICKLOAD9)
         {
-            S9xQuickLoadSlot(cmd.port[0] - PORT_QUICKLOAD0);
+            /* The numbered save/load hotkeys address slots inside the
+             * currently selected bank, as on win32. */
+            S9xQuickLoadSlot(gui_config->current_save_bank * SAVE_SLOTS_PER_BANK +
+                             cmd.port[0] - PORT_QUICKLOAD0);
+        }
+        else if (cmd.port[0] >= PORT_QUICKSAVE0 && cmd.port[0] <= PORT_QUICKSAVE9)
+        {
+            S9xQuickSaveSlot(gui_config->current_save_bank * SAVE_SLOTS_PER_BANK +
+                             cmd.port[0] - PORT_QUICKSAVE0);
         }
         else if (cmd.port[0] == PORT_SAVESLOT)
         {
-            S9xQuickSaveSlot(gui_config->current_save_slot);
+            S9xQuickSaveSlot(S9xCurrentSaveSlot());
         }
         else if (cmd.port[0] == PORT_LOADSLOT)
         {
-            S9xQuickLoadSlot(gui_config->current_save_slot);
+            S9xQuickLoadSlot(S9xCurrentSaveSlot());
         }
         else if (cmd.port[0] == PORT_INCREMENTSAVESLOT)
         {
             change_slot(1);
-            S9xQuickSaveSlot(gui_config->current_save_slot);
+            S9xQuickSaveSlot(S9xCurrentSaveSlot());
         }
         else if (cmd.port[0] == PORT_DECREMENTLOADSLOT)
         {
             change_slot(-1);
-            S9xQuickLoadSlot(gui_config->current_save_slot);
+            S9xQuickLoadSlot(S9xCurrentSaveSlot());
         }
         else if (cmd.port[0] == PORT_INCREMENTSLOT)
         {
@@ -321,6 +373,36 @@ void S9xHandlePortCommand(s9xcommand_t cmd, int16 data1, int16 data2)
         else if (cmd.port[0] == PORT_DECREMENTSLOT)
         {
             change_slot(-1);
+        }
+        else if (cmd.port[0] == PORT_INCREMENTBANK)
+        {
+            change_bank(1);
+        }
+        else if (cmd.port[0] == PORT_DECREMENTBANK)
+        {
+            change_bank(-1);
+        }
+        else if (cmd.port[0] >= PORT_SELECTSLOT0 && cmd.port[0] <= PORT_SELECTSLOT9)
+        {
+            /* Select a slot in the current bank without saving or loading. */
+            gui_config->current_save_slot = cmd.port[0] - PORT_SELECTSLOT0;
+            show_slot_info();
+        }
+        else if (cmd.port[0] == PORT_DIALOGSAVE)
+        {
+            top_level->state_preview_dialog(true);
+        }
+        else if (cmd.port[0] == PORT_DIALOGLOAD)
+        {
+            top_level->state_preview_dialog(false);
+        }
+        else if (cmd.port[0] == PORT_FILESAVE)
+        {
+            top_level->save_state_dialog();
+        }
+        else if (cmd.port[0] == PORT_FILELOAD)
+        {
+            top_level->load_state_dialog();
         }
         else if (cmd.port[0] == PORT_GRABMOUSE)
         {
@@ -425,6 +507,75 @@ s9xcommand_t S9xGetPortCommandT(const char *name)
     else if (strstr(name, "QuickLoad009"))
     {
         cmd.port[0] = PORT_QUICKLOAD9;
+    }
+    else if (strstr(name, "QuickSave000"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE0;
+    }
+    else if (strstr(name, "QuickSave001"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE1;
+    }
+    else if (strstr(name, "QuickSave002"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE2;
+    }
+    else if (strstr(name, "QuickSave003"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE3;
+    }
+    else if (strstr(name, "QuickSave004"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE4;
+    }
+    else if (strstr(name, "QuickSave005"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE5;
+    }
+    else if (strstr(name, "QuickSave006"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE6;
+    }
+    else if (strstr(name, "QuickSave007"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE7;
+    }
+    else if (strstr(name, "QuickSave008"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE8;
+    }
+    else if (strstr(name, "QuickSave009"))
+    {
+        cmd.port[0] = PORT_QUICKSAVE9;
+    }
+    else if (!strncmp(name, "GTK_state_select_", 17) &&
+             name[17] >= '0' && name[17] <= '9')
+    {
+        cmd.port[0] = PORT_SELECTSLOT0 + (name[17] - '0');
+    }
+    else if (strstr(name, "GTK_state_dialog_save"))
+    {
+        cmd.port[0] = PORT_DIALOGSAVE;
+    }
+    else if (strstr(name, "GTK_state_dialog_load"))
+    {
+        cmd.port[0] = PORT_DIALOGLOAD;
+    }
+    else if (strstr(name, "GTK_state_file_save"))
+    {
+        cmd.port[0] = PORT_FILESAVE;
+    }
+    else if (strstr(name, "GTK_state_file_load"))
+    {
+        cmd.port[0] = PORT_FILELOAD;
+    }
+    else if (strstr(name, "GTK_state_bank_increment"))
+    {
+        cmd.port[0] = PORT_INCREMENTBANK;
+    }
+    else if (strstr(name, "GTK_state_bank_decrement"))
+    {
+        cmd.port[0] = PORT_DECREMENTBANK;
     }
     else if (strstr(name, "GTK_state_save_current"))
     {

--- a/gtk/src/gtk_control.h
+++ b/gtk/src/gtk_control.h
@@ -16,6 +16,12 @@
 
 const int NUM_JOYPADS = 10;
 
+/* Save states are organized in banks of slots, as on win32. The state file
+ * extension is the flat index, i.e. bank * SAVE_SLOTS_PER_BANK + slot. */
+const int SAVE_SLOTS_PER_BANK = 10;
+const int NUM_SAVE_BANKS      = 10;
+const int NUM_SAVE_SLOTS      = NUM_SAVE_BANKS * SAVE_SLOTS_PER_BANK;
+
 enum {
     JOY_MODE_GLOBAL     = 0,
     JOY_MODE_INDIVIDUAL = 1,
@@ -52,7 +58,33 @@ enum {
     PORT_DECREMENTLOADSLOT  = 22,
     PORT_INCREMENTSLOT      = 23,
     PORT_DECREMENTSLOT      = 24,
-    PORT_GRABMOUSE          = 25
+    PORT_GRABMOUSE          = 25,
+    PORT_QUICKSAVE0         = 26,
+    PORT_QUICKSAVE1         = 27,
+    PORT_QUICKSAVE2         = 28,
+    PORT_QUICKSAVE3         = 29,
+    PORT_QUICKSAVE4         = 30,
+    PORT_QUICKSAVE5         = 31,
+    PORT_QUICKSAVE6         = 32,
+    PORT_QUICKSAVE7         = 33,
+    PORT_QUICKSAVE8         = 34,
+    PORT_QUICKSAVE9         = 35,
+    PORT_INCREMENTBANK      = 36,
+    PORT_DECREMENTBANK      = 37,
+    PORT_SELECTSLOT0        = 38,
+    PORT_SELECTSLOT1        = 39,
+    PORT_SELECTSLOT2        = 40,
+    PORT_SELECTSLOT3        = 41,
+    PORT_SELECTSLOT4        = 42,
+    PORT_SELECTSLOT5        = 43,
+    PORT_SELECTSLOT6        = 44,
+    PORT_SELECTSLOT7        = 45,
+    PORT_SELECTSLOT8        = 46,
+    PORT_SELECTSLOT9        = 47,
+    PORT_DIALOGSAVE         = 48,
+    PORT_DIALOGLOAD         = 49,
+    PORT_FILESAVE           = 50,
+    PORT_FILELOAD           = 51
 };
 
 typedef struct BindingLink
@@ -65,7 +97,7 @@ typedef struct BindingLink
 extern const BindingLink b_links[];
 extern const int b_breaks[];
 const int NUM_JOYPAD_LINKS = 24;
-const int NUM_EMU_LINKS = 62;
+const int NUM_EMU_LINKS = 78;
 
 typedef struct JoypadBinding
 {
@@ -74,6 +106,7 @@ typedef struct JoypadBinding
 
 bool S9xGrabJoysticks();
 void S9xReleaseJoysticks();
+int S9xCurrentSaveSlot();
 
 typedef struct JoyEvent
 {

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "gtk_shader_parameters.h"
+#include "gtk_state_preview_dialog.h"
 
 #include "gtk_s9x.h"
 #include "gtk_preferences.h"
@@ -235,21 +236,7 @@ void Snes9xWindow::connect_signals()
         get_object<Gtk::MenuItem>(name)->signal_activate().connect(sigc::bind<const char *>(sigc::mem_fun(*this, &Snes9xWindow::port_activate), name));
     }
 
-    for (int i = 0; i <= 9; i++)
-    {
-        std::string name = "load_state_" + std::to_string(i);
-        get_object<Gtk::MenuItem>(name.c_str())->signal_activate().connect([i] {
-#ifdef RETROACHIEVEMENTS_SUPPORT
-            if (!RA_WarnDisableHardcore(_("Loading save states")))
-                return;
-#endif
-            S9xQuickLoadSlot(i);
-        });
-        name = "save_state_" + std::to_string(i);
-        get_object<Gtk::MenuItem>(name.c_str())->signal_activate().connect([i] {
-            S9xQuickSaveSlot(i);
-        });
-    }
+    build_state_menus();
 
     get_object<Gtk::MenuItem>("from_file1")->signal_activate().connect([&] {
         load_state_dialog();
@@ -257,6 +244,14 @@ void Snes9xWindow::connect_signals()
 
     get_object<Gtk::MenuItem>("to_file1")->signal_activate().connect([&] {
         save_state_dialog();
+    });
+
+    get_object<Gtk::MenuItem>("save_state_preview_item")->signal_activate().connect([&] {
+        state_preview_dialog(true);
+    });
+
+    get_object<Gtk::MenuItem>("load_state_preview_item")->signal_activate().connect([&] {
+        state_preview_dialog(false);
     });
 
     get_object<Gtk::MenuItem>("load_state_undo")->signal_activate().connect([&] {
@@ -965,6 +960,32 @@ void Snes9xWindow::load_state_dialog()
     unpause_from_focus_change();
 }
 
+/* win32's "Save/Load with Preview": pick a slot from a thumbnail grid. */
+void Snes9xWindow::state_preview_dialog(bool is_save)
+{
+    if (!config->rom_loaded)
+        return;
+
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    if (!is_save && !RA_WarnDisableHardcore(_("Loading save states")))
+        return;
+#endif
+
+    pause_from_focus_change();
+
+    int slot = S9xStatePreviewDialog(*window.get(), is_save);
+
+    if (slot >= 0)
+    {
+        if (is_save)
+            S9xQuickSaveSlot(slot);
+        else
+            S9xQuickLoadSlot(slot);
+    }
+
+    unpause_from_focus_change();
+}
+
 void Snes9xWindow::movie_seek_dialog()
 {
     if (!S9xMovieActive())
@@ -1136,6 +1157,8 @@ void Snes9xWindow::configure_widgets()
         "reset_item",
         "load_state_item",
         "save_state_item",
+        "save_state_preview_item",
+        "load_state_preview_item",
         "save_spc_item",
         "hard_reset_item",
         "record_movie_item",
@@ -1665,7 +1688,7 @@ bool Snes9xWindow::is_paused()
     return false;
 }
 
-void Snes9xWindow::set_accelerator_to_binding(const char *name, const char *binding)
+void Snes9xWindow::set_accelerator_to_binding(Gtk::MenuItem *item, const char *binding)
 {
     Binding bin;
 
@@ -1682,12 +1705,69 @@ void Snes9xWindow::set_accelerator_to_binding(const char *name, const char *bind
         return;
 
     AcceleratorEntry entry{};
-    entry.name = name;
+    entry.item = item;
     entry.key = bin.get_key();
     entry.modifiers = bin.get_gdk_modifiers();
 
-    get_object<Gtk::MenuItem>(name)->add_accelerator("activate", accel_group, entry.key, entry.modifiers, Gtk::ACCEL_VISIBLE);
+    item->add_accelerator("activate", accel_group, entry.key, entry.modifiers, Gtk::ACCEL_VISIBLE);
     accelerators.push_back(entry);
+}
+
+void Snes9xWindow::set_accelerator_to_binding(const char *name, const char *binding)
+{
+    set_accelerator_to_binding(get_object<Gtk::MenuItem>(name).get(), binding);
+}
+
+/* Populates File->Save State and File->Load State with a submenu per bank,
+ * each holding one item per slot, mirroring the win32 layout. */
+void Snes9xWindow::build_state_menus()
+{
+    auto save_menu = get_object<Gtk::Menu>("save_state_item_menu");
+    auto load_menu = get_object<Gtk::Menu>("load_state_item_menu");
+
+    for (int bank = 0; bank < NUM_SAVE_BANKS; bank++)
+    {
+        auto bank_label = fmt::format(fmt::runtime(_("Bank #_{}")), bank);
+
+        auto save_bank_item = Gtk::manage(new Gtk::MenuItem(bank_label, true));
+        auto load_bank_item = Gtk::manage(new Gtk::MenuItem(bank_label, true));
+        auto save_bank_menu = Gtk::manage(new Gtk::Menu());
+        auto load_bank_menu = Gtk::manage(new Gtk::Menu());
+
+        for (int slot = 0; slot < SAVE_SLOTS_PER_BANK; slot++)
+        {
+            int index = bank * SAVE_SLOTS_PER_BANK + slot;
+            auto slot_label = fmt::format(fmt::runtime(_("Slot #_{}")), slot);
+
+            auto save_item = Gtk::manage(new Gtk::MenuItem(slot_label, true));
+            save_item->signal_activate().connect([index] {
+                S9xQuickSaveSlot(index);
+            });
+            save_bank_menu->append(*save_item);
+            save_state_items[index] = save_item;
+
+            auto load_item = Gtk::manage(new Gtk::MenuItem(slot_label, true));
+            load_item->signal_activate().connect([index] {
+#ifdef RETROACHIEVEMENTS_SUPPORT
+                if (!RA_WarnDisableHardcore(_("Loading save states")))
+                    return;
+#endif
+                S9xQuickLoadSlot(index);
+            });
+            load_bank_menu->append(*load_item);
+            load_state_items[index] = load_item;
+        }
+
+        save_bank_item->set_submenu(*save_bank_menu);
+        load_bank_item->set_submenu(*load_bank_menu);
+
+        /* Insert ahead of the separator and the "…File…" items from the .ui. */
+        save_menu->insert(*save_bank_item, bank);
+        load_menu->insert(*load_bank_item, bank);
+    }
+
+    save_menu->show_all();
+    load_menu->show_all();
 }
 
 void Snes9xWindow::update_accelerators()
@@ -1700,7 +1780,7 @@ void Snes9xWindow::update_accelerators()
 
     for (auto &entry : accelerators)
     {
-        get_object<Gtk::MenuItem>(entry.name.c_str())->remove_accelerator(accel_group, entry.key, entry.modifiers);
+        entry.item->remove_accelerator(accel_group, entry.key, entry.modifiers);
     }
     accelerators.clear();
 
@@ -1708,27 +1788,11 @@ void Snes9xWindow::update_accelerators()
     {
         { "fullscreen_item", "GTK_fullscreen" },
         { "reset_item", "SoftReset" },
-        { "save_state_0", "QuickSave000" },
-        { "save_state_1", "QuickSave001" },
-        { "save_state_2", "QuickSave002" },
-        { "save_state_3", "QuickSave003" },
-        { "save_state_4", "QuickSave004" },
-        { "save_state_5", "QuickSave005" },
-        { "save_state_6", "QuickSave006" },
-        { "save_state_7", "QuickSave007" },
-        { "save_state_8", "QuickSave008" },
-        { "save_state_9", "QuickSave009" },
-        { "load_state_0", "QuickLoad000" },
-        { "load_state_1", "QuickLoad001" },
-        { "load_state_2", "QuickLoad002" },
-        { "load_state_3", "QuickLoad003" },
-        { "load_state_4", "QuickLoad004" },
-        { "load_state_5", "QuickLoad005" },
-        { "load_state_6", "QuickLoad006" },
-        { "load_state_7", "QuickLoad007" },
-        { "load_state_8", "QuickLoad008" },
-        { "load_state_9", "QuickLoad009" },
         { "pause_item", "GTK_pause" },
+        { "save_state_preview_item", "GTK_state_dialog_save" },
+        { "load_state_preview_item", "GTK_state_dialog_load" },
+        { "from_file1", "GTK_state_file_load" },
+        { "to_file1", "GTK_state_file_save" },
         { "save_spc_item", "GTK_save_spc" },
         { "open_rom_item", "GTK_open_rom" },
         { "record_movie_item", "BeginRecordingMovie" },
@@ -1744,6 +1808,18 @@ void Snes9xWindow::update_accelerators()
 
     for (auto &[accelerator, binding_name] : pairs) {
         set_accelerator_to_binding(accelerator, binding_name);
+    }
+
+    /* The numbered quick save/load hotkeys act on the current bank, so show
+     * them on that bank's slot items only. */
+    for (int slot = 0; slot < SAVE_SLOTS_PER_BANK; slot++)
+    {
+        int index = config->current_save_bank * SAVE_SLOTS_PER_BANK + slot;
+        auto save_binding = fmt::format("QuickSave{:03d}", slot);
+        auto load_binding = fmt::format("QuickLoad{:03d}", slot);
+
+        set_accelerator_to_binding(save_state_items[index], save_binding.c_str());
+        set_accelerator_to_binding(load_state_items[index], load_binding.c_str());
     }
 }
 

--- a/gtk/src/gtk_s9xwindow.h
+++ b/gtk/src/gtk_s9xwindow.h
@@ -18,7 +18,7 @@ class Snes9xWindow : public GtkBuilderWindow
 
     struct AcceleratorEntry
     {
-        std::string name;
+        Gtk::MenuItem *item;
         unsigned int key;
         Gdk::ModifierType modifiers;
     };
@@ -49,6 +49,7 @@ class Snes9xWindow : public GtkBuilderWindow
     std::string open_rom_dialog(bool run = true);
     void save_state_dialog();
     void load_state_dialog();
+    void state_preview_dialog(bool is_save);
     void configure_widgets();
     void save_spc_dialog();
     bool try_open_rom(const std::string &filename);
@@ -64,7 +65,10 @@ class Snes9xWindow : public GtkBuilderWindow
     void set_mouseable_area(int x, int y, int width, int height);
     void set_accelerator_to_binding(const char *name,
                                         const char *binding);
+    void set_accelerator_to_binding(Gtk::MenuItem *item,
+                                        const char *binding);
     void reset_screensaver();
+    void build_state_menus();
     void update_accelerators();
     void toggle_ui();
     void resize_to_multiple(int factor);
@@ -109,6 +113,11 @@ class Snes9xWindow : public GtkBuilderWindow
     Glib::RefPtr<Gdk::DrawingContext> gdk_drawing_context;
     Glib::RefPtr<Gtk::AccelGroup> accel_group;
     std::vector<AcceleratorEntry> accelerators;
+
+    /* File->Save/Load State slot items, indexed by bank * SAVE_SLOTS_PER_BANK
+     * + slot. Built at runtime since there are too many for the .ui file. */
+    std::array<Gtk::MenuItem *, NUM_SAVE_SLOTS> save_state_items;
+    std::array<Gtk::MenuItem *, NUM_SAVE_SLOTS> load_state_items;
 
     unsigned int last_key_pressed_keyval;
     GdkEventType last_key_pressed_type;

--- a/gtk/src/gtk_state_preview_dialog.cpp
+++ b/gtk/src/gtk_state_preview_dialog.cpp
@@ -1,0 +1,206 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "gtk_state_preview_dialog.h"
+#include "gtk_s9x.h"
+#include "gtk_config.h"
+#include "gtk_control.h"
+
+#include "snes9x.h"
+#include "snapshot.h"
+#include "stream.h"
+
+#include "fmt/format.h"
+
+#include <ctime>
+#include <sys/stat.h>
+
+/* Three quarters of the SNES resolution: big enough to recognize a scene,
+ * small enough that a row of five fits a normal screen. */
+static const int PREVIEW_WIDTH = 192;
+static const int PREVIEW_HEIGHT = 168;
+
+static std::string state_filename(int index)
+{
+    char extension[5];
+    snprintf(extension, sizeof(extension), ".%03d", index);
+    return S9xGetFilename(extension, SNAPSHOT_DIR);
+}
+
+/* Converts the RGB565 screenshot stored in a snapshot into a scaled pixbuf.
+ *
+ * This opens the stream itself rather than calling S9xUnfreezeScreenshot,
+ * which reports missing or screenshot-less files through S9xMessage. Every
+ * empty slot in the grid would otherwise log twice on each refresh. */
+static Glib::RefPtr<Gdk::Pixbuf> state_thumbnail(const std::string &filename)
+{
+    uint16 *image_buffer = nullptr;
+    int width = 0;
+    int height = 0;
+
+    STREAM stream = OPEN_STREAM(filename.c_str(), "rb");
+    if (!stream)
+        return {};
+
+    int result = S9xUnfreezeScreenshotFromStream(stream, &image_buffer, width, height);
+    CLOSE_STREAM(stream);
+
+    if (result != SUCCESS || !image_buffer || width < 1 || height < 1)
+    {
+        free(image_buffer);
+        return {};
+    }
+
+    auto pixbuf = Gdk::Pixbuf::create(Gdk::COLORSPACE_RGB, false, 8, width, height);
+    auto pixels = pixbuf->get_pixels();
+    int rowstride = pixbuf->get_rowstride();
+
+    for (int y = 0; y < height; y++)
+    {
+        uint16 *in = image_buffer + y * width;
+        guint8 *out = pixels + y * rowstride;
+
+        for (int x = 0; x < width; x++)
+        {
+            uint16 pixel = in[x];
+            unsigned int r = (pixel >> 11) & 0x1f;
+            unsigned int g = (pixel >> 5) & 0x3f;
+            unsigned int b = pixel & 0x1f;
+
+            /* Replicate the high bits into the low ones so full-scale input
+             * maps to full-scale output. */
+            *out++ = (r << 3) | (r >> 2);
+            *out++ = (g << 2) | (g >> 4);
+            *out++ = (b << 3) | (b >> 2);
+        }
+    }
+
+    free(image_buffer);
+
+    return pixbuf->scale_simple(PREVIEW_WIDTH, PREVIEW_HEIGHT, Gdk::INTERP_BILINEAR);
+}
+
+static std::string state_description(const std::string &filename)
+{
+    struct stat info{};
+    if (stat(filename.c_str(), &info) != 0)
+        return _("Empty");
+
+    char timestamp[64]{};
+    struct tm local{};
+    if (localtime_r(&info.st_mtime, &local))
+        strftime(timestamp, sizeof(timestamp), "%x %X", &local);
+
+    return Glib::path_get_basename(filename) + "\n" + timestamp;
+}
+
+namespace
+{
+
+class StatePreviewDialog : public Gtk::Dialog
+{
+  public:
+    StatePreviewDialog(Gtk::Window &parent, bool is_save)
+        : Gtk::Dialog(is_save ? _("Save with Preview") : _("Load with Preview"),
+                      parent, true)
+    {
+        set_border_width(6);
+
+        auto content = get_content_area();
+        content->set_spacing(6);
+
+        grid.set_row_spacing(6);
+        grid.set_column_spacing(6);
+        content->pack_start(grid, Gtk::PACK_EXPAND_WIDGET);
+
+        for (int slot = 0; slot < SAVE_SLOTS_PER_BANK; slot++)
+        {
+            auto box = Gtk::manage(new Gtk::VBox());
+            box->set_spacing(4);
+            box->pack_start(images[slot], Gtk::PACK_SHRINK);
+            box->pack_start(labels[slot], Gtk::PACK_SHRINK);
+
+            images[slot].set_size_request(PREVIEW_WIDTH, PREVIEW_HEIGHT);
+            labels[slot].set_justify(Gtk::JUSTIFY_CENTER);
+            labels[slot].set_max_width_chars(20);
+            labels[slot].set_ellipsize(Pango::ELLIPSIZE_MIDDLE);
+
+            buttons[slot].add(*box);
+            buttons[slot].signal_clicked().connect([this, slot] {
+                selection = bank_combo.get_active_row_number() * SAVE_SLOTS_PER_BANK + slot;
+                response(Gtk::RESPONSE_OK);
+            });
+
+            /* Two rows of five, matching the win32 layout. */
+            grid.attach(buttons[slot], slot % 5, slot / 5, 1, 1);
+        }
+
+        for (int bank = 0; bank < NUM_SAVE_BANKS; bank++)
+            bank_combo.append(fmt::format(fmt::runtime(_("Bank #{}")), bank));
+        bank_combo.set_active(gui_config->current_save_bank);
+        bank_combo.signal_changed().connect([this] { refresh(); });
+
+        auto bank_box = Gtk::manage(new Gtk::HBox());
+        bank_box->set_spacing(6);
+        bank_box->pack_start(*Gtk::manage(new Gtk::Label(_("Bank:"))), Gtk::PACK_SHRINK);
+        bank_box->pack_start(bank_combo, Gtk::PACK_SHRINK);
+        content->pack_start(*bank_box, Gtk::PACK_SHRINK);
+
+        add_button(Gtk::StockID("gtk-cancel"), Gtk::RESPONSE_CANCEL);
+
+        refresh();
+        show_all_children();
+    }
+
+    int get_selection() const
+    {
+        return selection;
+    }
+
+  private:
+    void refresh()
+    {
+        int bank = bank_combo.get_active_row_number();
+        if (bank < 0)
+            bank = 0;
+
+        for (int slot = 0; slot < SAVE_SLOTS_PER_BANK; slot++)
+        {
+            auto filename = state_filename(bank * SAVE_SLOTS_PER_BANK + slot);
+            auto thumbnail = state_thumbnail(filename);
+
+            if (thumbnail)
+                images[slot].set(thumbnail);
+            else
+                images[slot].clear();
+
+            labels[slot].set_text(fmt::format(fmt::runtime(_("Slot #{}")), slot) +
+                                  "\n" + state_description(filename));
+        }
+    }
+
+    Gtk::Grid grid;
+    Gtk::ComboBoxText bank_combo;
+    Gtk::Button buttons[SAVE_SLOTS_PER_BANK];
+    Gtk::Image images[SAVE_SLOTS_PER_BANK];
+    Gtk::Label labels[SAVE_SLOTS_PER_BANK];
+    int selection = -1;
+};
+
+} // namespace
+
+int S9xStatePreviewDialog(Gtk::Window &parent, bool is_save)
+{
+    if (!gui_config->rom_loaded)
+        return -1;
+
+    StatePreviewDialog dialog(parent, is_save);
+
+    if (dialog.run() != Gtk::RESPONSE_OK)
+        return -1;
+
+    return dialog.get_selection();
+}

--- a/gtk/src/gtk_state_preview_dialog.h
+++ b/gtk/src/gtk_state_preview_dialog.h
@@ -1,0 +1,14 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+#include "gtk_compat.h"
+
+/* Shows the win32-style save/load-with-preview picker: a grid of the current
+ * bank's slots with their screenshots, plus a bank selector. Returns the flat
+ * state index (bank * SAVE_SLOTS_PER_BANK + slot) that was picked, or -1 if
+ * the dialog was cancelled. */
+int S9xStatePreviewDialog(Gtk::Window &parent, bool is_save);

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1363,96 +1363,6 @@
                           <object class="GtkMenu" id="load_state_item_menu">
                             <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkMenuItem" id="load_state_0">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _0</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _1</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _2</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_3">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _3</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_4">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _4</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_5">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _5</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_6">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _6</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_7">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _7</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_8">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _8</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="load_state_9">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _9</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="load_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
                               <object class="GtkSeparatorMenuItem" id="separator7">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -1497,96 +1407,6 @@
                           <object class="GtkMenu" id="save_state_item_menu">
                             <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkMenuItem" id="save_state_0">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _0</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _1</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _2</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_3">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _3</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_4">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _4</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_5">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _5</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_6">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _6</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_7">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _7</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_8">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _8</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="save_state_9">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Slot _9</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="save_save_state" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
                               <object class="GtkSeparatorMenuItem" id="separator8">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -1603,6 +1423,22 @@
                             </child>
                           </object>
                         </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="save_state_preview_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Sa_ve with Preview…</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="load_state_preview_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Loa_d with Preview…</property>
+                        <property name="use_underline">True</property>
                       </object>
                     </child>
                     <child>
@@ -8311,7 +8147,7 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="border_width">10</property>
-                                        <property name="n_rows">8</property>
+                                        <property name="n_rows">12</property>
                                         <property name="n_columns">2</property>
                                         <property name="column_spacing">10</property>
                                         <property name="row_spacing">5</property>
@@ -8513,6 +8349,204 @@
                                             <property name="y_options">GTK_FILL</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur561">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Increment bank</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">6</property>
+                                            <property name="bottom_attach">7</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_state_bank_increment">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">6</property>
+                                            <property name="bottom_attach">7</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur562">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Decrement bank</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">7</property>
+                                            <property name="bottom_attach">8</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_state_bank_decrement">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">7</property>
+                                            <property name="bottom_attach">8</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur570">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Save with preview</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">8</property>
+                                            <property name="bottom_attach">9</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_state_dialog_save">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">8</property>
+                                            <property name="bottom_attach">9</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur571">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Load with preview</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">9</property>
+                                            <property name="bottom_attach">10</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_state_dialog_load">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">9</property>
+                                            <property name="bottom_attach">10</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur572">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Save to file</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">10</property>
+                                            <property name="bottom_attach">11</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_state_file_save">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">10</property>
+                                            <property name="bottom_attach">11</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur573">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Load from file</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">11</property>
+                                            <property name="bottom_attach">12</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_state_file_load">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">11</property>
+                                            <property name="bottom_attach">12</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                     <child>
@@ -8529,7 +8563,7 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">&lt;b&gt;Quick save state&lt;/b&gt;</property>
+                                            <property name="label" translatable="yes">&lt;b&gt;Quick save state (current bank)&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
                                             <property name="justify">center</property>
                                           </object>
@@ -8544,7 +8578,7 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">&lt;b&gt;Quick load state&lt;/b&gt;</property>
+                                            <property name="label" translatable="yes">&lt;b&gt;Quick load state (current bank)&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
                                           </object>
                                           <packing>
@@ -9235,6 +9269,368 @@
                                           </packing>
                                         </child>
                                       </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTable" id="select_slot_table">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="border_width">10</property>
+                                        <property name="n_rows">11</property>
+                                        <property name="n_columns">2</property>
+                                        <property name="column_spacing">10</property>
+                                        <property name="row_spacing">5</property>
+                                        <child>
+                                          <object class="GtkLabel" id="select_slot_header">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">&lt;b&gt;Select save slot (current bank)&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">0</property>
+                                            <property name="bottom_attach">1</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur600">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">1</property>
+                                            <property name="bottom_attach">2</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_0">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">1</property>
+                                            <property name="bottom_attach">2</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur601">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 1</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">2</property>
+                                            <property name="bottom_attach">3</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_1">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">2</property>
+                                            <property name="bottom_attach">3</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur602">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 2</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">3</property>
+                                            <property name="bottom_attach">4</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_2">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">3</property>
+                                            <property name="bottom_attach">4</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur603">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 3</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">4</property>
+                                            <property name="bottom_attach">5</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_3">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">4</property>
+                                            <property name="bottom_attach">5</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur604">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 4</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">5</property>
+                                            <property name="bottom_attach">6</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_4">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">5</property>
+                                            <property name="bottom_attach">6</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur605">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 5</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">6</property>
+                                            <property name="bottom_attach">7</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_5">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">6</property>
+                                            <property name="bottom_attach">7</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur606">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 6</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">7</property>
+                                            <property name="bottom_attach">8</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_6">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">7</property>
+                                            <property name="bottom_attach">8</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur607">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 7</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">8</property>
+                                            <property name="bottom_attach">9</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_7">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">8</property>
+                                            <property name="bottom_attach">9</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur608">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 8</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">9</property>
+                                            <property name="bottom_attach">10</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_8">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">9</property>
+                                            <property name="bottom_attach">10</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="cur609">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Select slot 9</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="right_attach">1</property>
+                                            <property name="top_attach">10</property>
+                                            <property name="bottom_attach">11</property>
+                                            <property name="x_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="b_select_slot_9">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="editable">False</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">10</property>
+                                            <property name="bottom_attach">11</property>
+                                            <property name="y_options">GTK_FILL</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -306,6 +306,8 @@ list(APPEND QT_GUI_SOURCES
     src/SDLInputManager.cpp
     src/ShaderParametersDialog.cpp
     src/CheatsDialog.cpp
+    src/StatePreviewDialog.cpp
+    src/StatePreviewDialog.hpp
     src/SoftwareScalers.cpp
     src/SoftwareFilters.cpp
     src/SoftwareFilters.hpp

--- a/qt/src/EmuApplication.cpp
+++ b/qt/src/EmuApplication.cpp
@@ -361,7 +361,11 @@ void EmuApplication::updateBindings()
 
             if (binding.type != EmuBinding::None)
             {
-                auto handler = core->acceptsCommand(name) ? Core : UI;
+                /* The core's QuickSave/QuickLoad commands address absolute
+                 * slots; handle them here so they apply to the current bank. */
+                bool bank_relative = strncmp(name, "QuickSave", 9) == 0 ||
+                                     strncmp(name, "QuickLoad", 9) == 0;
+                auto handler = (!bank_relative && core->acceptsCommand(name)) ? Core : UI;
                 bindings.insert({ binding.hash(), { name, handler } });
             }
         }
@@ -478,30 +482,84 @@ void EmuApplication::handleBinding(const std::string &name, bool pressed)
                 window->pauseContinue();
             }
 
-            else if (name == "IncreaseSlot" || name == "DecreaseSlot")
+            else if (name == "IncreaseSlot" || name == "DecreaseSlot" ||
+                     name == "IncreaseBank" || name == "DecreaseBank")
             {
+                auto &slot = config->current_save_slot;
+                auto &bank = config->current_save_bank;
+
+                /* Slots wrap inside the current bank; banks wrap on their own. */
                 if (name == "IncreaseSlot")
-                    save_slot++;
+                    slot++;
+                else if (name == "DecreaseSlot")
+                    slot--;
+                else if (name == "IncreaseBank")
+                    bank++;
                 else
-                    save_slot--;
+                    bank--;
 
-                if (save_slot > 999)
-                    save_slot = 0;
-                if (save_slot < 0)
-                    save_slot = 999;
+                if (slot >= EmuConfig::save_slots_per_bank)
+                    slot = 0;
+                if (slot < 0)
+                    slot = EmuConfig::save_slots_per_bank - 1;
+                if (bank >= EmuConfig::num_save_banks)
+                    bank = 0;
+                if (bank < 0)
+                    bank = EmuConfig::num_save_banks - 1;
 
-                emu_thread->runOnThread([&, slot = this->save_slot] {
-                    std::string status = core->slotUsed(slot) ? " [used]" : " [empty]";
-                    core->setMessage("Current slot: " + std::to_string(save_slot) + status);
+                emu_thread->runOnThread([&, slot, bank, index = currentSaveSlot()] {
+                    std::string status = core->slotUsed(index) ? " [used]" : " [empty]";
+                    core->setMessage("Current slot: " + std::to_string(slot) +
+                                     ", bank: " + std::to_string(bank) + status);
                 });
             }
             else if (name == "SaveState")
             {
-                saveState(save_slot);
+                saveState(currentSaveSlot());
             }
             else if (name == "LoadState")
             {
-                loadState(save_slot);
+                loadState(currentSaveSlot());
+            }
+            else if (name.compare(0, 9, "QuickSave") == 0)
+            {
+                /* The numbered hotkeys address slots inside the current bank. */
+                saveState(config->current_save_bank * EmuConfig::save_slots_per_bank +
+                          std::stoi(name.substr(9)));
+            }
+            else if (name.compare(0, 9, "QuickLoad") == 0)
+            {
+                loadState(config->current_save_bank * EmuConfig::save_slots_per_bank +
+                          std::stoi(name.substr(9)));
+            }
+            else if (name.compare(0, 10, "SelectSlot") == 0)
+            {
+                /* Select a slot in the current bank without saving or loading. */
+                config->current_save_slot = std::stoi(name.substr(10));
+
+                emu_thread->runOnThread([&, index = currentSaveSlot()] {
+                    std::string status = core->slotUsed(index) ? " [used]" : " [empty]";
+                    core->setMessage("Current slot: " +
+                                     std::to_string(config->current_save_slot) +
+                                     ", bank: " +
+                                     std::to_string(config->current_save_bank) + status);
+                });
+            }
+            else if (name == "SaveStateDialog")
+            {
+                window->statePreviewDialog(true);
+            }
+            else if (name == "LoadStateDialog")
+            {
+                window->statePreviewDialog(false);
+            }
+            else if (name == "SaveStateFile")
+            {
+                window->chooseState(true);
+            }
+            else if (name == "LoadStateFile")
+            {
+                window->chooseState(false);
             }
             else if (name == "SwapControllers1and2")
             {
@@ -647,6 +705,13 @@ void EmuApplication::startInputTimer()
     poll_input_timer->start();
 }
 
+/* Flat state index of the currently selected bank/slot pair. */
+int EmuApplication::currentSaveSlot()
+{
+    return config->current_save_bank * EmuConfig::save_slots_per_bank +
+           config->current_save_slot;
+}
+
 void EmuApplication::loadState(int slot)
 {
     emu_thread->runOnThread([&, slot] {
@@ -719,6 +784,11 @@ void EmuApplication::loadUndoState()
 std::string EmuApplication::getStateFolder()
 {
     return core->getStateFolder();
+}
+
+std::string EmuApplication::getStateFilename(int slot)
+{
+    return core->getStateFilename(slot);
 }
 
 std::vector<std::tuple<bool, std::string, std::string>> EmuApplication::getCheatList()

--- a/qt/src/EmuApplication.hpp
+++ b/qt/src/EmuApplication.hpp
@@ -78,7 +78,9 @@ struct EmuApplication
     void loadState(const std::string& filename);
     void saveState(int slot);
     void saveState(const std::string& filename);
+    int currentSaveSlot();
     std::string getStateFolder();
+    std::string getStateFilename(int slot);
     void loadUndoState();
     void startGame();
     void startThread();
@@ -108,7 +110,6 @@ struct EmuApplication
     std::unique_ptr<QTimer> poll_input_timer;
     std::function<void(EmuBinding)> binding_callback = nullptr;
     std::function<void()> joypads_changed_callback = nullptr;
-    int save_slot = 0;
     int pause_count = 0;
     int suspend_count = 0;
 };

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -34,6 +34,8 @@ static const char *shortcut_names[] =
     "LoadState",
     "IncreaseSlot",
     "DecreaseSlot",
+    "IncreaseBank",
+    "DecreaseBank",
     "QuickSave000",
     "QuickSave001",
     "QuickSave002",
@@ -54,6 +56,20 @@ static const char *shortcut_names[] =
     "QuickLoad007",
     "QuickLoad008",
     "QuickLoad009",
+    "SelectSlot0",
+    "SelectSlot1",
+    "SelectSlot2",
+    "SelectSlot3",
+    "SelectSlot4",
+    "SelectSlot5",
+    "SelectSlot6",
+    "SelectSlot7",
+    "SelectSlot8",
+    "SelectSlot9",
+    "SaveStateDialog",
+    "LoadStateDialog",
+    "SaveStateFile",
+    "LoadStateFile",
     "Rewind",
     "GrabMouse",
     "SwapControllers1and2",
@@ -93,6 +109,8 @@ static const char *default_controller_keys[] =
     "Keyboard F4", //    eLoadState
     "Keyboard F6", //    eIncreaseSlot
     "Keyboard F5", //    eDecreaseSlot
+    "Keyboard Shift+F6", //    eIncreaseBank
+    "Keyboard Shift+F5", //    eDecreaseBank
     "Keyboard 0", //    eSaveState0
     "Keyboard 1", //    eSaveState1
     "Keyboard 2", //    eSaveState2
@@ -113,6 +131,23 @@ static const char *default_controller_keys[] =
     "Keyboard Ctrl+7", //    eLoadState7
     "Keyboard Ctrl+8", //    eLoadState8
     "Keyboard Ctrl+9", //    eLoadState9
+    "", //    eSelectSlot0
+    "", //    eSelectSlot1
+    "", //    eSelectSlot2
+    "", //    eSelectSlot3
+    "", //    eSelectSlot4
+    "", //    eSelectSlot5
+    "", //    eSelectSlot6
+    "", //    eSelectSlot7
+    "", //    eSelectSlot8
+    "", //    eSelectSlot9
+    // win32 defaults these to Shift+F11 / F11, but F11 is already Qt's
+    // fullscreen toggle and the first binding registered wins, so leave them
+    // unassigned rather than shadowing one silently.
+    "", //    eSaveStateDialog
+    "", //    eLoadStateDialog
+    "", //    eSaveStateFile
+    "", //    eLoadStateFile
     "", //    eRewind
     "Keyboard Ctrl+g", //    eGrabMouse
     "", //    eSwapControllers1and2
@@ -298,6 +333,7 @@ bool EmuConfig::setDefaults(int section)
         run_ahead_frames = 0;
 
         allow_invalid_vram_access = false;
+        snapshot_screenshots = true;
         allow_opposing_dpad_directions = false;
         overclock = eNoOverclock;
         remove_sprite_limit = false;
@@ -457,6 +493,16 @@ void EmuConfig::config(const std::string &filename, bool write)
     Int("ShaderParametersDialogHeight", shader_parameters_dialog_height);
     Int("CheatDialogWidth", cheat_dialog_width);
     Int("CheatDialogHeight", cheat_dialog_height);
+    Int("CurrentSaveSlot", current_save_slot, "Currently selected save-state slot within the bank (remembered automatically)");
+    Int("CurrentSaveBank", current_save_bank, "Currently selected save-state bank (remembered automatically)");
+
+    if (!write)
+    {
+        if (current_save_slot < 0 || current_save_slot >= save_slots_per_bank)
+            current_save_slot = 0;
+        if (current_save_bank < 0 || current_save_bank >= num_save_banks)
+            current_save_bank = 0;
+    }
 
     int recent_count = recently_used.size();
     Int("RecentlyUsedEntries", recent_count, "Number of RecentlyUsed entries below");
@@ -540,6 +586,7 @@ void EmuConfig::config(const std::string &filename, bool write)
     Int("RewindFrameInterval", rewind_frame_interval, "Save a rewind snapshot every N frames");
     Int("RunAhead", run_ahead_frames, "Number of frames to run ahead for reduced input latency (0 = off, 1-4)");
     Bool("AllowInvalidVRAMAccess", allow_invalid_vram_access, "Let games make the VRAM accesses real hardware blocks (off for accuracy; on only for a few broken hacks)");
+    Bool("SnapshotScreenshots", snapshot_screenshots, "Store a screenshot inside each save state, for the save/load-with-preview dialog");
     Bool("AllowOpposingDpadDirections", allow_opposing_dpad_directions, "Allow the D-Pad to press both left+right or up+down at once");
     Int("Overclock", overclock, "CPU overclock: 0 none, 1 auto-FastROM, 2 low, 3 high (reduces slowdown; inaccurate, can break games)");
     Bool("RemoveSpriteLimit", remove_sprite_limit, "Draw more sprites per line than the hardware allows (reduces flicker, may glitch)");

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -37,6 +37,8 @@ struct EmuConfig
     int cheat_dialog_height = 0;
     int shader_parameters_dialog_width = 0;
     int shader_parameters_dialog_height = 0;
+    int current_save_slot = 0;
+    int current_save_bank = 0;
     std::vector<std::string> recently_used;
 
     // General
@@ -159,6 +161,7 @@ struct EmuConfig
     // Emulation/Hacks
 
     bool allow_invalid_vram_access;
+    bool snapshot_screenshots;
     bool allow_opposing_dpad_directions;
     enum Overclock
     {
@@ -227,7 +230,12 @@ struct EmuConfig
 
     static const int allowed_bindings = 4;
     static const int num_controller_bindings = 18;
-    static const int num_shortcuts = 55;
+    static const int num_shortcuts = 71;
+
+    /* Save states are organized in banks of slots, as on win32. The state
+     * file extension is the flat index, bank * save_slots_per_bank + slot. */
+    static const int save_slots_per_bank = 10;
+    static const int num_save_banks = 10;
 
     bool automap_gamepads;
 
@@ -267,6 +275,8 @@ struct EmuConfig
         eLoadState,
         eIncreaseSlot,
         eDecreaseSlot,
+        eIncreaseBank,
+        eDecreaseBank,
         eSaveState0,
         eSaveState1,
         eSaveState2,
@@ -287,6 +297,20 @@ struct EmuConfig
         eLoadState7,
         eLoadState8,
         eLoadState9,
+        eSelectSlot0,
+        eSelectSlot1,
+        eSelectSlot2,
+        eSelectSlot3,
+        eSelectSlot4,
+        eSelectSlot5,
+        eSelectSlot6,
+        eSelectSlot7,
+        eSelectSlot8,
+        eSelectSlot9,
+        eSaveStateDialog,
+        eLoadStateDialog,
+        eSaveStateFile,
+        eLoadStateFile,
         eRewind,
         eGrabMouse,
         eSwapControllers1and2,

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include "CheatsDialog.hpp"
+#include "StatePreviewDialog.hpp"
 #include "EmuApplication.hpp"
 #include "EmuConfig.hpp"
 #include "snes9x.h"
@@ -315,19 +316,28 @@ void EmuMainWindow::createWidgets()
     // File->Load/Save State submenus
     load_state_menu = new QMenu(tr("&Load State"));
     save_state_menu = new QMenu(tr("&Save State"));
-    for  (size_t i = 0; i < state_items_size; i++)
+    // One submenu per bank, each holding one item per slot, as on win32.
+    for (int bank = 0; bank < EmuConfig::num_save_banks; bank++)
     {
-        auto action = load_state_menu->addAction(tr("Slot &%1").arg(i));
-        connect(action, &QAction::triggered, [&, i] {
-            app->loadState(i);
-        });
-        core_actions.push_back(action);
+        auto load_bank_menu = load_state_menu->addMenu(tr("Bank &%1").arg(bank));
+        auto save_bank_menu = save_state_menu->addMenu(tr("Bank &%1").arg(bank));
 
-        action = save_state_menu->addAction(tr("Slot &%1").arg(i));
-        connect(action, &QAction::triggered, [&, i] {
-            app->saveState(i);
-        });
-        core_actions.push_back(action);
+        for (int slot = 0; slot < EmuConfig::save_slots_per_bank; slot++)
+        {
+            int index = bank * EmuConfig::save_slots_per_bank + slot;
+
+            auto action = load_bank_menu->addAction(tr("Slot &%1").arg(slot));
+            connect(action, &QAction::triggered, [&, index] {
+                app->loadState(index);
+            });
+            core_actions.push_back(action);
+
+            action = save_bank_menu->addAction(tr("Slot &%1").arg(slot));
+            connect(action, &QAction::triggered, [&, index] {
+                app->saveState(index);
+            });
+            core_actions.push_back(action);
+        }
     }
 
     load_state_menu->addSeparator();
@@ -355,6 +365,18 @@ void EmuMainWindow::createWidgets()
     });
     core_actions.push_back(save_state_file_item);
     file_menu->addMenu(save_state_menu);
+
+    auto save_preview_item = file_menu->addAction(tr("Sa&ve with Preview..."));
+    connect(save_preview_item, &QAction::triggered, [&] {
+        this->statePreviewDialog(true);
+    });
+    core_actions.push_back(save_preview_item);
+
+    auto load_preview_item = file_menu->addAction(tr("Loa&d with Preview..."));
+    connect(load_preview_item, &QAction::triggered, [&] {
+        this->statePreviewDialog(false);
+    });
+    core_actions.push_back(load_preview_item);
 
     auto languages = EmuPoTranslator::availableLanguages();
     if (languages.size() > 1)
@@ -723,6 +745,28 @@ void EmuMainWindow::setBypassCompositor(bool bypass)
         XChangeProperty(display, xid, net_wm_bypass_compositor, 6, 32, PropModeReplace, (unsigned char *)&value, 1);
     }
 #endif
+}
+
+/* win32's "Save/Load with Preview": pick a slot from a thumbnail grid. */
+void EmuMainWindow::statePreviewDialog(bool save)
+{
+    if (!app->isCoreActive())
+        return;
+
+    app->pause();
+
+    StatePreviewDialog dialog(app, this, save);
+    int slot = dialog.exec() ? dialog.selection() : -1;
+
+    if (slot >= 0)
+    {
+        if (save)
+            app->saveState(slot);
+        else
+            app->loadState(slot);
+    }
+
+    app->unpause();
 }
 
 void EmuMainWindow::chooseState(bool save)

--- a/qt/src/EmuMainWindow.hpp
+++ b/qt/src/EmuMainWindow.hpp
@@ -31,6 +31,7 @@ class EmuMainWindow : public QMainWindow
     void resizeToMultiple(int multiple);
     void populateRecentlyUsed();
     void chooseState(bool save);
+    void statePreviewDialog(bool save);
     void pauseContinue();
     bool isActivelyDrawing();
     void openFile();
@@ -49,7 +50,6 @@ class EmuMainWindow : public QMainWindow
     void createWidgets();
 
     static const size_t recent_menu_size = 10;
-    static const size_t state_items_size = 10;
 
     std::unique_ptr<CheatsDialog> cheats_dialog;
 

--- a/qt/src/ShortcutsPanel.ui
+++ b/qt/src/ShortcutsPanel.ui
@@ -128,6 +128,16 @@
      </row>
      <row>
       <property name="text">
+       <string>Increase Current Save Bank</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Decrease Current Save Bank</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
        <string>Quick Save Slot 0</string>
       </property>
      </row>
@@ -224,6 +234,76 @@
      <row>
       <property name="text">
        <string>Quick Load Slot 9</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 0</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 1</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 2</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 3</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 4</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 5</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 6</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 7</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 8</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Select Slot 9</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Save State with Preview</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Load State with Preview</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Save State to File</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Load State from File</string>
       </property>
      </row>
      <row>

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -88,6 +88,9 @@ void Snes9xController::init()
     Settings.ShowOverscan = false;
     Settings.InitialInfoStringTimeout = 120;
     Settings.SGB_BIOSPreference = 2;
+    /* Embed a screenshot in each snapshot so the save/load-with-preview
+     * dialog has something to show, as win32 does by default. */
+    Settings.SnapshotScreenshots = true;
 
     CPU.Flags = 0;
 
@@ -166,6 +169,8 @@ void Snes9xController::updateSettings(EmuConfig *config)
     // effective flag per game, so writing the effective one here was lost on
     // every ROM load.
     Settings.BlockInvalidVRAMAccessMaster = !config->allow_invalid_vram_access;
+
+    Settings.SnapshotScreenshots = config->snapshot_screenshots;
 
     Settings.SoundSync = config->speed_sync_method == EmuConfig::eSoundSync;
 
@@ -994,6 +999,11 @@ void Snes9xController::loadUndoState()
 std::string Snes9xController::getStateFolder()
 {
     return S9xGetDirectory(SNAPSHOT_DIR);
+}
+
+std::string Snes9xController::getStateFilename(int slot)
+{
+    return save_slot_path(slot).string();
 }
 
 bool Snes9xController::slotUsed(int slot)

--- a/qt/src/Snes9xController.hpp
+++ b/qt/src/Snes9xController.hpp
@@ -50,6 +50,7 @@ class Snes9xController
     std::string getContentFolder();
 
     std::string getStateFolder();
+    std::string getStateFilename(int slot);
     std::string config_folder;
     std::string sram_folder;
     std::string state_folder;

--- a/qt/src/StatePreviewDialog.cpp
+++ b/qt/src/StatePreviewDialog.cpp
@@ -1,0 +1,133 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "StatePreviewDialog.hpp"
+
+#include <QDialogButtonBox>
+#include <QFileInfo>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QImage>
+#include <QPixmap>
+
+#include "EmuConfig.hpp"
+
+#include "snes9x.h"
+#include "snapshot.h"
+#include "stream.h"
+
+/* Three quarters of the SNES resolution: big enough to recognize a scene,
+ * small enough that a row of five fits a normal screen. */
+static const int PREVIEW_WIDTH = 192;
+static const int PREVIEW_HEIGHT = 168;
+
+/* The screenshot stored in a snapshot is RGB565, which maps straight onto
+ * QImage::Format_RGB16.
+ *
+ * This opens the stream itself rather than calling S9xUnfreezeScreenshot,
+ * which reports missing or screenshot-less files through S9xMessage. Every
+ * empty slot in the grid would otherwise log twice on each refresh. */
+static QPixmap state_thumbnail(const std::string &filename)
+{
+    uint16 *image_buffer = nullptr;
+    int width = 0;
+    int height = 0;
+
+    STREAM stream = OPEN_STREAM(filename.c_str(), "rb");
+    if (!stream)
+        return {};
+
+    int result = S9xUnfreezeScreenshotFromStream(stream, &image_buffer, width, height);
+    CLOSE_STREAM(stream);
+
+    if (result != SUCCESS || !image_buffer || width < 1 || height < 1)
+    {
+        free(image_buffer);
+        return {};
+    }
+
+    QImage image((uchar *)image_buffer, width, height, width * 2,
+                 QImage::Format_RGB16);
+    auto pixmap = QPixmap::fromImage(
+        image.scaled(PREVIEW_WIDTH, PREVIEW_HEIGHT, Qt::IgnoreAspectRatio,
+                     Qt::SmoothTransformation));
+
+    free(image_buffer);
+
+    return pixmap;
+}
+
+StatePreviewDialog::StatePreviewDialog(EmuApplication *app_, QWidget *parent,
+                                       bool is_save)
+    : QDialog(parent), app(app_)
+{
+    setWindowTitle(is_save ? tr("Save with Preview") : tr("Load with Preview"));
+
+    auto layout = new QVBoxLayout(this);
+    auto grid = new QGridLayout();
+    layout->addLayout(grid);
+
+    for (int slot = 0; slot < EmuConfig::save_slots_per_bank; slot++)
+    {
+        auto button = new QToolButton(this);
+        button->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+        button->setIconSize(QSize(PREVIEW_WIDTH, PREVIEW_HEIGHT));
+        /* Keep the grid steady when a slot has no screenshot to show. */
+        button->setMinimumSize(PREVIEW_WIDTH + 16, PREVIEW_HEIGHT + 16);
+        connect(button, &QToolButton::clicked, this, [&, slot] {
+            picked = bank_combo->currentIndex() * EmuConfig::save_slots_per_bank + slot;
+            accept();
+        });
+
+        slot_buttons.push_back(button);
+
+        // Two rows of five, matching the win32 layout.
+        grid->addWidget(button, slot / 5, slot % 5);
+    }
+
+    auto bank_row = new QHBoxLayout();
+    bank_row->addWidget(new QLabel(tr("Bank:"), this));
+
+    bank_combo = new QComboBox(this);
+    for (int bank = 0; bank < EmuConfig::num_save_banks; bank++)
+        bank_combo->addItem(tr("Bank #%1").arg(bank));
+    bank_combo->setCurrentIndex(app->config->current_save_bank);
+    connect(bank_combo, &QComboBox::currentIndexChanged, this, [&] { refresh(); });
+
+    bank_row->addWidget(bank_combo);
+    bank_row->addStretch();
+    layout->addLayout(bank_row);
+
+    auto buttons = new QDialogButtonBox(QDialogButtonBox::Cancel, this);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(buttons);
+
+    refresh();
+}
+
+void StatePreviewDialog::refresh()
+{
+    int bank = bank_combo->currentIndex();
+    if (bank < 0)
+        bank = 0;
+
+    for (int slot = 0; slot < EmuConfig::save_slots_per_bank; slot++)
+    {
+        auto filename = app->getStateFilename(
+            bank * EmuConfig::save_slots_per_bank + slot);
+
+        slot_buttons[slot]->setIcon(QIcon(state_thumbnail(filename)));
+
+        QFileInfo info(QString::fromStdString(filename));
+        QString description = info.exists()
+            ? info.fileName() + "\n" +
+                  info.lastModified().toLocalTime().toString(Qt::TextDate)
+            : tr("Empty");
+
+        slot_buttons[slot]->setText(tr("Slot #%1").arg(slot) + "\n" + description);
+    }
+}

--- a/qt/src/StatePreviewDialog.hpp
+++ b/qt/src/StatePreviewDialog.hpp
@@ -1,0 +1,37 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#include <QDialog>
+#include <QComboBox>
+#include <QLabel>
+#include <QToolButton>
+#include <vector>
+
+#include "EmuApplication.hpp"
+
+/* win32-style save/load-with-preview picker: a grid of the selected bank's
+ * slots showing each snapshot's screenshot, plus a bank selector. */
+class StatePreviewDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+    StatePreviewDialog(EmuApplication *app, QWidget *parent, bool is_save);
+
+    /* Flat state index (bank * save_slots_per_bank + slot) that was picked,
+     * or -1 when the dialog was cancelled. */
+    int selection() const { return picked; }
+
+  private:
+    void refresh();
+
+    EmuApplication *app;
+    QComboBox *bank_combo;
+    std::vector<QToolButton *> slot_buttons;
+    int picked = -1;
+};


### PR DESCRIPTION
## Why

The Linux ports had a flat save state slot counter and no banks; win32 organizes save states as **10 banks of 10 slots** and can switch banks by hotkey. This closes that parity gap, plus the state hotkeys and the Save/Load-with-Preview dialog that were also win32-only.

The state file extension is now the flat index (`bank * 10 + slot`), so `.000`–`.099` mean the same thing in every port and states stay interchangeable with win32.

## Banks

- `current_save_bank` alongside the existing slot, persisted in the config.
- Slot +/− wraps **inside** the bank; new **bank +/−** hotkeys cycle banks.
- `File ▸ Save/Load State` becomes `Bank #N ▸ Slot #M` in both ports, so every menu action names exactly one file.
- The numbered quick save/load hotkeys are now **bank-relative**, as on win32. GTK intercepts `QuickSave000-009` (load was already intercepted) and Qt routes both to the UI handler, since the core's versions address absolute slots.
- GTK shows the quick save/load accelerators on the current bank's slot items, so the menu reflects which bank the hotkeys will hit.
- Old GTK configs holding a flat slot are migrated: slot 42 becomes bank 4, slot 2.

## Hotkeys that were missing from both ports

| win32 | added as |
| --- | --- |
| `BankPlus` / `BankMinus` | Increase/Decrease Current Save Bank |
| `SelectSave[0..9]` | Select Slot 0-9 — moves the current slot without saving or loading |
| `DialogSave` / `DialogLoad` | Save/Load with Preview |
| `SaveFileSelect` / `LoadFileSelect` | hotkeys for the plain state file chooser |

## Save/Load with Preview

New `gtk_state_preview_dialog` / `StatePreviewDialog`: a 2×5 grid of the selected bank's slots showing each snapshot's screenshot with its filename and timestamp, plus a bank selector. Reachable from the File menu as well as the hotkey. No core changes were needed — `S9xUnfreezeScreenshot` was already portable.

Two things this turned up:

- **`Settings.SnapshotScreenshots` was never enabled in either port.** Both only save/restore it around Run Ahead, so it sat at its zero-initialized `false` and *no state either port has ever written contains a screenshot* — previews came up blank. Now defaulted on with a config key, as win32 does. Pre-existing states stay blank until re-saved, since the screenshot is written at save time.
- The dialogs read previews via `S9xUnfreezeScreenshotFromStream` on a stream they open themselves. `S9xUnfreezeScreenshot` reports missing and screenshot-less files through `S9xMessage`, which printfs, so every empty slot in the grid logged twice on each refresh.

## Notes for review

- **Qt leaves the preview dialog hotkeys unbound** rather than taking win32's F11 / Shift+F11: F11 is already Qt's fullscreen toggle, and Qt registers bindings into a map where the first one wins, so one would have been silently shadowed. Qt binds bank +/− to Shift+F6 / Shift+F5, following its own F6/F5 slot pattern (win32 ships bank +/− unbound). GTK leaves all of these unbound, which is that port's convention for every emulator shortcut.
- **Enabling snapshot screenshots has two side effects, both matching win32:** states are larger and marginally slower to write, and rewind snapshots include the screenshot so a given rewind buffer holds fewer frames. Win32 strips screenshots only for Run Ahead, which both ports already mirror. Easy to change if we'd rather rewind stay lean.
- Bank/slot selection is now persisted in Qt (`[Operational] CurrentSaveSlot` / `CurrentSaveBank`). Qt previously forgot the slot on restart; win32 and GTK both remember it.
- No `.po` files are touched.

## Testing

Both ports build clean and start without warnings, criticals, or assertions. Verified programmatically after the binding-table changes: GTK's 78 emulator links match `NUM_EMU_LINKS`, all 102 `b_links` entries resolve to real widget IDs in `snes9x.ui`, the recomputed `b_breaks` land on group boundaries, and every `get_object` menu name exists; Qt's shortcut names, defaults, and UI rows all agree at 71. `snes9x.ui` passes `gtk-builder-tool validate`. The RGB565→RGB888 unpacking used for GTK thumbnails was unit-tested in isolation (channels isolate, endpoints exact).

The Qt preview dialog was confirmed working against a real save state. The GTK dialog is code-complete and built but has not been exercised on screen.
