### PR TITLE
qt/gtk: add View->Color Correction dialog

### DIFF
--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -144,6 +144,11 @@ int Snes9xConfig::load_defaults()
     Settings.GBFrameBlend = 0;
     Settings.GBFrameBlendLayer = 0;
     Settings.GBFrameBlendAuto = true;
+    Settings.ColorCorrection = false;
+    Settings.AdjustmentsEnabled = false;
+    Settings.Gamma = 0;
+    Settings.Contrast = 0;
+    Settings.Saturation = 0;
     netplay_activated = false;
     netplay_server_up = false;
     netplay_is_server = false;
@@ -280,6 +285,11 @@ int Snes9xConfig::save_config_file()
     outint("BlendGBFrames", Settings.GBFrameBlend, "Game Boy frame-blend mode (Super Game Boy only): 0=off, 1=Simple Blend (mix each frame 50/50 with the previous, fixes flicker-based fake transparency e.g. ZAS), 2=LCD Blend (slow-decay LCD-style ghosting)");
     outint("BlendGBFramesLayer", Settings.GBFrameBlendLayer, "Which Game Boy layer the frame-blend applies to: 0=all, 1=background (keeps moving sprites crisp), 2=window, 3=sprites");
     outbool("BlendGBFramesAuto", Settings.GBFrameBlendAuto, "Auto-pick the GB frame-blend per game from a built-in known-flicker-game table at load (off for unlisted games); when false the manual mode/layer apply to every GB game");
+    outbool("ColorCorrection", Settings.ColorCorrection, "Enable accurate SNES color correction (simulates SNES CRT output)");
+    outbool("AdjustmentsEnabled", Settings.AdjustmentsEnabled, "Apply the Gamma/Contrast/Saturation adjustments below");
+    outint("Gamma", Settings.Gamma, "Gamma adjustment (-100..+100, 0 = no change)");
+    outint("Contrast", Settings.Contrast, "Contrast adjustment (-100..+100, 0 = no change)");
+    outint("Saturation", Settings.Saturation, "Saturation adjustment (-100..+100, 0 = no change)");
     
     
     // NTSC composite-video filter knobs; only used when the NTSC software filter
@@ -547,6 +557,11 @@ int Snes9xConfig::load_config_file()
     inint("BlendGBFrames", Settings.GBFrameBlend);
     inint("BlendGBFramesLayer", Settings.GBFrameBlendLayer);
     inbool("BlendGBFramesAuto", Settings.GBFrameBlendAuto);
+    inbool("ColorCorrection", Settings.ColorCorrection);
+    inbool("AdjustmentsEnabled", Settings.AdjustmentsEnabled);
+    inint("Gamma", Settings.Gamma);
+    inint("Contrast", Settings.Contrast);
+    inint("Saturation", Settings.Saturation);
 
     section = "NTSC";
     indouble("Hue", ntsc_setup.hue);
@@ -790,6 +805,9 @@ int Snes9xConfig::load_config_file()
     hires_effect = CLAMP(hires_effect, 0, 2);
     Settings.GBFrameBlend = CLAMP(Settings.GBFrameBlend, 0, 2);
     Settings.GBFrameBlendLayer = CLAMP(Settings.GBFrameBlendLayer, 0, 3);
+    Settings.Gamma = CLAMP(Settings.Gamma, -100, 100);
+    Settings.Contrast = CLAMP(Settings.Contrast, -100, 100);
+    Settings.Saturation = CLAMP(Settings.Saturation, -100, 100);
     Settings.DynamicRateLimit = CLAMP(Settings.DynamicRateLimit, 1, 1000);
     Settings.SuperFXClockMultiplier = CLAMP(Settings.SuperFXClockMultiplier, 50, 400);
     ntsc_scanline_intensity = MIN(ntsc_scanline_intensity, 4);

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -33,9 +33,11 @@
 #include "gtk_s9xwindow.h"
 
 #include "fmt/format.h"
+#include <array>
 #include <utility>
 
 #include "snes9x.h"
+#include "ppu.h"
 #include "controls.h"
 #include "movie.h"
 #include "apu/apu.h"
@@ -351,6 +353,10 @@ void Snes9xWindow::connect_signals()
 
     get_object<Gtk::MenuItem>("enable_all_channels_item")->signal_activate().connect([] {
         S9xSetSoundChannelMask(255);
+    });
+
+    get_object<Gtk::MenuItem>("color_correction_item")->signal_activate().connect([this] {
+        show_color_correction_dialog();
     });
 
     // Same setting as the preferences dialog's "Mute sound output" checkbox.
