### PR TITLE
qt/gtk: add rumble support for LRG rumble carts

### DIFF
--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -101,6 +101,7 @@ int Snes9xConfig::load_defaults()
     num_threads = 2;
     mute_sound = false;
     mute_sound_turbo = false;
+    enable_rumble = true;
     fullscreen = false;
     ui_visible = true;
     default_esc_behavior = 1;
@@ -451,6 +452,7 @@ int Snes9xConfig::save_config_file()
     }
 
     outint("JoystickThreshold", joystick_threshold, "How far an analog stick/trigger must move to register as pressed (percent, 1-100)");
+    outbool("EnableRumble", enable_rumble, "on to pass rumble-cart motor effects (LRG SNES releases) to the port-1 gamepad");
 
     for (int i = 0; i < NUM_JOYPADS; i++)
     {
@@ -715,6 +717,7 @@ int Snes9xConfig::load_config_file()
     }
 
     inint("JoystickThreshold", joystick_threshold);
+    inbool("EnableRumble", enable_rumble);
 
     std::string buffer;
     for (int i = 0; i < NUM_JOYPADS; i++)

--- a/gtk/src/gtk_config.h
+++ b/gtk/src/gtk_config.h
@@ -183,6 +183,7 @@ class Snes9xConfig
 
     JoyDevices joysticks;
     int joystick_threshold;
+    bool enable_rumble;
 };
 
 std::string get_config_dir();

--- a/gtk/src/gtk_control.cpp
+++ b/gtk/src/gtk_control.cpp
@@ -634,6 +634,43 @@ void S9xProcessEvents(bool8 block)
     }
 }
 
+// LRG rumble dongle -> the SDL device holding SNES Port 1's bindings, as on
+// win32. Called once per emulated frame: the SDL effect's 120ms duration
+// outlives one refresh interval, so the motors keep running while the game
+// drives them and auto-stop if we go quiet (pause, ROM close). A single
+// zero-send stops them promptly when the magnitudes drop to zero.
+void S9xUpdateRumble()
+{
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+    static uint16 last_low = 0, last_high = 0;
+
+    uint8 l = 0, r = 0;
+    if (gui_config->enable_rumble && !Settings.Paused)
+        S9xGetRumble(l, r);
+    const uint16 low = l * 0x1111, high = r * 0x1111;
+
+    if (low || high || last_low || last_high)
+    {
+        // Joypad 1's bindings store the device as joynum + 1.
+        Binding *pad = (Binding *)&gui_config->pad[0];
+        unsigned int devnum = 0;
+        for (int i = 0; i < NUM_JOYPAD_LINKS && !devnum; i++)
+            if (pad[i].is_joy())
+                devnum = pad[i].get_device();
+
+        if (devnum)
+        {
+            for (auto &j : gui_config->joysticks)
+                if (j.second->joynum == (int) (devnum - 1) && j.second->filedes)
+                    SDL_JoystickRumble(j.second->filedes, low, high, 120);
+        }
+    }
+
+    last_low = low;
+    last_high = high;
+#endif
+}
+
 
 void S9xInitInputDevices()
 {

--- a/gtk/src/gtk_control.h
+++ b/gtk/src/gtk_control.h
@@ -106,6 +106,7 @@ typedef struct JoypadBinding
 
 bool S9xGrabJoysticks();
 void S9xReleaseJoysticks();
+void S9xUpdateRumble();
 int S9xCurrentSaveSlot();
 
 typedef struct JoyEvent

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -437,6 +437,8 @@ static void game_loop()
             S9xMainLoop();
         }
 
+        S9xUpdateRumble();
+
 #ifdef RETROACHIEVEMENTS_SUPPORT
         // Suspend achievement processing during netplay so remote players'
         // inputs can't earn unlocks on this account.

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -375,6 +375,14 @@ void Snes9xWindow::connect_signals()
         snes9x_preferences_open(this, 1); // the Sound tab
     });
 
