### PR TITLE
libretro: don't strip the ROM extension twice

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -83,6 +83,11 @@ const int MAX_SNES_WIDTH_NTSC = ((SNES_NTSC_OUT_WIDTH(256) + 3) / 4) * 4;
 static bool show_lightgun_settings = true;
 static bool show_advanced_av_settings = true;
 
+// Keep the extension: this becomes Memory.ROMFilename, and every consumer
+// (S9xGetFilename for MSU-1/.cht/.rtc/soft patches, S9xMSU1ROMExists) runs
+// splitpath on it to swap in its own extension. Stripping it here made
+// splitpath take the last '.' inside the name as the extension, so a ROM
+// called "Super Mario Bros. (USA).sfc" looked for "Super Mario Bros-1.pcm".
 static void extract_basename(char *buf, const char *path, size_t size)
 {
     const char *base = strrchr(path, '/');
@@ -96,10 +101,6 @@ static void extract_basename(char *buf, const char *path, size_t size)
 
     strncpy(buf, base, size - 1);
     buf[size - 1] = '\0';
-
-    char *ext = strrchr(buf, '.');
-    if (ext)
-        *ext = '\0';
 }
 
 static void extract_directory(char *buf, const char *path, size_t size)


### PR DESCRIPTION
Fixes the MSU-1 failure reported in #204, where the libretro core ignores MSU-1 audio for any ROM with a period in its filename.

## The bug

The extension is stripped twice.

`extract_basename` (`libretro/libretro.cpp`) chopped everything after the last `.` before handing the name to `LoadROMMem` as `Memory.ROMFilename`. `S9xGetFilename` (`fscompat.cpp`) then ran `splitpath` on it and stripped an "extension" a second time — but by that point the only `.` left was one inside the name itself:

```
content path : /roms/Super Mario Bros. (USA).sfc
ROMFilename  : Super Mario Bros. (USA)      <- extract_basename
splitpath    : stem "Super Mario Bros", ext ". (USA)"
MSU-1 opens  : /roms/Super Mario Bros-1.pcm  <- wrong, no such file
```

MSU-1 found nothing and stayed silent. Renaming the ROM to drop the period works around it, which is what @Piloto40 observed in #204.

The `[MSU-1 v1.2]` version tag that most MSU-1 hack distributions ship with trips the same path, so this hit more people than just those with `Bros.` in a filename.

## Why libretro only

Standalone builds set `ROMFilename` to the full path *with* its real extension, so `splitpath` strips the right thing. The libretro core always takes the mangled path because `need_fullpath` is `false` — the `Memory.LoadROM(game->path)` branch that would have preserved the full path is never reached.

## Beyond MSU-1

The same mangled stem was used for `.cht` cheat files, `.rtc` clock saves, and `.ips`/`.bps`/`.ups` soft patches, all of which silently missed their files for period-named ROMs. `S9xMSU1ROMExists` also checks `splitpath(ROMFilename).ext_is(".msu1")`, which could never be true in libretro because the extension was always gone by then.

## The fix

Keep the extension in `extract_basename`. Every consumer of `ROMFilename` either runs `splitpath` itself or finds the directory by looking for a slash, so they all expect it to be there.

## Verification

Exercised the real `fscompat.cpp` `splitpath`/`makepath` against the fixed basename logic:

```
/roms/Super Mario Bros. (USA).sfc         ->  /roms/Super Mario Bros. (USA)-1.pcm
/roms/Zelda ... [MSU-1 v1.2].sfc          ->  /roms/Zelda ... [MSU-1 v1.2]-1.pcm
/roms/Super Mario Bros (USA).sfc          ->  /roms/Super Mario Bros (USA)-1.pcm
/roms/plain.smc                           ->  /roms/plain-1.pcm
```

The last two are the cases that already worked; they are unchanged. `libretro/supersnes9x_libretro.so` builds and links.

## Upstream

`extract_basename` is inherited from snes9x unchanged, so upstream has the identical bug. That matches @elseniorx1989 reporting the same failure on the stock Snes9x core in #204, and this fix applies there as-is.