### PR TITLE
retroachievements: fix win32 user agent reported as "S/1.63"

### DIFF
--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -772,8 +772,10 @@ int Snes9xConfig::load_config_file()
     if (default_esc_behavior != ESC_TOGGLE_MENUBAR)
         fullscreen = false;
 
-    // The RA-registered emulator name must be non-empty (drives the User-Agent).
-    if (ra_emulator_name.empty())
+    // The client name drives the RetroAchievements User-Agent, and only the
+    // registered "SuperSnes9x" identity is accepted there, so pin it on load
+    // rather than trusting whatever a stale or hand-edited config holds.
+    if (ra_emulator_name != "SuperSnes9x")
         ra_emulator_name = "SuperSnes9x";
 
 #ifdef USE_HQ2X

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -711,6 +711,12 @@ void EmuConfig::config(const std::string &filename, bool write)
     String("EmulatorName", ra_emulator_name, "Client name reported to the RetroAchievements server");
     EndSection();
 
+    // The client name drives the RetroAchievements User-Agent, and only the
+    // registered "SuperSnes9x" identity is accepted there, so pin it on load
+    // rather than trusting whatever a stale or hand-edited config holds.
+    if (!write && ra_emulator_name != "SuperSnes9x")
+        ra_emulator_name = "SuperSnes9x";
+
     if (write)
     {
         ConfigFile::SetProgramName("SuperSnes9x");

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -732,8 +732,6 @@ void EmuMainWindow::createWidgets()
         RA_SetHardcoreEnabled(checked);
     });
 
-    app->config->ra_emulator_name = "SuperSnes9x";
-
     auto ra_ua_action = ra_menu->addAction(QString("User Agent: SuperSnes9x/%1").arg(VERSION));
     ra_ua_action->setCheckable(true);
     ra_ua_action->setChecked(true);

--- a/win32/wconfig.cpp
+++ b/win32/wconfig.cpp
@@ -385,7 +385,7 @@ static const char* keyToAlternateString [256] =
 // and to allow us to manage custom types of config items, such as virtual key codes represented as strings
 
 enum ConfigItemType	{
-	CIT_BOOL, CIT_INT, CIT_UINT, CIT_STRING, CIT_INVBOOL, CIT_BOOLONOFF, CIT_INVBOOLONOFF, CIT_VKEY, CIT_VKEYMOD
+	CIT_BOOL, CIT_INT, CIT_UINT, CIT_STRING, CIT_ASTRING, CIT_INVBOOL, CIT_BOOLONOFF, CIT_INVBOOLONOFF, CIT_VKEY, CIT_VKEYMOD
 };
 
 struct ConfigItem
@@ -426,6 +426,14 @@ struct ConfigItem
 			case CIT_STRING:
 				lstrcpyn((TCHAR*)addr, _tFromChar(conf.GetString(name, reinterpret_cast<const char*>(def))), size-1);
 				((TCHAR*)addr)[size-1] = TEXT('\0');
+				break;
+			case CIT_ASTRING:
+				{
+					// narrow char[] target: never widen, and treat size as a byte count
+					const char* aval = conf.GetString(name, reinterpret_cast<const char*>(def));
+					lstrcpynA((char*)addr, aval ? aval : "", size);
+					((char*)addr)[size-1] = '\0';
+				}
 				break;
 			case CIT_INVBOOL:
 			case CIT_INVBOOLONOFF:
@@ -533,6 +541,10 @@ struct ConfigItem
 				if((TCHAR*)addr)
 					conf.SetString(name, std::string(_tToChar((TCHAR*)addr)), comment);
 				break;
+			case CIT_ASTRING:
+				if((char*)addr)
+					conf.SetString(name, std::string((const char*)addr), comment);
+				break;
 			case CIT_INVBOOL:
 				if(size	== 1) conf.SetBool(name, 0==(*(uint8 *)addr), "TRUE","FALSE", comment);
 				if(size	== 2) conf.SetBool(name, 0==(*(uint16*)addr), "TRUE","FALSE", comment);
@@ -602,6 +614,9 @@ std::vector<ConfigItem> configItems;
 #define AddInvBool2C(name, var, def, comment) AddItemC(name,var,def,comment,CIT_INVBOOLONOFF)
 #define AddStringC(name, var, buflen, def, comment) configItems.push_back(ConfigItem((const char*)(CATEGORY "::" name), (void*)var, buflen, (void*)(pint)def, (const char*)comment, CIT_STRING))
 #define AddString(name, var, buflen, def) AddStringC(name, var, buflen, def, "")