+    // win32's Input->Enable Rumble (Shake): pass LRG rumble-cart motor
+    // effects to the port-1 gamepad.
+    auto rumble_item = get_object<Gtk::CheckMenuItem>("enable_rumble_item");
+    rumble_item->set_active(gui_config->enable_rumble);
+    rumble_item->signal_toggled().connect([rumble_item] {
+        gui_config->enable_rumble = rumble_item->get_active();
+    });
+
     get_object<Gtk::MenuItem>("sound_menu_item")->signal_activate().connect([this] {
         uint8_t mask = S9xGetSoundChannelMask();
         // Channels 1-4 drive both SPC voices 1-4 and the GB APU's CH1-CH4.

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -2212,6 +2212,14 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkCheckMenuItem" id="enable_rumble_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Enable _Rumble (Shake)</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem" id="separator6">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/qt/src/EmuApplication.cpp
+++ b/qt/src/EmuApplication.cpp
@@ -13,12 +13,14 @@
 #include <QScreen>
 #include <QThread>
 #include <QStyleHints>
+#include <chrono>
 #include <thread>
 
+#include "snes9x.h"
+#include "controls.h"
 #ifdef RETROACHIEVEMENTS_SUPPORT
 #include "RAIntegrationQt.hpp"
 #include "retroachievements.h"
-#include "snes9x.h"
 #include "display.h"
 #endif
 #ifdef KAILLERA_SUPPORT
@@ -681,6 +683,54 @@ void EmuApplication::pollJoysticks()
     }
 }
 
