### PR TITLE
qt/gtk: add Sound menu with channel toggles, mute, and settings shortcut

### DIFF
--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -20,7 +20,7 @@
 
 static Snes9xPreferences *preferences = nullptr;
 
-void snes9x_preferences_open(Snes9xWindow *window)
+void snes9x_preferences_open(Snes9xWindow *window, int page)
 {
     if (!preferences)
         preferences = new Snes9xPreferences(window->config);
@@ -30,6 +30,9 @@ void snes9x_preferences_open(Snes9xWindow *window)
     window->pause_from_focus_change ();
 
     preferences->window->set_transient_for(*window->window.get());
+
+    if (page >= 0)
+        preferences->get_object<Gtk::Notebook>("preferences_notebook")->set_current_page(page);
 
     config->joysticks.set_mode(JOY_MODE_GLOBAL);
     preferences->show();

--- a/gtk/src/gtk_preferences.h
+++ b/gtk/src/gtk_preferences.h
@@ -10,7 +10,7 @@
 #include "gtk_builder_window.h"
 
 void snes9x_preferences_create(Snes9xConfig *config);
-void snes9x_preferences_open(Snes9xWindow *window);
+void snes9x_preferences_open(Snes9xWindow *window, int page = -1);
 
 class Snes9xPreferences final : public GtkBuilderWindow
 {

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -365,6 +365,10 @@ void Snes9xWindow::connect_signals()
         }
     });
 
+    get_object<Gtk::MenuItem>("sound_settings_item")->signal_activate().connect([&] {
+        snes9x_preferences_open(this, 1); // the Sound tab
+    });
+
     get_object<Gtk::MenuItem>("sound_menu_item")->signal_activate().connect([this] {
         uint8_t mask = S9xGetSoundChannelMask();
         // Channels 1-4 drive both SPC voices 1-4 and the GB APU's CH1-CH4.

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -334,6 +334,54 @@ void Snes9xWindow::connect_signals()
         configure_widgets();
     });
 