+// For char[] members (not TCHAR[]): buflen is a byte count and the value is
+// stored as-is, without the UTF-8 -> UTF-16 conversion CIT_STRING applies.
+#define AddAStringC(name, var, buflen, def, comment) configItems.push_back(ConfigItem((const char*)(CATEGORY "::" name), (void*)var, buflen, (void*)(pint)def, (const char*)comment, CIT_ASTRING))
 
 static char filterString [1024], filterString2 [1024], snapVerString [256];
 static bool niceAlignment, showComments, readOnlyConfig;
@@ -743,9 +758,21 @@ void WinPostLoad(ConfigFile& conf)
 	ConfigFile::SetTimeSort(configSort==1);
 
 #ifdef RETROACHIEVEMENTS_SUPPORT
-	// Migration: RASnes9x/1.2 user agent was removed — force default
-	if (strcmp(GUI.RAEmulatorName, "RASnes9x") == 0)
+	// Repair configs written by builds that stored these char[] fields through
+	// CIT_STRING, which widened them to UTF-16: reading them back narrow stopped
+	// at the first embedded NUL, so "SuperSnes9x" was saved back out as "S" and
+	// the user agent went out as "S/1.63". The user agent is always SuperSnes9x,
+	// so anything else here is corrupt or the retired RASnes9x/1.2 identity.
+	if (strcmp(GUI.RAEmulatorName, "SuperSnes9x") != 0)
 		strcpy(GUI.RAEmulatorName, "SuperSnes9x");
+
+	// A token truncated the same way can never authenticate — drop the saved
+	// credentials so the user is prompted to log in again.
+	if (GUI.RAApiToken[0] && strlen(GUI.RAApiToken) < 8)
+	{
+		GUI.RAApiToken[0] = '\0';
+		GUI.RAUsername[0] = '\0';
+	}
 #endif
 
 	WinPostSave(conf);
@@ -965,7 +992,7 @@ void WinRegisterConfigItems()
 #ifdef NETPLAY_SUPPORT
 #define	CATEGORY "Netplay"
 	AddUInt("Port", Settings.Port, NP_DEFAULT_PORT);
-	AddString("Server", Settings.ServerName, 128, Settings.ServerName);
+	AddAStringC("Server", Settings.ServerName, 128, Settings.ServerName, "");
 	AddBool2("SyncByReset", NPServer.SyncByReset, true);
 	AddBool2("SendROMImageOnConnect", NPServer.SendROMImageOnConnect, false);
 	AddUInt("MaxFrameSkip", NetPlay.MaxFrameSkip, 10);
@@ -1029,7 +1056,7 @@ void WinRegisterConfigItems()
 #undef ADDXTB3
 #undef ADDXTBALL
 	// SDL device GUIDs for stable controller identification across sessions
-#define ADDGUID(n) AddStringC("Joypad" #n ":DeviceGUID", GUI.JoypadGUID[n-1], 64, "", "SDL device GUID for controller identity persistence")
+#define ADDGUID(n) AddAStringC("Joypad" #n ":DeviceGUID", GUI.JoypadGUID[n-1], 64, "", "SDL device GUID for controller identity persistence")
 	ADDGUID(1); ADDGUID(2); ADDGUID(3); ADDGUID(4); ADDGUID(5); ADDGUID(6); ADDGUID(7); ADDGUID(8);
 #undef ADDGUID
 	AddBool2C("Input:Background", GUI.BackgroundInput, false, "on to detect game keypresses and hotkeys while window is inactive, if PauseWhenInactive = FALSE.");
@@ -1120,9 +1147,9 @@ void WinRegisterConfigItems()
     AddBoolC("Enabled", GUI.RAEnabled, false, "true to enable RetroAchievements support");
     AddBoolC("HardcoreMode", GUI.RAHardcoreMode, false, "true to enable hardcore mode (disables save state loading, rewind, cheats)");
     AddBoolC("ShowChallengeImages", GUI.RAShowChallengeImages, true, "true to show active challenge achievements as on-screen badge images, false to show them as text toasts");