+// LRG rumble dongle -> the SDL device holding SNES Port 1's bindings, as on
+// win32. The motor magnitudes are plain uint8 snapshots written by the core on
+// the emu thread; a stale read here only delays the motor by one poll.
+// SDL effects have a finite duration, so refresh while active; one zero-send
+// stops the motors when the game goes quiet.
+void EmuApplication::updateRumble()
+{
+    static uint16_t last_low = 0, last_high = 0;
+    static std::chrono::steady_clock::time_point last_send;
+
+    uint8_t l = 0, r = 0;
+    if (config->enable_rumble && !isPaused())
+        S9xGetRumble(l, r);
+    const uint16_t low = l * 0x1111, high = r * 0x1111;
+
+    auto now = std::chrono::steady_clock::now();
+    const bool changed = (low != last_low || high != last_high);
+    const bool refresh = (low || high) &&
+                         (now - last_send >= std::chrono::milliseconds(50));
+    if (changed || refresh)
+    {
+        int device = -1;
+        for (auto &b : config->binding.controller[0].buttons)
+        {
+            if (b.type == EmuBinding::Joystick)
+            {
+                device = b.guid;
+                break;
+            }
+        }
+
+        for (auto &d : input_manager->devices)
+        {
+            if (d.second.index != device)
+                continue;
+            // 120ms outlives the refresh interval; auto-stops if we go quiet.
+            if (d.second.gamepad)
+                SDL_RumbleGamepad(d.second.gamepad, low, high, 120);
+            else if (d.second.joystick)
+                SDL_RumbleJoystick(d.second.joystick, low, high, 120);
+        }
+        last_send = now;
+    }
+
+    last_low = low;
+    last_high = high;
+}
+
 void EmuApplication::reportPointer(int x, int y)
 {
     emu_thread->runOnThread([&, x, y] {
@@ -701,7 +751,10 @@ void EmuApplication::startInputTimer()
     poll_input_timer->setTimerType(Qt::TimerType::PreciseTimer);
     poll_input_timer->setInterval(1);
     poll_input_timer->setSingleShot(false);
-    poll_input_timer->callOnTimeout([&] { pollJoysticks(); });
+    poll_input_timer->callOnTimeout([&] {
+        pollJoysticks();
+        updateRumble();
+    });
     poll_input_timer->start();
 }
 

--- a/qt/src/EmuApplication.hpp
+++ b/qt/src/EmuApplication.hpp
@@ -62,6 +62,7 @@ struct EmuApplication
     void reportBinding(EmuBinding b, bool active);
     void startInputTimer();
     void pollJoysticks();
+    void updateRumble();
     void reportPointer(int x, int y);
     void reportMouseButton(int button, bool pressed);
     void restartAudio();

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -352,6 +352,7 @@ bool EmuConfig::setDefaults(int section)
     if (section == -1 || section == 4)
     {
         automap_gamepads = true;
+        enable_rumble = true;
         // Controllers
         port_configuration = 0;
         memset(binding.controller, 0, sizeof(binding.controller));
@@ -649,6 +650,7 @@ void EmuConfig::config(const std::string &filename, bool write)
 
     BeginSection("Ports");
     Bool("AutomapGamepads", automap_gamepads, "Automatically map newly connected gamepads to a sensible default layout");
+    Bool("EnableRumble", enable_rumble, "on to pass rumble-cart motor effects (LRG SNES releases) to the port-1 gamepad");
     Enum("PortConfiguration", port_configuration, { "OneController", "TwoControllers", "Mouse", "SuperScope", "Multitap" }, "What is plugged into the console's controller ports: OneController, TwoControllers, Mouse, SuperScope, or Multitap");
     EndSection();
 

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -244,6 +244,7 @@ struct EmuConfig
     static const int num_save_banks = 10;
 
     bool automap_gamepads;
+    bool enable_rumble;
 
     struct
     {

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -668,6 +668,17 @@ void EmuMainWindow::createWidgets()
     options_menu->addAction(shader_settings_item);
     updateShaderSettingsItem();
 
+    options_menu->addSeparator();
+
+    // win32's Input->Enable Rumble (Shake): pass LRG rumble-cart motor
+    // effects to the port-1 gamepad.
+    auto rumble_item = options_menu->addAction(tr("Enable &Rumble (Shake)"));
+    rumble_item->setCheckable(true);
+    rumble_item->setChecked(app->config->enable_rumble);
+    QObject::connect(rumble_item, &QAction::triggered, [&](bool checked) {
+        app->config->enable_rumble = checked;
+    });
+
     menuBar()->addMenu(options_menu);
 
 #ifdef RETROACHIEVEMENTS_SUPPORT


### PR DESCRIPTION
Brings win32's **Input → Enable Rumble (Shake)** feature to the Qt and GTK ports.

## What
- Pass the core's LRG rumble-dongle motor magnitudes (`S9xGetRumble()`) to the SDL device holding SNES Port 1's bindings, mirroring win32's behavior exactly: magnitudes scaled by `0x1111`, 120ms SDL effects refreshed while active, one zero-send when the motors go quiet.
- New checkable **Options → Enable Rumble (Shake)** menu item in both ports, default on (matching win32's `Input:EnableRumble`).

## Port details
- **Qt**: `EmuApplication::updateRumble()` runs off the existing 1ms input-poll timer, throttled to a 50ms refresh; works with both `SDL_Gamepad` and plain `SDL_Joystick` devices. Setting persisted as `Ports::EnableRumble`.
- **GTK**: new `S9xUpdateRumble()` in `gtk_control.cpp`, called once per emulated frame from `game_loop()`; uses `SDL_JoystickRumble` guarded for SDL ≥ 2.0.9. Setting persisted as `Input::EnableRumble`, the same section win32 uses.

## Super FX 3
The LRG 2026 FX3 re-releases (Doom, Star Fox — ROM types $17/$18) already ran on Linux: chip detection and emulation are entirely core-side (`fxemu`/`fxinst`/`memmap`), so this PR only adds the missing rumble pass-through. GB cart rumble (MBC5/MBC7 under SGB) remains intentionally unwired, as on win32.

Both ports build cleanly (`super-snes9x-qt`, `super-snes9x-gtk`).