### PR TITLE
gfx: don't skip frames mid-interlace, half the scanlines go black

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -601,6 +601,18 @@ static void S9xApplyMidLineRaster (void)
 
 void S9xStartScreenRefresh (void)
 {
+	// Interlaced output is drawn one field per frame: this frame fills the
+	// even rows of the doubled-height buffer, the next one fills the odd
+	// rows. Dropping a frame therefore leaves its field unwritten, and a
+	// steady every-other-frame skip never renders the second field at all -
+	// half the scanlines stay black for as long as the interlaced screen is
+	// up (SHVC/SNSP Aging's hires BG mode screens, PSS-61's intro). Frame
+	// skipping is driven by how fast the host can present, so this only
+	// shows on machines slow enough for auto-frameskip to engage.
+	// Never drop a frame while an interlaced field pair is in flight.
+	if (!IPPU.RenderThisFrame && !Settings.InRunAhead && (IPPU.Interlace || GFX.DoInterlace))
+		IPPU.RenderThisFrame = TRUE;
+
 	if (GFX.DoInterlace)
 		GFX.DoInterlace--;
 


### PR DESCRIPTION
Fixes #249 — "Background rendering is partially broken with Intel Iris Xe graphics".

## The GPU is incidental

The affected screens are all **512x448 (hires + interlace)**. PPU state dumped at one of them:

```
mode=6 CG0=7393 TM=01 TS=01 CGWSEL=00 CGADSUB=00 bright=15 fblank=0
```

BG mode 6, and the background colour is just the backdrop (CGRAM 0). Nothing exotic.

Interlaced output is drawn **one field per frame** — this frame fills the even rows of the doubled-height buffer, the next fills the odd rows:

```c
GFX.S = GFX.Screen;
if (GFX.DoInterlace && S9xInterlaceField())
    GFX.S += GFX.RealPPL;      // odd field starts one row down
```

A complete picture therefore takes two consecutive frames. But `S9xStartScreenRefresh` advanced the field counter unconditionally, and a *skipped* frame still advances the field while drawing nothing. Drop every other frame and the parity is pinned: render field 0, skip field 1, render field 0, skip field 1 — field 1's rows are **never written for as long as that screen is up**.

Downscaling 512x448 for display then collapses the alternating dead rows into a flat dark wash, which is what the screenshots in the issue show rather than visible combing.

## Measurements — both aging ROMs

Fully black scanlines out of 448 on an interlaced screen, by frame-skip period, via a headless libretro frontend:

**SHVC — Super Famicom Aging Program v1.00** (md5 `eaf9f580b4798470f26786d9340922ab`)

| period | 1 (none) | 2 | 3 | 4 | 5 | 10 | 16 |
|---|---|---|---|---|---|---|---|
| master | 0 | **112** | 0 | **112** | 0 | **112** | **112** |
| this PR | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

**SNSP AGING Ver1.02** (md5 `55b2a79c117f03079a75f51a89990ca0`) — the ROM from the report

| period | 1 (none) | 2 | 10 |
|---|---|---|---|
| master | 0 | **112** | **112** |
| this PR | 0 | 0 | 0 |

The 112 are every other row across the lower half of the buffer, starting at y=224 — the field that never gets written. **Even** periods pin the parity and lose it permanently; **odd** periods still alternate and come out clean.

> Note on ROM naming: No-Intro lists the second ROM as `Aging Cassette (Japan)`, but its title screen reads **`SNSP AGING Ver1.02`**. It is a different program from the Super Famicom Aging Program v1.00, and it is the one whose screens match the issue. Its interlaced screens are at roughly frames 440, 1720, 4440-4960, 6720, 10720-11240, 13040; everything else is 256x224.

## Simulating a low-end device

A fixed skip period is artificial, so the harness also models the real trigger: the win32 `AUTO_FRAMERATE` chooser (`win32/win32.cpp:396`) driven by a host that presents slower than realtime, with per-frame cost scaled by pixel count (a 512x448 screen costs ~4x a 256x224 one — which is what pushes a weak GPU into skipping on exactly these screens).

With the default `AutoMaxSkipFrames = 1`, the loop converges to **50% skipping — i.e. period 2, the pathological case** — at every host speed tried:

| host speed | 0.50x | 0.70x | 0.85x |
|---|---|---|---|
| skipped | 50% | 50% | 50% |
| master | **112/448** | **112/448** | **112/448** |
| this PR | 0/448 | 0/448 | 0/448 |

Same result on the SHVC ROM at 0.70x: master **112/448**, this PR **0/448**.

This is why it shows on an Iris Xe and not on a discrete GPU: integrated graphics share system memory bandwidth and the CPU package's power budget, so they miss the frame deadline, auto-frameskip engages, and the parity gets pinned. On a discrete GPU the deadline is never missed, nothing is skipped, and the bug cannot appear.

Setting `AutoMaxSkipFrames = 2` gives 55% skipping on an odd-ish cadence and master shows **0/448** — it happens not to reproduce, which is further confirmation that parity is the mechanism (and a usable workaround on affected machines).

## The fix

```c
if (!IPPU.RenderThisFrame && !Settings.InRunAhead && (IPPU.Interlace || GFX.DoInterlace))
    IPPU.RenderThisFrame = TRUE;
```

It only ever flips a frame that was already going to be dropped, so it can add rendered frames but never remove them, and it is a strict no-op when frame skipping is off — verified byte-identical to upstream across 25 frames. It lives in `gfx.cpp` rather than the win32 skip chooser so gtk/qt/unix and libretro all get it. The `InRunAhead` guard keeps run-ahead's throwaway frames unrendered.

**Tradeoff:** frame skipping is effectively disabled while interlaced content is on screen (in one run, 90 frames rendered instead of 9). Interlaced screens are rare, and there is no way to show a correct interlaced frame while dropping half the fields — but on a machine slow enough to need auto-skip this trades black bars for reduced speed on those screens. A cheaper variant would render *consecutive pairs* then skip a run, keeping a complete picture and most of the savings; happy to reshape it that way if preferred.

## How to test

Load either aging ROM and let it reach an interlaced screen. Fast-forward is the easiest trigger since it uses a fixed skip: **Qt** defaults to a 10-frame period and **win32** to 16, both even, so both reproduce. (**GTK** defaults to 15 — odd — so it happens not to show it.) Alternatively set a fixed frame skip of 1 or 3 on win32.

## Caveats

- I do not have Iris Xe hardware. The mechanism is reproduced and fixed deterministically, and the low-end model reproduces the same failure through the actual auto-frameskip algorithm, but confirmation on the reporter's machine is still worth having — asking them to set a fixed frame skip of 0 is the decisive check.
- PAL timing (`V_Max` 312/313) is not tested; both ROMs tested here run NTSC timing.
- The `BG MODE 1` screen in the first screenshot of the issue is **256x224, not interlaced**, so this fix does not explain that particular image. The fix covers the 512x448 screens, which match the other screenshots.