-    AddStringC("Username", GUI.RAUsername, 256, "", "RetroAchievements username");
-    AddStringC("ApiToken", GUI.RAApiToken, 256, "", "RetroAchievements API token (set automatically on login)");
-    AddStringC("EmulatorName", GUI.RAEmulatorName, 64, "SuperSnes9x", "Emulator name sent to RetroAchievements");
+    AddAStringC("Username", GUI.RAUsername, 256, "", "RetroAchievements username");
+    AddAStringC("ApiToken", GUI.RAApiToken, 256, "", "RetroAchievements API token (set automatically on login)");
+    AddAStringC("EmulatorName", GUI.RAEmulatorName, 64, "SuperSnes9x", "Emulator name sent to RetroAchievements");
 #undef CATEGORY
 #endif
 }


### PR DESCRIPTION
## The bug

A user's RetroAchievements session history showed the client as `S 1.63` instead of `SuperSnes9x 1.63` — the emulator was sending `S/1.63` as its HTTP User-Agent.

The win32 config loader assumed every `CIT_STRING` target was a `TCHAR` array (`win32/wconfig.cpp:426-429`):

```cpp
case CIT_STRING:
    lstrcpyn((TCHAR*)addr, _tFromChar(conf.GetString(name, (const char*)def)), size-1);
    ((TCHAR*)addr)[size-1] = TEXT('\0');
```

`snes9xw.vcxproj` sets `<CharacterSet>Unicode</CharacterSet>`, so `_tFromChar` is `Utf8ToWide` and `size` is a `TCHAR` count. Five registered targets are actually `char[]`:

| Field | Declared |
|---|---|
| `GUI.RAEmulatorName` | `char[64]` |
| `GUI.RAUsername` | `char[256]` |
| `GUI.RAApiToken` | `char[256]` |
| `GUI.JoypadGUID[8]` | `char[64]` |
| `Settings.ServerName` | `char[128]` |

These got filled with UTF-16 (`'S' 00 'u' 00 …`) and read back narrow, stopping at the first embedded NUL. `RAEmulatorName[0]` was `'S'` — non-zero, so the `"SuperSnes9x"` fallback in `ra_http_thread` never fired. Saving folded the truncation back into `super-snes9x.conf`, so it stuck.

The same fields also wrote their terminator at `(buflen-1) * sizeof(TCHAR)` — byte offset 126 of a 64-byte buffer for `RAEmulatorName`, past the end of the `GUI` struct for `RAApiToken`. This happened on every config load.

Beyond the User-Agent, this silently broke saved RA logins (a one-character token can never authenticate), SDL controller identity persistence, and the NetPlay server name.

## The fix

- **`CIT_ASTRING`** for narrow `char[]` members: copies bytes verbatim via `lstrcpynA`, treats `buflen` as a byte count. All five targets moved onto it via a new `AddAStringC`.
- **Config repair on load** (`WinPostLoad`): pins `EmulatorName` to `SuperSnes9x` for any unexpected value (this subsumes the old `RASnes9x` migration, which itself never fired since it `strcmp`'d a widened buffer), and clears an implausibly short `ApiToken` plus username so users get a login prompt rather than a dead token.
- Joypad GUIDs need no repair — `SDLInput.cpp:44,70` use a full `_stricmp`, so a truncated GUID simply fails to match and is rewritten on the next save.

## gtk / qt

Neither had the bug — both use `std::string` end to end. But qt pinned the name from a stray assignment buried in menu construction (`EmuMainWindow.cpp:735`) and was correct only because `main.cpp:109` builds the window before `main.cpp:132` calls `RA_AttemptLogin`; reordering those would have leaked a stale config value into the login request. gtk guarded only against an empty value.

Both now pin the name in the config load path instead. `ra_username` / `ra_api_token` are untouched there, so valid saved logins keep working.

## Testing

- gtk and qt build and link clean; only pre-existing warnings (`snes_ntsc.h` enum arithmetic, `retroachievements.cpp:736` `fread`).
- End-to-end on both: planted `EmulatorName = S` in a config under a sandboxed `XDG_CONFIG_HOME`, ran the real binary, and confirmed it was repaired to `SuperSnes9x` and persisted.
- The new `CIT_ASTRING` switch cases pass an isolated MinGW `-municode -Wall -Wextra` check, and a simulation of both code paths reproduces `S/1.63` before and `SuperSnes9x/1.63` after.

**Not yet verified:** `win32/wconfig.cpp` has not been compiled — MinGW can't build it here, rejecting the pre-existing MSVC-only `std::ifstream(FILE*)` at `win32/_tfwopen.h:99` before reaching the change. Needs an MSVC build, plus a runtime check that a config containing `EmulatorName = S` comes back as `SuperSnes9x`.