+    // Sound Channels submenu, as on win32's Sound->Channels popup.
+    for (int i = 0; i < 8; i++)
+    {
+        std::string name = "sound_channel_" + std::to_string(i + 1) + "_item";
+        auto item = get_object<Gtk::CheckMenuItem>(name.c_str());
+        item->signal_toggled().connect([i, item] {
+            uint8_t mask = S9xGetSoundChannelMask();
+            uint8_t new_mask = item->get_active() ? mask | (1 << i)
+                                                  : mask & ~(1 << i);
+            // The menu-open sync also flips items; only apply real changes.
+            if (new_mask != mask)
+                S9xSetSoundChannelMask(new_mask);
+        });
+    }
+
+    get_object<Gtk::MenuItem>("enable_all_channels_item")->signal_activate().connect([] {
+        S9xSetSoundChannelMask(255);
+    });
+
+    // Same setting as the preferences dialog's "Mute sound output" checkbox.
+    auto mute_item = get_object<Gtk::CheckMenuItem>("mute_item");
+    mute_item->signal_toggled().connect([mute_item] {
+        bool active = mute_item->get_active();
+        // The menu-open sync also flips the item; only apply real changes.
+        if (gui_config->mute_sound != active)
+        {
+            gui_config->mute_sound = active;
+            S9xPortSoundReinit();
+        }
+    });
+
+    get_object<Gtk::MenuItem>("sound_menu_item")->signal_activate().connect([this] {
+        uint8_t mask = S9xGetSoundChannelMask();
+        // Channels 1-4 drive both SPC voices 1-4 and the GB APU's CH1-CH4.
+        // In BIOS-less GB mode the SPC isn't running, so 5-8 control
+        // nothing — grey them there, as on win32.
+        bool gb_only = Settings.SuperGameBoy && !Settings.SGB_BIOSModeActive;
+        for (int i = 0; i < 8; i++)
+        {
+            std::string name = "sound_channel_" + std::to_string(i + 1) + "_item";
+            auto item = get_object<Gtk::CheckMenuItem>(name.c_str());
+            item->set_active((mask & (1 << i)) != 0);
+            if (i >= 4)
+                item->set_sensitive(!gb_only);
+        }
+        get_object<Gtk::CheckMenuItem>("mute_item")->set_active(gui_config->mute_sound);
+    });
+
 #ifdef RETROACHIEVEMENTS_SUPPORT
     get_object<Gtk::CheckMenuItem>("ra_enabled_item")->set_active(gui_config->ra_enabled);
     get_object<Gtk::CheckMenuItem>("ra_enabled_item")->signal_toggled().connect([this] {

--- a/gtk/src/gtk_sound.cpp
+++ b/gtk/src/gtk_sound.cpp
@@ -286,14 +286,33 @@ bool8 S9xOpenSoundDevice()
 }
 
 /* This really shouldn't be in the port layer */
+static uint8_t sound_channel_mask = 255;
+
+static void apply_sound_channel_mask()
+{
+    S9xSetSoundControl(sound_channel_mask);
+    // Channels 1-4 double as the GB APU's CH1-CH4 (pulse A, pulse B, wave,
+    // noise) so the mask also works for GB/SGB games, as on win32.
+    S9xSGBSetSoundChannelMask(sound_channel_mask & 0x0f);
+}
+
+uint8_t S9xGetSoundChannelMask()
+{
+    return sound_channel_mask;
+}
+
+void S9xSetSoundChannelMask(uint8_t mask)
+{
+    sound_channel_mask = mask;
+    apply_sound_channel_mask();
+}
+
 void S9xToggleSoundChannel(int c)
 {
-    static int sound_switch = 255;
-
     if (c == 8)
-        sound_switch = 255;
+        sound_channel_mask = 255;
     else
-        sound_switch ^= 1 << c;
+        sound_channel_mask ^= 1 << c;
 
-    S9xSetSoundControl(sound_switch);
+    apply_sound_channel_mask();
 }

--- a/gtk/src/gtk_sound.h
+++ b/gtk/src/gtk_sound.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <cstdint>
 
 void S9xPortSoundInit();
 void S9xPortSoundDeinit();
@@ -16,3 +17,6 @@ void S9xSoundStop();
 void S9xSamplesAvailable(void *userdata);
 
 std::vector<std::string> S9xGetSoundDriverNames();
+
+uint8_t S9xGetSoundChannelMask();
+void S9xSetSoundChannelMask(uint8_t mask);

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1776,6 +1776,132 @@
               </object>
             </child>
             <child>
+              <object class="GtkMenuItem" id="sound_menu_item">
+                <property name="label" translatable="yes">_Sound</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="use_underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu" id="sound_menu_item_menu">
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkMenuItem" id="sound_channels_item">
+                        <property name="label" translatable="yes">_Channels</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_underline">True</property>
+                        <child type="submenu">
+                          <object class="GtkMenu" id="sound_channels_menu">
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sound_channel_1_item">
+                                <property name="label" translatable="yes">Channel _1</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sound_channel_2_item">
+                                <property name="label" translatable="yes">Channel _2</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sound_channel_3_item">
+                                <property name="label" translatable="yes">Channel _3</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sound_channel_4_item">
+                                <property name="label" translatable="yes">Channel _4</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sound_channel_5_item">
+                                <property name="label" translatable="yes">Channel _5</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sound_channel_6_item">
+                                <property name="label" translatable="yes">Channel _6</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sound_channel_7_item">
+                                <property name="label" translatable="yes">Channel _7</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sound_channel_8_item">
+                                <property name="label" translatable="yes">Channel _8</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSeparatorMenuItem" id="sound_channels_separator">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkMenuItem" id="enable_all_channels_item">
+                                <property name="label" translatable="yes">Enable All</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="mute_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="mute_item">
+                        <property name="label" translatable="yes">_Mute</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="GtkMenuItem" id="view_menu">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1897,6 +1897,20 @@
                         <property name="use_underline">True</property>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="sound_settings_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="sound_settings_item">
+                        <property name="label" translatable="yes">_Settings…</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/qt/src/EmuApplication.cpp
+++ b/qt/src/EmuApplication.cpp
@@ -781,6 +781,18 @@ void EmuApplication::loadUndoState()
     });
 }
 