@@ -1197,6 +1203,105 @@ const char *markup = _(R"(<b>Information for %s</b>
     auto dialog = Gtk::MessageDialog(*window.get(), str_output, true, Gtk::MESSAGE_OTHER, Gtk::BUTTONS_CLOSE, true);
     dialog.set_title(_("File Information"));
     dialog.run();
+
+    unpause_from_focus_change();
+}
+
+/* win32's Video->Color Correction dialog: an accurate-SNES-colors toggle plus
+ * optional gamma/contrast/saturation adjustments. Values apply on OK. */
+void Snes9xWindow::show_color_correction_dialog()
+{
+    const int RESPONSE_DEFAULTS = 1;
+
+    pause_from_focus_change();
+
+    Gtk::Dialog dialog(_("Color Correction"), *window.get(), true);
+    dialog.add_button(_("Defaults"), RESPONSE_DEFAULTS);
+    dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
+    dialog.add_button(_("_OK"), Gtk::RESPONSE_OK);
+    dialog.set_default_response(Gtk::RESPONSE_OK);
+
+    auto vbox = Gtk::manage(new Gtk::VBox);
+    vbox->set_spacing(6);
+    vbox->set_border_width(12);
+
+    auto correction_check = Gtk::manage(new Gtk::CheckButton(_("Enable color correction (accurate SNES colors)")));
+    correction_check->set_active(Settings.ColorCorrection);
+    vbox->pack_start(*correction_check, Gtk::PACK_SHRINK);
+
+    auto frame = Gtk::manage(new Gtk::Frame(_("Adjustments")));
+    auto grid = Gtk::manage(new Gtk::Grid);
+    grid->set_row_spacing(6);
+    grid->set_column_spacing(12);
+    grid->set_border_width(12);
+
+    auto adjustments_check = Gtk::manage(new Gtk::CheckButton(_("Apply adjustments")));
+    adjustments_check->set_active(Settings.AdjustmentsEnabled);
+    grid->attach(*adjustments_check, 0, 0, 2, 1);
+
+    const std::pair<const char *, int> rows[] = {
+        { _("Gamma:"), Settings.Gamma },
+        { _("Contrast:"), Settings.Contrast },
+        { _("Saturation:"), Settings.Saturation },
+    };
+
+    std::array<Gtk::Scale *, 3> scales{};
+    for (int i = 0; i < 3; i++)
+    {
+        auto label = Gtk::manage(new Gtk::Label(rows[i].first));
+        label->set_halign(Gtk::ALIGN_END);
+
+        auto scale = Gtk::manage(new Gtk::Scale(
+            Gtk::Adjustment::create(rows[i].second, -100.0, 100.0, 1.0, 10.0, 0.0)));
+        scale->set_digits(0);
+        scale->set_value_pos(Gtk::POS_RIGHT);
+        scale->set_size_request(300, -1);
+        scale->set_hexpand(true);
+        scale->add_mark(0.0, Gtk::POS_BOTTOM, "");
+        scale->signal_format_value().connect([](double value) -> Glib::ustring {
+            int v = (int)value;
+            return (v > 0 ? "+" : "") + std::to_string(v);
+        });
+        scales[i] = scale;
+
+        grid->attach(*label, 0, i + 1, 1, 1);
+        grid->attach(*scale, 1, i + 1, 1, 1);
+    }
+
+    // Sliders mean nothing until "Apply adjustments" is on, as on win32.
+    auto sync_sensitive = [adjustments_check, scales] {
+        for (auto *scale : scales)
+            scale->set_sensitive(adjustments_check->get_active());
+    };
+    adjustments_check->signal_toggled().connect(sync_sensitive);
+    sync_sensitive();
+
+    frame->add(*grid);
+    vbox->pack_start(*frame, Gtk::PACK_SHRINK);
+
+    dialog.get_content_area()->pack_start(*vbox, Gtk::PACK_EXPAND_WIDGET);
+    dialog.show_all();
+
+    int result;
+    while ((result = dialog.run()) == RESPONSE_DEFAULTS)
+    {
+        correction_check->set_active(false);
+        adjustments_check->set_active(false);
+        for (auto *scale : scales)
+            scale->set_value(0.0);
+    }
+
+    if (result == Gtk::RESPONSE_OK)
+    {
+        Settings.ColorCorrection = correction_check->get_active();
+        Settings.AdjustmentsEnabled = adjustments_check->get_active();
+        Settings.Gamma = (int)scales[0]->get_value();
+        Settings.Contrast = (int)scales[1]->get_value();
+        Settings.Saturation = (int)scales[2]->get_value();
+        // The palette tables bake these in; rebuild them so the change shows.
+        if (config->rom_loaded)
+            S9xFixColourBrightness();
+    }
 
     unpause_from_focus_change();
 }

