### PR TITLE
qt: make the SRAM autosave interval setting work

### DIFF
--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -389,6 +389,8 @@ bool EmuConfig::setDefaults(int section)
         patch_location = eROMDirectory;
         export_location = eROMDirectory;
         bios_location = eCustomDirectory;
+
+        sram_save_interval = 0;
     }
 
     return restart;

--- a/qt/src/FoldersPanel.cpp
+++ b/qt/src/FoldersPanel.cpp
@@ -14,6 +14,11 @@ FoldersPanel::FoldersPanel(EmuApplication *app_)
     connectEntry(comboBox_patch, lineEdit_patch, pushButton_patch, &app->config->patch_location, &app->config->patch_folder);
     connectEntry(comboBox_export, lineEdit_export, pushButton_export, &app->config->export_location, &app->config->export_folder);
     connectEntry(comboBox_bios, lineEdit_bios, pushButton_bios, &app->config->bios_location, &app->config->bios_folder);
+
+    connect(spinBox_sram_interval, &QSpinBox::valueChanged, [&](int value) {
+        app->config->sram_save_interval = value;
+        app->updateSettings();
+    });
 }
 
 void FoldersPanel::connectEntry(QComboBox *combo, QLineEdit *lineEdit, QPushButton *browse, int *location, std::string *folder)
@@ -33,6 +38,8 @@ void FoldersPanel::refreshData()
     refreshEntry(comboBox_patch, lineEdit_patch, pushButton_patch, &app->config->patch_location, &app->config->patch_folder);
     refreshEntry(comboBox_export, lineEdit_export, pushButton_export, &app->config->export_location, &app->config->export_folder);
     refreshEntry(comboBox_bios, lineEdit_bios, pushButton_bios, &app->config->bios_location, &app->config->bios_folder);
+
+    spinBox_sram_interval->setValue(app->config->sram_save_interval);
 }
 
 void FoldersPanel::refreshEntry(QComboBox *combo, QLineEdit *lineEdit, QPushButton *browse, int *location, std::string *folder)

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -287,6 +287,9 @@ void Snes9xController::updateSettings(EmuConfig *config)
             dest = src;
     };
 
+    // 0 disables the timer; the core then only writes SRAM on exit/reset.
+    Settings.AutoSaveDelay = config->sram_save_interval < 0 ? 0 : config->sram_save_interval;
+
     doFolder(config->sram_location, sram_folder, config->sram_folder, "sram");
     doFolder(config->state_location, state_folder, config->state_folder, "state");
     doFolder(config->cheat_location, cheat_folder, config->cheat_folder, "cheat");
@@ -861,7 +864,6 @@ void S9xCloseSnapshotFile(STREAM file)
 
 void S9xAutoSaveSRAM()
 {
-    printf("%s\n", S9xGetFilename(".srm", SRAM_DIR).c_str());
     Memory.SaveSRAM(S9xGetFilename(".srm", SRAM_DIR).c_str());
     S9xSaveCheatFile(S9xGetFilename(".cht", CHEAT_DIR));
 }


### PR DESCRIPTION
## Summary
Fixes the bug where the **Options → Files → "Save SRAM to disk every: N seconds"** setting in the Qt port neither persisted nor did anything. (GTK was checked and is wired correctly — this was Qt-only.)

The spinbox existed in `FoldersPanel.ui` but was orphaned at all three layers:

- `FoldersPanel.cpp` never connected the spinbox or loaded the stored value back into it, so the setting appeared to reset every time the dialog was reopened.
- `EmuConfig::setDefaults()` never initialized `sram_save_interval`, so an uninitialized value could be written to `SRAMSaveInterval` in the conf file.
- `Snes9xController::updateSettings()` never copied the value into `Settings.AutoSaveDelay`, which is what the core's autosave timer in `gfx.cpp` reads — so even a hand-edited conf value had no effect.

## Changes
- Connect `spinBox_sram_interval` to the config and refresh it when the panel is shown.
- Default `sram_save_interval` to 0 (save only on exit/reset), matching GTK and the core default.
- Apply the value to `Settings.AutoSaveDelay` in `updateSettings()`, clamping negatives to 0.
- Remove a leftover debug `printf` in `S9xAutoSaveSRAM()` that would print the .srm path on every periodic save now that the timer actually fires.

## Testing
- Built `snes9x-qt` successfully.
- Set an interval, closed/reopened the dialog — value persists; `SRAMSaveInterval` is written to the conf on exit; with a game that writes SRAM, the `.srm` mtime updates N seconds after an in-game save.