+uint8_t EmuApplication::getSoundChannelMask()
+{
+    return S9xGetSoundChannelMask();
+}
+
+void EmuApplication::setSoundChannelMask(uint8_t mask)
+{
+    emu_thread->runOnThread([mask] {
+        S9xSetSoundChannelMask(mask);
+    });
+}
+
 std::string EmuApplication::getStateFolder()
 {
     return core->getStateFolder();

--- a/qt/src/EmuApplication.hpp
+++ b/qt/src/EmuApplication.hpp
@@ -82,6 +82,8 @@ struct EmuApplication
     std::string getStateFolder();
     std::string getStateFilename(int slot);
     void loadUndoState();
+    uint8_t getSoundChannelMask();
+    void setSoundChannelMask(uint8_t mask);
     void startGame();
     void startThread();
     void stopThread();

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -532,6 +532,60 @@ void EmuMainWindow::createWidgets()
 
     menuBar()->addMenu(emulation_menu);
 
+    // Sound Menu, mirroring win32's Sound menu (Channels popup + Mute).
+    auto sound_menu = new QMenu(tr("&Sound"));
+
+    auto channels_menu = new QMenu(tr("&Channels"));
+    std::array<QAction *, 8> channel_actions{};
+    for (int i = 0; i < 8; i++)
+    {
+        auto action = channels_menu->addAction(tr("Channel &%1").arg(i + 1));
+        action->setCheckable(true);
+        action->setChecked(true);
+        connect(action, &QAction::triggered, [&, i](bool checked) {
+            uint8_t mask = app->getSoundChannelMask();
+            if (checked)
+                mask |= 1 << i;
+            else
+                mask &= ~(1 << i);
+            app->setSoundChannelMask(mask);
+        });
+        channel_actions[i] = action;
+    }
+    channels_menu->addSeparator();
+    auto enable_all_channels_item = channels_menu->addAction(tr("Enable All"));
+    connect(enable_all_channels_item, &QAction::triggered, [&] {
+        app->setSoundChannelMask(255);
+    });
+    core_actions.push_back(sound_menu->addMenu(channels_menu));
+
+    sound_menu->addSeparator();
+
+    // Same setting as the Sound panel's "Mute all sound" checkbox.
+    auto mute_item = sound_menu->addAction(tr("&Mute"));
+    mute_item->setCheckable(true);
+    connect(mute_item, &QAction::triggered, [&](bool checked) {
+        app->config->mute_audio = checked;
+        app->updateSettings();
+    });
+
+    connect(sound_menu, &QMenu::aboutToShow, this, [this, channel_actions, mute_item] {
+        const uint8_t mask = app->getSoundChannelMask();
+        // Channels 1-4 drive both SPC voices 1-4 and the GB APU's CH1-CH4.
+        // In BIOS-less GB mode the SPC isn't running, so 5-8 control
+        // nothing — grey them there, as on win32.
+        const bool gb_only = Settings.SuperGameBoy && !Settings.SGB_BIOSModeActive;
+        for (int i = 0; i < 8; i++)
+        {
+            channel_actions[i]->setChecked(mask & (1 << i));
+            if (i >= 4)
+                channel_actions[i]->setEnabled(!gb_only);
+        }
+        mute_item->setChecked(app->config->mute_audio);
+    });
+
+    menuBar()->addMenu(sound_menu);
+
     // View Menu
     auto view_menu = new QMenu(tr("&View"));
 

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -569,6 +569,15 @@ void EmuMainWindow::createWidgets()
         app->updateSettings();
     });
 