--- a/gtk/src/gtk_s9xwindow.h
+++ b/gtk/src/gtk_s9xwindow.h
@@ -58,6 +58,7 @@ class Snes9xWindow : public GtkBuilderWindow
     void open_multicart_dialog();
     void open_voicekun_dialog();
     void show_rom_info();
+    void show_color_correction_dialog();
 
     /* GTK-base-related functions */
     void show();

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -2062,6 +2062,20 @@
                         <signal name="activate" handler="on_fullscreen_item_activate" swapped="no"/>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="color_correction_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="color_correction_item">
+                        <property name="label" translatable="yes">_Color Correction…</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -308,6 +308,8 @@ list(APPEND QT_GUI_SOURCES
     src/CheatsDialog.cpp
     src/StatePreviewDialog.cpp
     src/StatePreviewDialog.hpp
+    src/ColorCorrectionDialog.cpp
+    src/ColorCorrectionDialog.hpp
     src/SoftwareScalers.cpp
     src/SoftwareFilters.cpp
     src/SoftwareFilters.hpp

--- a/qt/src/ColorCorrectionDialog.cpp
+++ b/qt/src/ColorCorrectionDialog.cpp
@@ -1,0 +1,116 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "ColorCorrectionDialog.hpp"
+#include "EmuConfig.hpp"
+
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+static QString adjustmentText(int value)
+{
+    return value > 0 ? QStringLiteral("+%1").arg(value) : QString::number(value);
+}
+
+ColorCorrectionDialog::ColorCorrectionDialog(EmuApplication *app, QWidget *parent)
+    : QDialog(parent), app(app)
+{
+    setWindowTitle(tr("Color Correction"));
+
+    auto layout = new QVBoxLayout(this);
+
+    color_correction_checkbox = new QCheckBox(tr("Enable color correction (accurate SNES colors)"));
+    layout->addWidget(color_correction_checkbox);
+
+    auto group = new QGroupBox(tr("Adjustments"));
+    auto grid = new QGridLayout(group);
+
+    adjustments_checkbox = new QCheckBox(tr("Apply adjustments"));
+    grid->addWidget(adjustments_checkbox, 0, 0, 1, 3);
+
+    const std::pair<QString, QSlider **> rows[] = {
+        { tr("Gamma:"), &gamma_slider },
+        { tr("Contrast:"), &contrast_slider },
+        { tr("Saturation:"), &saturation_slider },
+    };
+
+    int row = 1;
+    for (auto &[name, slider_ptr] : rows)
+    {
+        auto label = new QLabel(name);
+        label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+
+        auto slider = new QSlider(Qt::Horizontal);
+        slider->setRange(-100, 100);
+        slider->setTickPosition(QSlider::TicksBelow);
+        slider->setTickInterval(25);
+        slider->setMinimumWidth(300);
+        *slider_ptr = slider;
+
+        auto value_label = new QLabel(adjustmentText(0));
+        value_label->setAlignment(Qt::AlignCenter);
+        value_label->setMinimumWidth(value_label->fontMetrics().horizontalAdvance("+100 "));
+        connect(slider, &QSlider::valueChanged, value_label, [value_label](int value) {
+            value_label->setText(adjustmentText(value));
+        });
+
+        grid->addWidget(label, row, 0);
+        grid->addWidget(slider, row, 1);
+        grid->addWidget(value_label, row, 2);
+        row++;
+    }
+
+    // Sliders mean nothing until "Apply adjustments" is on, as on win32.
+    auto enable_sliders = [this](bool enabled) {
+        gamma_slider->setEnabled(enabled);
+        contrast_slider->setEnabled(enabled);
+        saturation_slider->setEnabled(enabled);
+    };
+    connect(adjustments_checkbox, &QCheckBox::toggled, this, enable_sliders);
+
+    layout->addWidget(group);
+
+    auto buttons = new QDialogButtonBox(QDialogButtonBox::RestoreDefaults |
+                                        QDialogButtonBox::Ok |
+                                        QDialogButtonBox::Cancel);
+    connect(buttons->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked,
+            this, &ColorCorrectionDialog::setDefaults);
+    connect(buttons, &QDialogButtonBox::accepted, this, &ColorCorrectionDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &ColorCorrectionDialog::reject);
+    layout->addWidget(buttons);
+
+    auto config = app->config.get();
+    color_correction_checkbox->setChecked(config->color_correction);
+    adjustments_checkbox->setChecked(config->color_adjustments_enabled);
+    gamma_slider->setValue(config->color_gamma);
+    contrast_slider->setValue(config->color_contrast);
+    saturation_slider->setValue(config->color_saturation);
+    enable_sliders(config->color_adjustments_enabled);
+}
+
+void ColorCorrectionDialog::setDefaults()
+{
+    color_correction_checkbox->setChecked(false);
+    adjustments_checkbox->setChecked(false);
+    gamma_slider->setValue(0);
+    contrast_slider->setValue(0);
+    saturation_slider->setValue(0);
+}
+
+void ColorCorrectionDialog::accept()
+{
+    auto config = app->config.get();
+    config->color_correction = color_correction_checkbox->isChecked();
+    config->color_adjustments_enabled = adjustments_checkbox->isChecked();
+    config->color_gamma = gamma_slider->value();
+    config->color_contrast = contrast_slider->value();
+    config->color_saturation = saturation_slider->value();
+    app->updateSettings();
+    QDialog::accept();
+}

--- a/qt/src/ColorCorrectionDialog.hpp
+++ b/qt/src/ColorCorrectionDialog.hpp
@@ -1,0 +1,35 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#include <QCheckBox>
+#include <QDialog>
+#include <QLabel>
+#include <QSlider>
+
+#include "EmuApplication.hpp"
+
+/* win32-style Video->Color Correction dialog: an accurate-SNES-colors toggle
+ * plus optional gamma/contrast/saturation adjustments. Values apply on OK. */
+class ColorCorrectionDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+    ColorCorrectionDialog(EmuApplication *app, QWidget *parent);
+
+  private:
+    void setDefaults();
+    void accept() override;
+
+    EmuApplication *app;
+    QCheckBox *color_correction_checkbox;
+    QCheckBox *adjustments_checkbox;
+    QSlider *gamma_slider;
+    QSlider *contrast_slider;
+    QSlider *saturation_slider;
+};

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -295,6 +295,12 @@ bool EmuConfig::setDefaults(int section)
         gb_frame_blend = eGBBlendOff;
         gb_frame_blend_layer = eGBBlendLayerAll;
         gb_frame_blend_auto = true;
