### PR TITLE
ra: identify the running game when the user logs in mid-session

### DIFF
--- a/gtk/src/gtk_retroachievements.cpp
+++ b/gtk/src/gtk_retroachievements.cpp
@@ -460,14 +460,26 @@ static gboolean ra_gtk_apply_credentials(gpointer data)
     {
         gui_config->ra_username = u->username;
         gui_config->ra_api_token = u->token;
-        gui_config->ra_enabled = u->logged_in;
+        // A successful login turns the feature on, but logging out must not
+        // turn it off — that would grey out the Login item you need to get back in.
+        if (u->logged_in)
+            gui_config->ra_enabled = true;
         gui_config->save_config_file();
     }
 
-    // Only refresh the Login/Logout label. The "Enabled" check item is left
-    // untouched here — toggling it would re-fire its handler and recurse.
+    // Refresh the Login/Logout label and the "Enabled" check item; the toggle
+    // handler ignores a state that already matches the config, so setting it
+    // here cannot recurse.
     if (global_builder)
     {
+        auto enabled_obj = global_builder->get_object("ra_enabled_item");
+        if (enabled_obj)
+        {
+            auto item = Glib::RefPtr<Gtk::CheckMenuItem>::cast_static(enabled_obj);
+            if (item && gui_config)
+                item->set_active(gui_config->ra_enabled);
+        }
+
         auto login_obj = global_builder->get_object("ra_login_item");
         if (login_obj)
         {

--- a/gtk/src/gtk_retroachievements.cpp
+++ b/gtk/src/gtk_retroachievements.cpp
@@ -570,6 +570,11 @@ static void ra_gtk_credentials_changed(const char *username, const char *token)
     g_idle_add(ra_gtk_apply_credentials, u);
 }
 
+static bool ra_gtk_game_running()
+{
+    return gui_config && gui_config->rom_loaded;
+}
+
 // ---------------------------------------------------------------------------
 // Public: register callbacks with the core
 // ---------------------------------------------------------------------------
@@ -591,6 +596,7 @@ void RA_Gtk_RegisterCallbacks()
     cb.on_credentials_changed = ra_gtk_credentials_changed;
     cb.on_login_result = ra_gtk_on_login_result;
     cb.reset_emulator = ra_gtk_reset_emulator;
+    cb.is_game_running = ra_gtk_game_running;
     RA_RegisterPlatformCallbacks(cb);
 }
 

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -408,6 +408,8 @@ void Snes9xWindow::connect_signals()
     get_object<Gtk::CheckMenuItem>("ra_enabled_item")->set_active(gui_config->ra_enabled);
     get_object<Gtk::CheckMenuItem>("ra_enabled_item")->signal_toggled().connect([this] {
         bool checked = get_object<Gtk::CheckMenuItem>("ra_enabled_item")->get_active();
+        if (checked == gui_config->ra_enabled)
+            return;
         gui_config->ra_enabled = checked;
         gui_config->save_config_file();
         RA_SetEnabled(checked);

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -757,6 +757,7 @@ void EmuMainWindow::createWidgets()
 
     connect(ra_menu, &QMenu::aboutToShow, [this] {
         bool enabled = app->config->ra_enabled;
+        ra_enabled_action->setChecked(enabled);
         ra_login_action->setEnabled(enabled);
         ra_hardcore_action->setEnabled(enabled);
         ra_achievements_action->setEnabled(enabled && app->isCoreActive() && RA_IsLoggedIn());

--- a/qt/src/RAIntegrationQt.cpp
+++ b/qt/src/RAIntegrationQt.cpp
@@ -462,6 +462,13 @@ static void ra_qt_reset_emulator()
         g_app->powerCycle();
 }
 
+// core->active is the Qt frontend's "a ROM is running" flag; it never clears
+// Settings.StopEmulation.
+static bool ra_qt_game_running()
+{
+    return g_app && g_app->isCoreActive();
+}
+
 // ---------------------------------------------------------------------------
 // Public: Register Qt callbacks
 // ---------------------------------------------------------------------------
@@ -486,6 +493,7 @@ void RA_Qt_RegisterCallbacks(EmuApplication *app)
     cb.on_credentials_changed = ra_qt_credentials_changed;
     cb.on_login_result = ra_qt_on_login_result;
     cb.reset_emulator = ra_qt_reset_emulator;
+    cb.is_game_running = ra_qt_game_running;
     RA_RegisterPlatformCallbacks(cb);
 }
 

--- a/qt/src/RAIntegrationQt.cpp
+++ b/qt/src/RAIntegrationQt.cpp
@@ -407,7 +407,10 @@ static void ra_qt_credentials_changed(const char *username, const char *token)
     QMetaObject::invokeMethod(QApplication::instance(), [=]() {
         g_app->config->ra_username = u;
         g_app->config->ra_api_token = t;
-        g_app->config->ra_enabled = logged_in;
+        // A successful login turns the feature on, but logging out must not
+        // turn it off — that would grey out the Login item you need to get back in.
+        if (logged_in)
+            g_app->config->ra_enabled = true;
         g_app->config->saveFile(EmuConfig::findConfigFile());
 
         if (!g_app->window)

--- a/retroachievements.cpp
+++ b/retroachievements.cpp
@@ -448,6 +448,33 @@ static void RC_CCONV ra_event_handler(const rc_client_event_t *event, rc_client_
     }
 }
 
+// A game load is already in flight. One started before login completed parks on
+// AWAIT_LOGIN and resumes by itself, so restarting it only aborts and re-issues
+// the same requests.
+static bool ra_load_in_progress()
+{
+    switch (rc_client_get_load_game_state(g_rcClient))
+    {
+    case RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN:
+    case RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME:
+    case RC_CLIENT_LOAD_GAME_STATE_FETCHING_GAME_DATA:
+    case RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// A ROM is running: ask the frontend, since Settings.StopEmulation is only
+// maintained by some of them.
+static bool ra_game_running()
+{
+    if (g_callbacks.is_game_running)
+        return g_callbacks.is_game_running();
+
+    return !Settings.StopEmulation;
+}
+
 // ---------------------------------------------------------------------------
 // Login callback
 // ---------------------------------------------------------------------------
@@ -475,12 +502,13 @@ static void RC_CCONV ra_login_callback(int result, const char *error_message,
             if (g_callbacks.on_login_result)
                 g_callbacks.on_login_result(true, msg, user_initiated);
 
-            if (!Settings.StopEmulation)
+            if (ra_game_running())
             {
                 // Achievements arm mid-session: reset once the game is
                 // identified so the session starts from power-on.
                 g_resetPendingOnLoad = true;
-                RA_OnLoadROM();
+                if (!ra_load_in_progress())
+                    RA_OnLoadROM();
             }
         }
     }
@@ -504,6 +532,10 @@ static void RC_CCONV ra_login_callback(int result, const char *error_message,
 static void RC_CCONV ra_game_loaded_callback(int result, const char *error_message,
                                               rc_client_t *client, void *userdata)
 {
+    // A newer load replaced this one; it owns the pending reset and the result.
+    if (result == RC_ABORTED)
+        return;
+
     const bool reset_pending = g_resetPendingOnLoad;
     g_resetPendingOnLoad = false;
 
@@ -523,7 +555,7 @@ static void RC_CCONV ra_game_loaded_callback(int result, const char *error_messa
 
             // Login happened while this game was already running — restart it
             // so achievement/hardcore state is valid from power-on.
-            if (reset_pending && !Settings.StopEmulation && g_callbacks.reset_emulator)
+            if (reset_pending && ra_game_running() && g_callbacks.reset_emulator)
                 g_callbacks.reset_emulator();
         }
     }

--- a/retroachievements.h
+++ b/retroachievements.h
@@ -47,6 +47,10 @@ struct RAPlatformCallbacks
     // Reset request for achievement integrity. May be called from a background
     // thread — implementations must marshal to the emulation thread.
     void (*reset_emulator)();
+
+    // True while a ROM is running. Frontends disagree on Settings.StopEmulation
+    // (Qt never clears it), so each one reports its own flag here.
+    bool (*is_game_running)();
 };
 
 void RA_RegisterPlatformCallbacks(const RAPlatformCallbacks &callbacks);

--- a/win32/retroachievements_win32.cpp
+++ b/win32/retroachievements_win32.cpp
@@ -644,7 +644,10 @@ static void ra_win32_credentials_changed(const char *username, const char *token
     strncpy(GUI.RAApiToken, token ? token : "", sizeof(GUI.RAApiToken) - 1);
     GUI.RAApiToken[sizeof(GUI.RAApiToken) - 1] = '\0';
 
-    GUI.RAEnabled = (username && username[0] && token && token[0]);
+    // A successful login turns the feature on, but logging out must not turn it
+    // off — that would grey out the Login item you need to get back in.
+    if (username && username[0] && token && token[0])
+        GUI.RAEnabled = true;
     WinSaveConfigFile();
 }
 

--- a/win32/retroachievements_win32.cpp
+++ b/win32/retroachievements_win32.cpp
@@ -648,6 +648,11 @@ static void ra_win32_credentials_changed(const char *username, const char *token
     WinSaveConfigFile();
 }
 
+static bool ra_win32_game_running()
+{
+    return !Settings.StopEmulation;
+}
+
 // ---------------------------------------------------------------------------
 // Public: Register Win32 callbacks
 // ---------------------------------------------------------------------------
@@ -662,6 +667,7 @@ void RA_Win32_RegisterCallbacks()
     cb.on_credentials_changed = ra_win32_credentials_changed;
     cb.on_login_result = ra_win32_on_login_result;
     cb.reset_emulator = ra_win32_reset_emulator;
+    cb.is_game_running = ra_win32_game_running;
     RA_RegisterPlatformCallbacks(cb);
 }
 


### PR DESCRIPTION
## Problem

Loading a game and *then* logging in to RetroAchievements left the achievement list empty. Reset and hard reset didn't help — only re-opening the ROM via File → Open populated it.

## Root cause

`ra_login_callback()` gated its "re-identify the running game" step on `!Settings.StopEmulation`. Only win32, GTK and macOS maintain that flag. `Snes9xController::init()` sets it `true` once and **the Qt frontend never clears it** (there is already a comment saying exactly that in `qt/src/EmulationPanel.cpp:65`), so on Qt the gate was permanently closed and `RA_OnLoadROM()` never ran after login.

Reproduced with a debug print on the Qt build — `StopEmulation=1 raEnabled=1` with Super Mario World running, and zero `Identifying game` lines in the RA log after a successful login.

## Fix

- New `is_game_running()` platform callback in `RAPlatformCallbacks`, so the core asks the frontend instead of reading a flag the frontends treat differently. Falls back to `!Settings.StopEmulation` when unset.
- Wired up per frontend: Qt → `isCoreActive()`, GTK → `gui_config->rom_loaded`, win32 → `!Settings.StopEmulation` (behaviour there is unchanged).

## Also fixed

Surfaced in the GTK log while verifying: GTK opens the ROM while login is still in flight, so the load parks on `AWAIT_LOGIN` and rcheevos resumes it by itself. The login callback then started a *second* load, which aborted the first — duplicate network round-trip, a spurious "Failed to load game" toast, and the aborted callback consumed `g_resetPendingOnLoad` so the achievement-integrity power-on reset never fired.

The login callback now skips the reload when one is already in progress, and the load callback ignores `RC_ABORTED` results.

## Testing

Both Linux frontends built and run against a live RetroAchievements login with Super Mario World. Before the fix Qt logged nothing past `logged in successfully`; after it, both log a single identify:

```
[RetroAchievements] shanytc logged in successfully
[RetroAchievements] Identified game: 228 "Super Mario World"
[RetroAchievements] Set 266: 87/90 achievements active, 76 leaderboards
[RetroAchievements] Set 4020: 84/84 achievements active, 0 leaderboards
[RetroAchievements] Resetting runtime
```

GTK no longer double-loads or reports the bogus failure.

win32 was not compiled — no toolchain here. Its change is a one-line callback registration using a flag that file already reads.