+    sound_menu->addSeparator();
+
+    auto sound_settings_item = sound_menu->addAction(QIcon(iconset + "sound.svg"), tr("&Settings..."));
+    connect(sound_settings_item, &QAction::triggered, [&] {
+        if (!g_emu_settings_window)
+            g_emu_settings_window = new EmuSettingsWindow(this, app);
+        g_emu_settings_window->show(2); // the Sound panel
+    });
+
     connect(sound_menu, &QMenu::aboutToShow, this, [this, channel_actions, mute_item] {
         const uint8_t mask = app->getSoundChannelMask();
         // Channels 1-4 drive both SPC voices 1-4 and the GB APU's CH1-CH4.

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -660,16 +660,35 @@ bool S9xPollButton(unsigned int, bool *)
     return false;
 }
 
+static uint8_t sound_channel_mask = 255;
+
+static void applySoundChannelMask()
+{
+    S9xSetSoundControl(sound_channel_mask);
+    // Channels 1-4 double as the GB APU's CH1-CH4 (pulse A, pulse B, wave,
+    // noise) so the mask also works for GB/SGB games, as on win32.
+    S9xSGBSetSoundChannelMask(sound_channel_mask & 0x0f);
+}
+
+uint8_t S9xGetSoundChannelMask()
+{
+    return sound_channel_mask;
+}
+
+void S9xSetSoundChannelMask(uint8_t mask)
+{
+    sound_channel_mask = mask;
+    applySoundChannelMask();
+}
+
 void S9xToggleSoundChannel(int c)
 {
-    static int sound_switch = 255;
-
     if (c == 8)
-        sound_switch = 255;
+        sound_channel_mask = 255;
     else
-        sound_switch ^= 1 << c;
+        sound_channel_mask ^= 1 << c;
 
-    S9xSetSoundControl(sound_switch);
+    applySoundChannelMask();
 }
 
 std::string S9xGetFilenameInc(std::string e, enum s9x_getdirtype dirtype)

--- a/qt/src/Snes9xController.hpp
+++ b/qt/src/Snes9xController.hpp
@@ -85,4 +85,7 @@ class Snes9xController
 
 };
 
+uint8_t S9xGetSoundChannelMask();
+void S9xSetSoundChannelMask(uint8_t mask);
+
 #endif


### PR DESCRIPTION
## Summary

Adds a top-level **Sound** menu (next to Emulation) to both Linux frontends, bringing the per-channel sound toggles from the win32 Sound->Channels menu to Qt and GTK:

- **Channels** submenu with checkable **Channel 1–8** items and **Enable All**, mirroring the win32 popup. Checkmarks re-sync every time the menu opens.
  - Channels 1–4 also gate the GB APU's CH1–CH4 in GB/SGB games (low mask bits pushed to `S9xSGBSetSoundChannelMask`), as on win32.
  - Channels 5–8 are greyed out in BIOS-less GB mode, where the SPC isn't running.
- **Mute** check item, backed by the same setting as the sound preferences checkbox (`mute_audio` on Qt, `mute_sound` on GTK), so the menu and preferences stay in sync.
- **Settings…** item that opens the preferences dialog directly on the Sound page (GTK's `snes9x_preferences_open()` gains an optional page index, default keeps existing behavior).

The per-channel mask moves out of `S9xToggleSoundChannel`'s static local so the menus and the existing `SoundChannel0–7`/`SoundChannelsOn` hotkeys share one state. On Qt, menu writes hop to the emu thread via `runOnThread` like the other core-touching menu items. The channel state is session-only (resets to all-on at launch), matching win32.

## Testing

- Built both frontends (Qt 6.4.2 and GTK) cleanly.
- Verified live in both ports with a loaded ROM: menu placement, channel toggle round-trip (uncheck → recheck via Enable All), Mute round-trip including sync into the Sound preferences panel, and Settings… landing on the Sound page.