+
+        color_correction = false;
+        color_adjustments_enabled = false;
+        color_gamma = 0;
+        color_contrast = 0;
+        color_saturation = 0;
     }
 
     if (section == -1 || section == 2)
@@ -556,6 +562,23 @@ void EmuConfig::config(const std::string &filename, bool write)
     Enum("BlendGBFrames", gb_frame_blend, { "Off", "SimpleBlend", "LCDBlend" }, "Game Boy frame-blend (Super Game Boy only): Off, SimpleBlend (fixes flicker fake-transparency), or LCDBlend (LCD-style ghosting)");
     Enum("BlendGBFramesLayer", gb_frame_blend_layer, { "All", "Background", "Window", "Sprites" }, "Which Game Boy layer the frame-blend applies to: All, Background, Window, or Sprites");
     Bool("BlendGBFramesAuto", gb_frame_blend_auto, "Auto-pick the GB frame-blend per game from a built-in known-flicker table");
+
+    Bool("ColorCorrection", color_correction, "Enable accurate SNES color correction (simulates SNES CRT output)");
+    Bool("AdjustmentsEnabled", color_adjustments_enabled, "Apply the gamma/contrast/saturation adjustments below");
+    Int("Gamma", color_gamma, "Gamma adjustment (-100..+100, 0 = no change)");
+    Int("Contrast", color_contrast, "Contrast adjustment (-100..+100, 0 = no change)");
+    Int("Saturation", color_saturation, "Saturation adjustment (-100..+100, 0 = no change)");
+
+    if (!write)
+    {
+        auto clamp_adjustment = [](int &v) {
+            if (v < -100) v = -100;
+            if (v > 100) v = 100;
+        };
+        clamp_adjustment(color_gamma);
+        clamp_adjustment(color_contrast);
+        clamp_adjustment(color_saturation);
+    }
     EndSection();
 
     BeginSection("Sound");

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -113,6 +113,12 @@ struct EmuConfig
     int gb_frame_blend_layer;
     bool gb_frame_blend_auto;
 
+    bool color_correction;
+    bool color_adjustments_enabled;
+    int color_gamma;
+    int color_contrast;
+    int color_saturation;
+
     // Sound
     std::string sound_driver;
     std::string sound_device;

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include "CheatsDialog.hpp"
+#include "ColorCorrectionDialog.hpp"
 #include "StatePreviewDialog.hpp"
 #include "EmuApplication.hpp"
 #include "EmuConfig.hpp"
@@ -616,6 +617,14 @@ void EmuMainWindow::createWidgets()
     view_menu->addAction(fullscreen_item);
     connect(fullscreen_item, &QAction::triggered, [&](bool checked) {
         toggleFullscreen();
+    });
+
+    view_menu->addSeparator();
+
+    auto color_correction_item = view_menu->addAction(tr("&Color Correction..."));
+    connect(color_correction_item, &QAction::triggered, [&] {
+        ColorCorrectionDialog dialog(app, this);
+        dialog.exec();
     });
 
     menuBar()->addMenu(view_menu);

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -11,6 +11,7 @@ namespace fs = std::filesystem;
 #include "apu/apu.h"
 #include "sgb/sgb.h"
 #include "gfx.h"
+#include "ppu.h"
 #include "snapshot.h"
 #include "controls.h"
 #include "cheats.h"
@@ -194,6 +195,25 @@ void Snes9xController::updateSettings(EmuConfig *config)
         };
         S9xSGBMixGainSPC = clamp_db(config->sgb_mix_gain_spc);
         S9xSGBMixGainGB  = clamp_db(config->sgb_mix_gain_gb);
+    }
+
+    // Color correction feeds the palette tables, so a change only shows up
+    // after S9xFixColourBrightness rebuilds them.
+    {
+        bool changed = Settings.ColorCorrection != (bool8)config->color_correction ||
+                       Settings.AdjustmentsEnabled != (bool8)config->color_adjustments_enabled ||
+                       Settings.Gamma != config->color_gamma ||
+                       Settings.Contrast != config->color_contrast ||
+                       Settings.Saturation != config->color_saturation;
+
+        Settings.ColorCorrection = config->color_correction;
+        Settings.AdjustmentsEnabled = config->color_adjustments_enabled;
+        Settings.Gamma = config->color_gamma;
+        Settings.Contrast = config->color_contrast;
+        Settings.Saturation = config->color_saturation;
+
+        if (changed && active)
+            S9xFixColourBrightness();
     }
 
     Settings.DynamicRateControl = config->dynamic_rate_control;


### PR DESCRIPTION
## Summary

Port win32's **Video → Color Correction** dialog to both Linux frontends, under the **View** menu (their equivalent of win32's Video menu). The core already applies these settings when building the palette (`S9xApplyColorAdjustments`); the Linux frontends just had no UI for them.

- Checkbox for accurate SNES color correction (CRT gamma curve), plus an **Adjustments** group with gamma/contrast/saturation sliders (−100..+100) that stay greyed out until "Apply adjustments" is checked, and a Defaults button — mirroring the win32 dialog. Values apply on OK via `S9xFixColourBrightness`.
- **Qt**: new `ColorCorrectionDialog` class; settings sync to the core through `Snes9xController::updateSettings`, which rebuilds the palette only when a value actually changed. Qt 6.2-compatible APIs only.
- **GTK**: dialog built in gtkmm from `Snes9xWindow::show_color_correction_dialog`, new menu item in `snes9x.ui`.
- Both frontends persist the settings with the same config key names as `wconfig.cpp` (`ColorCorrection`, `AdjustmentsEnabled`, `Gamma`, `Contrast`, `Saturation`), clamped to ±100 on load. (GTK's existing NTSC-filter keys of the same names live in a different section — no clash.)

## Testing

- Built snes9x-qt and snes9x-gtk; drove both GUIs under Xwayland with a SF2 ROM.
- Dialog renders and behaves like win32 in both: slider gating, "+N" value labels, Defaults, Cancel discards, OK applies.
- Contrast −100 flattens the live picture to uniform gray in both frontends; gamma +50 + correction visibly shifts the palette. (SF2's sky gradients survive because they use post-palette color math — same as win32, identical core path.)
- Values persist across dialog reopen and app restart in both conf files.