### PR TITLE
qt/gtk: add the win32 Input menu and controller device list

### DIFF
--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -183,11 +183,14 @@ int Snes9xConfig::load_defaults()
     shader_filename.clear();
     reduce_input_lag = false;
 
+    controller_option = CONTROLLER_JOYPADS;
+    superscope_crosshair_visible = true;
+    valid_controller_options = 0xffff;
+    controller_option_before_rom = -1;
+
     /* Snes9x Variables */
-    Settings.MouseMaster = true;
-    Settings.SuperScopeMaster = true;
-    Settings.JustifierMaster = true;
-    Settings.MultiPlayer5Master = true;
+    // The controller-device master flags are set per controller option in
+    // S9xApplyControllerOption().
     Settings.UpAndDown = false;
     Settings.AutoSaveDelay = 0;
     Settings.SkipFrames = THROTTLE_TIMER_FRAMESKIP;
@@ -237,6 +240,12 @@ int Snes9xConfig::load_defaults()
 
     return 0;
 }
+
+// Config-file names for ControllerOption, in enum order.
+static const char *controller_option_names[NUM_CONTROLLER_OPTIONS] = {
+    "joypads", "mouse", "superscope", "multitap5", "justifier",
+    "mouse_swapped", "multitap8", "dual_justifiers", "macsrifle"
+};
 
 int Snes9xConfig::save_config_file()
 {
@@ -416,40 +425,9 @@ int Snes9xConfig::save_config_file()
     outint("BIOSPreference", Settings.SGB_BIOSPreference, "BIOS mode for GB/GBC ROMs: 0=No BIOS (BIOS-less), 1=SGB1, 2=SGB2 (default)");
 
     section = "Input";
-    controllers controller = CTL_NONE;
-    int8 id[4];
-
-    for (int i = 0; i < 2; i++)
-    {
-        std::string name;
-        std::string value;
-
-        name = "ControllerPort" + std::to_string(i);
-        S9xGetController(i, &controller, &id[0], &id[1], &id[2], &id[3]);
-
-        switch (controller)
-        {
-        case CTL_JOYPAD:
-            value = "joypad";
-            break;
-        case CTL_MOUSE:
-            value = "mouse";
-            break;
-        case CTL_SUPERSCOPE:
-            value = "superscope";
-            break;
-        case CTL_MP5:
-            value = "multitap";
-            break;
-        case CTL_JUSTIFIER:
-            value = "justifier";
-            break;
-        default:
-            value = "none";
-        }
-
-        outstring(name, value, "Device in this port: none, joypad, mouse, superscope, justifier, or multitap");
-    }
+    outstring("ControllerOption", controller_option_names[controller_option],
+              "What is plugged into the controller ports: joypads, mouse, superscope, multitap5, justifier, mouse_swapped, multitap8, dual_justifiers, or macsrifle");
+    outbool("SuperScopeCrosshair", superscope_crosshair_visible, "on to draw the Super Scope's crosshair on screen");
 
     outint("JoystickThreshold", joystick_threshold, "How far an analog stick/trigger must move to register as pressed (percent, 1-100)");
     outbool("EnableRumble", enable_rumble, "on to pass rumble-cart motor effects (LRG SNES releases) to the port-1 gamepad");
@@ -698,23 +676,39 @@ int Snes9xConfig::load_config_file()
 
     section = "Input";
 
-    for (int i = 0; i < 2; i++)
+    std::string option;
+    instr("ControllerOption", option);
+    if (!option.empty())
     {
-        std::string name = "ControllerPort" + std::to_string(i);
-        std::string value;
-        instr(name, value);
-
-        if (value.find("joypad") != std::string::npos)
-            S9xSetController(i, CTL_JOYPAD, i, 0, 0, 0);
-        else if (value.find("multitap") != std::string::npos)
-            S9xSetController(i, CTL_MP5, i, i + 1, i + 2, i + 3);
-        else if (value.find("superscope") != std::string::npos)
-            S9xSetController(i, CTL_SUPERSCOPE, 0, 0, 0, 0);
-        else if (value.find("mouse") != std::string::npos)
-            S9xSetController(i, CTL_MOUSE, i, 0, 0, 0);
-        else if (value.find("none") != std::string::npos)
-            S9xSetController(i, CTL_NONE, 0, 0, 0, 0);
+        for (int i = 0; i < NUM_CONTROLLER_OPTIONS; i++)
+            if (option == controller_option_names[i])
+                controller_option = i;
     }
+    else
+    {
+        // Older configs stored a device per port; map the pairs the menu can
+        // still express onto its options.
+        std::string port0, port1;
+        instr("ControllerPort0", port0);
+        instr("ControllerPort1", port1);
+        auto is = [](const std::string &value, const char *device) {
+            return value.find(device) != std::string::npos;
+        };
+
+        if (is(port0, "mouse"))
+            controller_option = CONTROLLER_MOUSE;
+        else if (is(port1, "mouse"))
+            controller_option = CONTROLLER_MOUSE_SWAPPED;
+        else if (is(port0, "superscope") || is(port1, "superscope"))
+            controller_option = CONTROLLER_SUPERSCOPE;
+        else if (is(port1, "justifier"))
+            controller_option = CONTROLLER_JUSTIFIER;
+        else if (is(port1, "multitap"))
+            controller_option = is(port0, "multitap") ? CONTROLLER_MULTITAP8 : CONTROLLER_MULTITAP5;
+        else
+            controller_option = CONTROLLER_JOYPADS;
+    }
+    inbool("SuperScopeCrosshair", superscope_crosshair_visible);
 
     inint("JoystickThreshold", joystick_threshold);
     inbool("EnableRumble", enable_rumble);
@@ -831,6 +825,8 @@ void Snes9xConfig::rebind_keys()
     for (int joypad_i = 0; joypad_i < NUM_JOYPADS; joypad_i++)
     {
         auto &bin = pad[joypad_i].data;
+        const int player = joypad_player(joypad_i);
+        const std::string joypad = "Joypad" + std::to_string(player + 1) + " ";
 
         for (int button_i = 0; button_i < NUM_JOYPAD_LINKS; button_i++)
         {
@@ -843,21 +839,25 @@ void Snes9xConfig::rebind_keys()
             if (dupe < NUM_JOYPAD_LINKS || bin[button_i].hex() == 0)
                 continue;
 
-            string = "Joypad" + std::to_string((joypad_i % 5) + 1) + " ";
-            string += b_links[button_i].snes9x_name;
+            // The pad button, plus whatever it also works on the device in
+            // the neighbouring port, plus any other buttons sharing the key.
+            std::vector<std::string> commands;
+            commands.push_back(joypad + b_links[button_i].snes9x_name);
+            S9xJoypadDeviceCommands(controller_option, player, b_links[button_i].snes9x_name, commands);
 
-            bool ismulti = false;
             for (dupe = button_i - 1; dupe > 0; dupe--)
             {
                 if (bin[button_i] == bin[dupe])
                 {
-                    ismulti = true;
-                    string += ",Joypad" + std::to_string((joypad_i % 5) + 1) + " ";
-                    string += b_links[dupe].snes9x_name;
+                    commands.push_back(joypad + b_links[dupe].snes9x_name);
+                    S9xJoypadDeviceCommands(controller_option, player, b_links[dupe].snes9x_name, commands);
                 }
             }
 
-            if (ismulti)
+            string = commands[0];
+            for (size_t i = 1; i < commands.size(); i++)
+                string += "," + commands[i];
+            if (commands.size() > 1)
                 string = std::string("{") + string + "}";
 
             cmd = S9xGetPortCommandT(string.c_str());
@@ -874,16 +874,23 @@ void Snes9xConfig::rebind_keys()
                      false);
     }
 
-    cmd = S9xGetPortCommandT("Pointer Mouse1+Superscope+Justifier1");
+    // The host pointer aims every device that can sit in a port, whichever
+    // one is plugged in. The second Justifier is the exception: as on win32
+    // it is steered from pad 2's D-pad through a pseudo pointer (see
+    // S9xJoypadDeviceCommands), so it must not also be claimed by the mouse.
+    cmd = S9xGetPortCommandT("Pointer Mouse1+Mouse2+Superscope+Justifier1+MacsRifle");
     S9xMapPointer(BINDING_MOUSE_POINTER, cmd, true);
 
-    cmd = S9xGetPortCommandT("{Mouse1 L,Superscope Fire,Justifier1 Trigger}");
+    cmd = S9xGetPortCommandT("Pointer Justifier2");
+    S9xMapPointer(PseudoPointerBase, cmd, false);
+
+    cmd = S9xGetPortCommandT("{Mouse1 L,Mouse2 L,Superscope Fire,Justifier1 Trigger,MacsRifle Trigger}");
     S9xMapButton(BINDING_MOUSE_BUTTON0, cmd, false);
 
     cmd = S9xGetPortCommandT("Superscope ToggleTurbo");
     S9xMapButton(BINDING_MOUSE_BUTTON1, cmd, false);
 
-    cmd = S9xGetPortCommandT("{Mouse1 R,Superscope Pause,Justifier1 Start}");
+    cmd = S9xGetPortCommandT("{Mouse1 R,Mouse2 R,Superscope Pause,Justifier1 Start}");
     S9xMapButton(BINDING_MOUSE_BUTTON2, cmd, false);
 
     cmd = S9xGetPortCommandT("Superscope Cursor");

--- a/gtk/src/gtk_config.h
+++ b/gtk/src/gtk_config.h
@@ -184,6 +184,15 @@ class Snes9xConfig
     JoyDevices joysticks;
     int joystick_threshold;
     bool enable_rumble;
+
+    /* Controller-port devices (ControllerOption in gtk_control.h). A ROM's
+     * NSRT header may pick the devices itself and narrow the menu to the ones
+     * the game supports; the choice it displaced comes back on the next load
+     * unless the user has picked something by hand since. */
+    int controller_option;
+    bool superscope_crosshair_visible;
+    int valid_controller_options;
+    int controller_option_before_rom;
 };
 
 std::string get_config_dir();

--- a/gtk/src/gtk_control.cpp
+++ b/gtk/src/gtk_control.cpp
@@ -15,6 +15,9 @@
 
 #include "snes9x.h"
 #include "controls.h"
+#include "crosshairs.h"
+#include "memmap.h"
+#include "movie.h"
 #include "display.h"
 #include "gfx.h"
 
@@ -158,14 +161,15 @@ bool S9xPollAxis(uint32 id, int16 *value)
     return true;
 }
 
-static bool using_superscope()
+// A light gun can only point at the screen, unlike the free-roaming mouse.
+static bool using_gun()
 {
     for (int i = 0; i < 2; i++)
     {
         enum controllers ctl;
         int8_t id1, id2, id3, id4;
         S9xGetController(i, &ctl, &id1, &id2, &id3, &id4);
-        if (ctl == CTL_SUPERSCOPE)
+        if (ctl == CTL_SUPERSCOPE || ctl == CTL_JUSTIFIER || ctl == CTL_MACSRIFLE)
             return true;
     }
 
@@ -174,7 +178,7 @@ static bool using_superscope()
 
 bool S9xPollPointer(uint32 id, int16 *x, int16 *y)
 {
-    if (using_superscope())
+    if (using_gun())
     {
         top_level->snes_mouse_x = std::clamp(top_level->snes_mouse_x, 0.0, 256.0);
         top_level->snes_mouse_y = std::clamp(top_level->snes_mouse_y, 0.0, 239.0);
@@ -194,11 +198,279 @@ bool S9xIsMousePluggedIn()
     for (int i = 0; i <= 1; i++)
     {
         S9xGetController(i, &ctl, &id1, &id2, &id3, &id4);
-        if (ctl == CTL_MOUSE || ctl == CTL_SUPERSCOPE)
+        if (ctl == CTL_MOUSE || ctl == CTL_SUPERSCOPE || ctl == CTL_JUSTIFIER || ctl == CTL_MACSRIFLE)
             return true;
     }
 
     return false;
+}
+
+/* Mirrors win32's ChangeInputDevice(): raise only the selected device's
+ * master flag and seat the devices where they sit on real hardware (a mouse
+ * or pad in port 1, a gun or multitap in port 2). Pad N is driven by the
+ * "Joypad N" bindings. */
+void S9xApplyControllerOption()
+{
+    Settings.MouseMaster = false;
+    Settings.JustifierMaster = false;
+    Settings.SuperScopeMaster = false;
+    Settings.MultiPlayer5Master = false;
+    Settings.MacsRifleMaster = false;
+
+    switch (gui_config->controller_option)
+    {
+    case CONTROLLER_MOUSE:
+        Settings.MouseMaster = true;
+        S9xSetController(0, CTL_MOUSE, 0, 0, 0, 0);
+        S9xSetController(1, CTL_JOYPAD, 1, 0, 0, 0);
+        break;
+    case CONTROLLER_MOUSE_SWAPPED:
+        Settings.MouseMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_MOUSE, 1, 0, 0, 0);
+        break;
+    case CONTROLLER_SUPERSCOPE:
+        Settings.SuperScopeMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_SUPERSCOPE, 0, 0, 0, 0);
+        break;
+    case CONTROLLER_MULTITAP5:
+        Settings.MultiPlayer5Master = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_MP5, 1, 2, 3, 4);
+        break;
+    case CONTROLLER_MULTITAP8:
+        Settings.MultiPlayer5Master = true;
+        S9xSetController(0, CTL_MP5, 0, 1, 2, 3);
+        S9xSetController(1, CTL_MP5, 4, 5, 6, 7);
+        break;
+    case CONTROLLER_JUSTIFIER:
+        Settings.JustifierMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_JUSTIFIER, 0, 0, 0, 0);
+        break;
+    case CONTROLLER_DUAL_JUSTIFIERS:
+        Settings.JustifierMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_JUSTIFIER, 1, 0, 0, 0);
+        break;
+    case CONTROLLER_MACSRIFLE:
+        Settings.MacsRifleMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_MACSRIFLE, 0, 0, 0, 0);
+        break;
+    case CONTROLLER_JOYPADS:
+    default:
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_JOYPAD, 1, 0, 0, 0);
+        break;
+    }
+
+    S9xApplySuperScopeCrosshair();
+}
+
+void S9xApplySuperScopeCrosshair()
+{
+    if (gui_config->superscope_crosshair_visible)
+        S9xSetControllerCrosshair(X_SUPERSCOPE, 2, "White", "Black");
+    else
+        S9xSetControllerCrosshair(X_SUPERSCOPE, 0, "Trans", "Trans");
+}
+
+void S9xSetControllerOption(int option)
+{
+    if (option < 0 || option >= NUM_CONTROLLER_OPTIONS)
+        return;
+
+    gui_config->controller_option = option;
+    // A manual pick is the new baseline: nothing to restore on the next ROM.
+    gui_config->controller_option_before_rom = -1;
+    S9xApplyControllerOption();
+    gui_config->rebind_keys();
+}
+
+bool S9xControllerOptionValid(int option)
+{
+    return (gui_config->valid_controller_options >> option) & 1;
+}
+
+void S9xAutoDetectControllerOption()
+{
+    // Port of win32's S9xPostRomInit(): undo whatever the previous ROM
+    // forced, then let this ROM's NSRT header (or the M.A.C.S. rifle title)
+    // choose the devices and restrict the menu to the ones it supports.
+    if (S9xMovieActive())
+        return;
+
+    const int applied = gui_config->controller_option;
+
+    if (gui_config->controller_option_before_rom >= 0)
+        gui_config->controller_option = gui_config->controller_option_before_rom;
+
+    const int previous = gui_config->controller_option;
+    int &option = gui_config->controller_option;
+    int &valid = gui_config->valid_controller_options;
+    valid = 0xffff;
+
+    if (!Settings.DisableGameSpecificHacks && strncmp(Memory.ROMName, "MAC:Basic Rifle", 15) == 0)
+        option = CONTROLLER_MACSRIFLE;
+
+    if (!strncmp((const char *)Memory.NSRTHeader + 24, "NSRT", 4))
+    {
+        switch (Memory.NSRTHeader[29])
+        {
+        default: // unknown or unsupported
+            break;
+        case 0x00: // Gamepad / Gamepad
+            option = CONTROLLER_JOYPADS;
+            valid = (1 << CONTROLLER_JOYPADS);
+            break;
+        case 0x10: // Mouse / Gamepad
+            option = CONTROLLER_MOUSE;
+            valid = (1 << CONTROLLER_MOUSE);
+            break;
+        case 0x20: // Mouse_or_Gamepad / Gamepad
+            if (option == CONTROLLER_MOUSE_SWAPPED)
+                option = CONTROLLER_MOUSE;
+            if (option != CONTROLLER_MOUSE)
+                option = CONTROLLER_JOYPADS;
+            valid = (1 << CONTROLLER_JOYPADS) | (1 << CONTROLLER_MOUSE);
+            break;
+        case 0x01: // Gamepad / Mouse
+            option = CONTROLLER_MOUSE_SWAPPED;
+            valid = (1 << CONTROLLER_MOUSE_SWAPPED);
+            break;
+        case 0x22: // Mouse_or_Gamepad / Mouse_or_Gamepad
+            if (option != CONTROLLER_MOUSE && option != CONTROLLER_MOUSE_SWAPPED)
+                option = CONTROLLER_JOYPADS;
+            valid = (1 << CONTROLLER_JOYPADS) | (1 << CONTROLLER_MOUSE) | (1 << CONTROLLER_MOUSE_SWAPPED);
+            break;
+        case 0x03: // Gamepad / Superscope
+            option = CONTROLLER_SUPERSCOPE;
+            valid = (1 << CONTROLLER_SUPERSCOPE);
+            break;
+        case 0x04: // Gamepad / Gamepad_or_Superscope
+            if (option == CONTROLLER_JUSTIFIER || option == CONTROLLER_DUAL_JUSTIFIERS)
+                option = CONTROLLER_SUPERSCOPE;
+            if (option != CONTROLLER_SUPERSCOPE)
+                option = CONTROLLER_JOYPADS;
+            valid = (1 << CONTROLLER_JOYPADS) | (1 << CONTROLLER_SUPERSCOPE);
+            break;
+        case 0x05: // Gamepad / Justifier
+            if (option != CONTROLLER_DUAL_JUSTIFIERS)
+                option = CONTROLLER_JUSTIFIER;
+            valid = (1 << CONTROLLER_JUSTIFIER) | (1 << CONTROLLER_DUAL_JUSTIFIERS);
+            break;
+        case 0x06: // Gamepad / Multitap_or_Gamepad
+            option = CONTROLLER_MULTITAP5;
+            valid = (1 << CONTROLLER_MULTITAP5) | (1 << CONTROLLER_JOYPADS);
+            break;
+        case 0x66: // Multitap_or_Gamepad / Multitap_or_Gamepad
+            option = CONTROLLER_MULTITAP8;
+            valid = (1 << CONTROLLER_MULTITAP8) | (1 << CONTROLLER_MULTITAP5) | (1 << CONTROLLER_JOYPADS);
+            break;
+        case 0x24: // Gamepad_or_Mouse / Gamepad_or_Superscope
+            if (option == CONTROLLER_JUSTIFIER || option == CONTROLLER_DUAL_JUSTIFIERS)
+                option = CONTROLLER_SUPERSCOPE;
+            if (option != CONTROLLER_SUPERSCOPE && option != CONTROLLER_MOUSE)
+                option = CONTROLLER_JOYPADS;
+            valid = (1 << CONTROLLER_JOYPADS) | (1 << CONTROLLER_MOUSE) | (1 << CONTROLLER_SUPERSCOPE);
+            break;
+        case 0x27: // Gamepad_or_Mouse / Gamepad_or_Mouse_or_Superscope
+            if (option == CONTROLLER_JUSTIFIER || option == CONTROLLER_DUAL_JUSTIFIERS)
+                option = CONTROLLER_SUPERSCOPE;
+            if (option != CONTROLLER_SUPERSCOPE && option != CONTROLLER_MOUSE && option != CONTROLLER_MOUSE_SWAPPED)
+                option = CONTROLLER_JOYPADS;
+            valid = (1 << CONTROLLER_JOYPADS) | (1 << CONTROLLER_MOUSE) | (1 << CONTROLLER_MOUSE_SWAPPED) | (1 << CONTROLLER_SUPERSCOPE);
+            break;
+        case 0x08: // Gamepad / Mouse_or_Multitap_or_Gamepad
+            if (option == CONTROLLER_MOUSE)
+                option = CONTROLLER_MOUSE_SWAPPED;
+            if (option == CONTROLLER_MULTITAP8)
+                option = CONTROLLER_MULTITAP5;
+            if (option != CONTROLLER_MULTITAP5 && option != CONTROLLER_MOUSE_SWAPPED)
+                option = CONTROLLER_JOYPADS;
+            valid = (1 << CONTROLLER_MOUSE_SWAPPED) | (1 << CONTROLLER_MULTITAP5) | (1 << CONTROLLER_JOYPADS);
+            break;
+        }
+    }
+
+    // Remember what (if anything) the devices were forced away from.
+    gui_config->controller_option_before_rom = previous;
+
+    if (option != applied)
+    {
+        S9xApplyControllerOption();
+        gui_config->rebind_keys();
+    }
+}
+
+/* The joypad buttons that also drive the device in the neighbouring port,
+ * as win32's S9xPollButton() lets them: pad 1 works the mouse or Justifier
+ * that replaces it, pad 2 fires the gun or second mouse in port 2. In Dual
+ * Justifiers mode pad 2's D-pad also steers the second gun, which is aimed
+ * through pseudo pointer 1 (see rebind_keys). */
+struct DeviceButton
+{
+    int option;
+    int player;
+    const char *button;
+    const char *command;
+};
+
+static const DeviceButton device_buttons[] = {
+    { CONTROLLER_MOUSE, 0, "A", "Mouse1 L" },
+    { CONTROLLER_MOUSE, 0, "L", "Mouse1 L" },
+    { CONTROLLER_MOUSE, 0, "B", "Mouse1 R" },
+    { CONTROLLER_MOUSE, 0, "R", "Mouse1 R" },
+
+    { CONTROLLER_MOUSE_SWAPPED, 1, "A", "Mouse2 L" },
+    { CONTROLLER_MOUSE_SWAPPED, 1, "L", "Mouse2 L" },
+    { CONTROLLER_MOUSE_SWAPPED, 1, "B", "Mouse2 R" },
+    { CONTROLLER_MOUSE_SWAPPED, 1, "R", "Mouse2 R" },
+
+    { CONTROLLER_SUPERSCOPE, 1, "A", "Superscope Fire" },
+    { CONTROLLER_SUPERSCOPE, 1, "L", "Superscope Fire" },
+    { CONTROLLER_SUPERSCOPE, 1, "B", "Superscope Cursor" },
+    { CONTROLLER_SUPERSCOPE, 1, "R", "Superscope Cursor" },
+    { CONTROLLER_SUPERSCOPE, 1, "Y", "Superscope ToggleTurbo" },
+    { CONTROLLER_SUPERSCOPE, 1, "Start", "Superscope Pause" },
+    { CONTROLLER_SUPERSCOPE, 1, "Select", "Superscope Pause" },
+    { CONTROLLER_SUPERSCOPE, 1, "X", "Superscope AimOffscreen" },
+
+    { CONTROLLER_JUSTIFIER, 0, "A", "Justifier1 Trigger" },
+    { CONTROLLER_JUSTIFIER, 0, "L", "Justifier1 Trigger" },
+    { CONTROLLER_JUSTIFIER, 0, "B", "Justifier1 Start" },
+    { CONTROLLER_JUSTIFIER, 0, "R", "Justifier1 Start" },
+    { CONTROLLER_JUSTIFIER, 0, "X", "Justifier1 AimOffscreen" },
+    { CONTROLLER_JUSTIFIER, 0, "Start", "Justifier1 AimOffscreen" },
+
+    { CONTROLLER_DUAL_JUSTIFIERS, 0, "A", "Justifier1 Trigger" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 0, "L", "Justifier1 Trigger" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 0, "B", "Justifier1 Start" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 0, "R", "Justifier1 Start" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 0, "X", "Justifier1 AimOffscreen" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 0, "Start", "Justifier1 AimOffscreen" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "A", "Justifier2 Trigger" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "L", "Justifier2 Trigger" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "B", "Justifier2 Start" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "R", "Justifier2 Start" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "X", "Justifier2 AimOffscreen" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "Start", "Justifier2 AimOffscreen" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "Up", "ButtonToPointer 1u Med" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "Down", "ButtonToPointer 1d Med" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "Left", "ButtonToPointer 1l Med" },
+    { CONTROLLER_DUAL_JUSTIFIERS, 1, "Right", "ButtonToPointer 1r Med" },
+
+    { CONTROLLER_MACSRIFLE, 1, "A", "MacsRifle Trigger" },
+    { CONTROLLER_MACSRIFLE, 1, "L", "MacsRifle Trigger" },
+};
+
+void S9xJoypadDeviceCommands(int option, int player, const char *button, std::vector<std::string> &commands)
+{
+    for (auto &d : device_buttons)
+        if (d.option == option && d.player == player && !strcmp(d.button, button))
+            commands.push_back(d.command);
 }
 
 bool S9xGrabJoysticks()

--- a/gtk/src/gtk_control.h
+++ b/gtk/src/gtk_control.h
@@ -6,6 +6,8 @@
 
 #pragma once
 #include <queue>
+#include <vector>
+#include <string>
 #include <array>
 
 #include "gtk_binding.h"
@@ -14,7 +16,37 @@
 #undef vector
 #undef bool
 
-const int NUM_JOYPADS = 10;
+/* Binding slots: pads 1-5, their "+" alternates, then pads 6-8 and their
+ * alternates, appended so older configs keep their slot numbers. Eight pads
+ * cover two multitaps, as on win32. joypad_player() maps a slot to its pad. */
+const int NUM_JOYPADS = 16;
+
+inline int joypad_player(int slot)
+{
+    if (slot < 5)
+        return slot;
+    if (slot < 10)
+        return slot - 5;
+    if (slot < 13)
+        return slot - 10 + 5;
+    return slot - 13 + 5;
+}
+
+/* What is plugged into the two controller ports: win32's Input menu device
+ * list, in its enum order (the NSRT auto-detection table depends on it). */
+enum ControllerOption
+{
+    CONTROLLER_JOYPADS = 0,
+    CONTROLLER_MOUSE,
+    CONTROLLER_SUPERSCOPE,
+    CONTROLLER_MULTITAP5,
+    CONTROLLER_JUSTIFIER,
+    CONTROLLER_MOUSE_SWAPPED,
+    CONTROLLER_MULTITAP8,
+    CONTROLLER_DUAL_JUSTIFIERS,
+    CONTROLLER_MACSRIFLE,
+    NUM_CONTROLLER_OPTIONS
+};
 
 /* Save states are organized in banks of slots, as on win32. The state file
  * extension is the flat index, i.e. bank * SAVE_SLOTS_PER_BANK + slot. */
@@ -171,3 +203,14 @@ class JoyDevices
 void S9xDeinitInputDevices();
 Binding S9xGetBindingByName(const char *name);
 bool S9xIsMousePluggedIn();
+
+/* Controller-port devices (see ControllerOption). Apply seats the devices
+ * from gui_config, Set is a user pick, AutoDetect applies a freshly loaded
+ * ROM's NSRT hints, and the last two add the joypad buttons that also work
+ * the device in the neighbouring port to a pad's bindings. */
+void S9xApplyControllerOption();
+void S9xApplySuperScopeCrosshair();
+void S9xSetControllerOption(int option);
+void S9xAutoDetectControllerOption();
+bool S9xControllerOptionValid(int option);
+void S9xJoypadDeviceCommands(int option, int player, const char *button, std::vector<std::string> &commands);

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -98,35 +98,9 @@ int main(int argc, char *argv[])
 
     S9xPortSoundInit();
 
+    S9xApplyControllerOption();
     S9xReportControllers();
-    for (int port = 0; port < 2; port++)
-    {
-        enum controllers type;
-        int8 id;
-        S9xGetController(port, &type, &id, &id, &id, &id);
-        std::string device_type;
-
-        switch (type)
-        {
-        case CTL_MP5:
-            device_type = "multitap";
-            break;
-        case CTL_MOUSE:
-            device_type = "mouse";
-            break;
-        case CTL_SUPERSCOPE:
-            device_type = "superscope";
-            break;
-        case CTL_JOYPAD:
-            device_type = "joypad";
-            break;
-        default:
-            device_type = "nothingpluggedin";
-        }
-
-        device_type += std::to_string(port + 1);
-        top_level->set_menu_item_selected(device_type.c_str());
-    }
+    top_level->update_controller_option_menu();
 
     gui_config->rebind_keys();
     top_level->update_accelerators();
@@ -227,6 +201,7 @@ void S9xROMLoaded()
 {
     gui_config->rom_loaded = true;
     run_ahead_buffer.clear();
+    S9xAutoDetectControllerOption();
     top_level->configure_widgets();
 
 #ifdef RETROACHIEVEMENTS_SUPPORT

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -237,11 +237,50 @@ void Snes9xWindow::connect_signals()
         gtk_shader_parameters_dialog(get_window());
     });
 
-    const std::vector<const char *> port_items = { "joypad1", "mouse1", "superscope1", "joypad2", "mouse2", "multitap2", "superscope2", "nothingpluggedin2" };
-    for (auto &name : port_items)
+    // win32's Input menu device list: what is plugged into the two
+    // controller ports. Radio items drawn as checks, as on win32.
+    const std::pair<const char *, int> device_items[] = {
+        { "input_joypad_item", CONTROLLER_JOYPADS },
+        { "input_mouse_item", CONTROLLER_MOUSE },
+        { "input_superscope_enable_item", CONTROLLER_SUPERSCOPE },
+        { "input_multitap5_item", CONTROLLER_MULTITAP5 },
+        { "input_justifier_item", CONTROLLER_JUSTIFIER },
+        { "input_mouse_swapped_item", CONTROLLER_MOUSE_SWAPPED },
+        { "input_multitap8_item", CONTROLLER_MULTITAP8 },
+        { "input_dual_justifiers_item", CONTROLLER_DUAL_JUSTIFIERS },
+        { "input_macsrifle_item", CONTROLLER_MACSRIFLE },
+    };
+    for (auto &[name, option] : device_items)
     {
-        get_object<Gtk::MenuItem>(name)->signal_activate().connect(sigc::bind<const char *>(sigc::mem_fun(*this, &Snes9xWindow::port_activate), name));
+        auto item = get_object<Gtk::RadioMenuItem>(name);
+        item->signal_toggled().connect([this, item, option] {
+            if (refreshing_controller_menu || !item->get_active())
+                return;
+            if (S9xMovieActive())
+            {
+                Gtk::MessageDialog msg(*window.get(), _("That setting is locked while a movie is active."), false,
+                                       Gtk::MESSAGE_WARNING, Gtk::BUTTONS_OK, true);
+                msg.run();
+            }
+            else
+            {
+                S9xSetControllerOption(option);
+            }
+            update_controller_option_menu();
+        });
     }
+
+    auto crosshair_item = get_object<Gtk::CheckMenuItem>("input_superscope_crosshair_item");
+    crosshair_item->signal_toggled().connect([this, crosshair_item] {
+        if (refreshing_controller_menu)
+            return;
+        config->superscope_crosshair_visible = crosshair_item->get_active();
+        S9xApplySuperScopeCrosshair();
+    });
+
+    get_object<Gtk::Menu>("input_menu_item_menu")->signal_show().connect([this] {
+        update_controller_option_menu();
+    });
 
     build_state_menus();
 
@@ -310,6 +349,16 @@ void Snes9xWindow::connect_signals()
 
     get_object<Gtk::MenuItem>("preferences_item")->signal_activate().connect([&] {
         snes9x_preferences_open(this);
+    });
+
+    // win32's Input->Input Configuration... and Customize Hotkeys...: the
+    // Joypads and Shortcuts tabs of the preferences dialog.
+    get_object<Gtk::MenuItem>("input_configuration_item")->signal_activate().connect([&] {
+        snes9x_preferences_open(this, 4);
+    });
+
+    get_object<Gtk::MenuItem>("customize_hotkeys_item")->signal_activate().connect([&] {
+        snes9x_preferences_open(this, 5);
     });
 
     get_object<Gtk::MenuItem>("open_netplay_item")->signal_activate().connect([&] {
@@ -552,35 +601,36 @@ bool Snes9xWindow::motion_notify(GdkEventMotion *event)
     return false;
 }
 
-void Snes9xWindow::port_activate(const char *name)
+void Snes9xWindow::update_controller_option_menu()
 {
-    auto item = get_object<Gtk::CheckMenuItem>(name);
-    if (!item->get_active())
-        return;
-
-    struct {
-        const char *name;
-        int port;
-        enum controllers controller;
-        int8_t id1, id2, id3, id4;
-    } map[] = {
-        { "joypad1", 0, CTL_JOYPAD, 0, 0, 0, 0 },
-        { "joypad2", 1, CTL_JOYPAD, 1, 0, 0, 0 },
-        { "mouse1", 0, CTL_MOUSE, 0, 0, 0, 0 },
-        { "mouse2", 1, CTL_MOUSE, 0, 0, 0, 0 },
-        { "superscope1", 0, CTL_SUPERSCOPE, 0, 0, 0, 0 },
-        { "superscope2", 1, CTL_SUPERSCOPE, 0, 0, 0, 0 },
-        { "multitap1", 0, CTL_MP5, 0, 1, 2, 3 },
-        { "multitap2", 1, CTL_MP5, 1, 2, 3, 4 },
-        { "nothingpluggedin2", 1, CTL_NONE, 0, 0, 0, 0}
+    const std::pair<const char *, int> device_items[] = {
+        { "input_joypad_item", CONTROLLER_JOYPADS },
+        { "input_mouse_item", CONTROLLER_MOUSE },
+        { "input_superscope_enable_item", CONTROLLER_SUPERSCOPE },
+        { "input_multitap5_item", CONTROLLER_MULTITAP5 },
+        { "input_justifier_item", CONTROLLER_JUSTIFIER },
+        { "input_mouse_swapped_item", CONTROLLER_MOUSE_SWAPPED },
+        { "input_multitap8_item", CONTROLLER_MULTITAP8 },
+        { "input_dual_justifiers_item", CONTROLLER_DUAL_JUSTIFIERS },
+        { "input_macsrifle_item", CONTROLLER_MACSRIFLE },
     };
 
-    for (auto &m : map)
-        if (!strcasecmp(m.name, name))
-        {
-            S9xSetController(m.port, m.controller, m.id1, m.id2, m.id3, m.id4);
-            break;
-        }
+    // As on win32: a ROM's NSRT header greys the devices it doesn't support,
+    // and nothing can be swapped once a movie is past its first frame.
+    const bool movie_locked = S9xMovieActive() && S9xMovieGetFrameCounter();
+
+    refreshing_controller_menu = true;
+    for (auto &[name, option] : device_items)
+    {
+        auto item = get_object<Gtk::RadioMenuItem>(name);
+        item->set_active(config->controller_option == option);
+        item->set_sensitive(S9xControllerOptionValid(option) && !movie_locked);
+    }
+
+    auto crosshair_item = get_object<Gtk::CheckMenuItem>("input_superscope_crosshair_item");
+    crosshair_item->set_active(config->superscope_crosshair_visible);
+    crosshair_item->set_sensitive(config->controller_option == CONTROLLER_SUPERSCOPE);
+    refreshing_controller_menu = false;
 }
 
 bool Snes9xWindow::event_key(GdkEventKey *event)
@@ -1539,6 +1589,7 @@ void Snes9xWindow::configure_widgets()
     }
 
     propagate_pause_state();
+    update_controller_option_menu();
 
     if (config->rom_loaded && !Settings.Paused)
         hide_mouse_cursor();

--- a/gtk/src/gtk_s9xwindow.h
+++ b/gtk/src/gtk_s9xwindow.h
@@ -67,6 +67,7 @@ class Snes9xWindow : public GtkBuilderWindow
     /* GTK-base-related functions */
     void show();
     void set_menu_item_selected(const char *name);
+    void update_controller_option_menu();
     void set_mouseable_area(int x, int y, int width, int height);
     void set_accelerator_to_binding(const char *name,
                                         const char *binding);
@@ -84,7 +85,6 @@ class Snes9xWindow : public GtkBuilderWindow
     int get_auto_input_rate();
     void connect_signals();
     bool event_key(GdkEventKey *event);
-    void port_activate(const char *name);
     bool button_press(GdkEventButton *event);
     bool button_release(GdkEventButton *event);
     bool motion_notify(GdkEventMotion *event);
@@ -95,6 +95,7 @@ class Snes9xWindow : public GtkBuilderWindow
     Snes9xConfig *config;
     bool refreshing_bios_menu = false;
     bool refreshing_runahead_menu = false;
+    bool refreshing_controller_menu = false;
     int user_pause, sys_pause;
     int last_width, last_height;
     int mouse_region_x, mouse_region_y;

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1104,7 +1104,25 @@
       <row>
         <col id="0" translatable="yes">5+</col>
       </row>
-    </data>
+          <row>
+        <col id="0" translatable="yes">6</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">7</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">8</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">6+</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">7+</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">8+</col>
+      </row>
+</data>
   </object>
   <object class="GtkListStore" id="liststore3">
     <columns>
@@ -1142,7 +1160,25 @@
       <row>
         <col id="0" translatable="yes">5+</col>
       </row>
-    </data>
+          <row>
+        <col id="0" translatable="yes">6</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">7</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">8</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">6+</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">7+</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">8+</col>
+      </row>
+</data>
   </object>
   <object class="GtkListStore" id="liststore4">
     <columns>
@@ -1813,6 +1849,167 @@
               </object>
             </child>
             <child>
+              <object class="GtkMenuItem" id="input_menu_item">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Input</property>
+                <property name="use_underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu" id="input_menu_item_menu">
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkMenuItem" id="input_configuration_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">_Input Configuration...</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="customize_hotkeys_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">_Customize Hotkeys...</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="input_configuration_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="enable_rumble_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Enable _Rumble (Shake)</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="input_devices_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkRadioMenuItem" id="input_joypad_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use SNES _Joypad(s)</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_as_radio">False</property>
+                        <property name="active">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkRadioMenuItem" id="input_mouse_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use SNES _Mouse</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_as_radio">False</property>
+                        <property name="group">input_joypad_item</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="input_superscope_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use Super _Scope</property>
+                        <property name="use_underline">True</property>
+                        <child type="submenu">
+                          <object class="GtkMenu" id="input_superscope_item_menu">
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkRadioMenuItem" id="input_superscope_enable_item">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">_Enable</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_as_radio">False</property>
+                                <property name="group">input_joypad_item</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="input_superscope_crosshair_item">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Show _Crosshair</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkRadioMenuItem" id="input_multitap5_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use Super Multi_tap (5-player)</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_as_radio">False</property>
+                        <property name="group">input_joypad_item</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkRadioMenuItem" id="input_justifier_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use Konami _Justifier</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_as_radio">False</property>
+                        <property name="group">input_joypad_item</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkRadioMenuItem" id="input_mouse_swapped_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use Mouse in _alternate port</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_as_radio">False</property>
+                        <property name="group">input_joypad_item</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkRadioMenuItem" id="input_multitap8_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use Multitaps (_8-player)</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_as_radio">False</property>
+                        <property name="group">input_joypad_item</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkRadioMenuItem" id="input_dual_justifiers_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use _Dual Justifiers</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_as_radio">False</property>
+                        <property name="group">input_joypad_item</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkRadioMenuItem" id="input_macsrifle_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Use M.A.C.S. _Rifle</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_as_radio">False</property>
+                        <property name="group">input_joypad_item</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="GtkMenuItem" id="sound_menu_item">
                 <property name="label" translatable="yes">_Sound</property>
                 <property name="visible">True</property>
@@ -2126,142 +2323,6 @@
                 <child type="submenu">
                   <object class="GtkMenu" id="options_menu_item_menu">
                     <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkMenuItem" id="controller_ports_item">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Controller Ports</property>
-                        <property name="use_underline">True</property>
-                        <child type="submenu">
-                          <object class="GtkMenu" id="controller_ports_item_menu">
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkMenuItem" id="snes_port_1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">SNES Port 1</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="on_snes_port_1_activate" swapped="no"/>
-                                <child type="submenu">
-                                  <object class="GtkMenu" id="snes_port_1_menu">
-                                    <property name="can_focus">False</property>
-                                    <child>
-                                      <object class="GtkRadioMenuItem" id="joypad1">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Joypad</property>
-                                        <property name="use_underline">True</property>
-                                        <signal name="activate" handler="on_port_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkRadioMenuItem" id="mouse1">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Mouse</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="group">joypad1</property>
-                                        <signal name="activate" handler="on_port_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkRadioMenuItem" id="superscope1">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Superscope</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="active">True</property>
-                                        <property name="group">joypad1</property>
-                                        <signal name="activate" handler="on_port_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="snes_port_2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">SNES Port 2</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="on_snes_port_2_activate" swapped="no"/>
-                                <child type="submenu">
-                                  <object class="GtkMenu" id="snes_port_2_menu">
-                                    <property name="can_focus">False</property>
-                                    <child>
-                                      <object class="GtkRadioMenuItem" id="joypad2">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Joypad</property>
-                                        <property name="use_underline">True</property>
-                                        <signal name="activate" handler="on_port_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkRadioMenuItem" id="mouse2">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Mouse</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="group">joypad2</property>
-                                        <signal name="activate" handler="on_port_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkRadioMenuItem" id="multitap2">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Multitap</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="group">joypad2</property>
-                                        <signal name="activate" handler="on_port_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkRadioMenuItem" id="superscope2">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Superscope</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="active">True</property>
-                                        <property name="group">joypad2</property>
-                                        <signal name="activate" handler="on_port_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkRadioMenuItem" id="nothingpluggedin2">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes" context="SNES port 2">None</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="active">True</property>
-                                        <property name="group">joypad2</property>
-                                        <signal name="activate" handler="on_port_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkCheckMenuItem" id="enable_rumble_item">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Enable _Rumble (Shake)</property>
-                        <property name="use_underline">True</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator6">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
                     <child>
                       <object class="GtkMenuItem" id="cheats_item">
                         <property name="visible">True</property>

--- a/qt/src/ControllerPanel.cpp
+++ b/qt/src/ControllerPanel.cpp
@@ -33,7 +33,7 @@ ControllerPanel::ControllerPanel(EmuApplication *app_)
     });
 
     auto swap_menu = edit_menu.addMenu(QObject::tr("Swap With"));
-    for (auto i = 0; i < 5; i++)
+    for (auto i = 0; i < EmuConfig::num_controllers; i++)
     {
         action = swap_menu->addAction(QObject::tr("Controller %1").arg(i + 1));
         connect(action, &QAction::triggered, [&, i](bool) {
@@ -63,9 +63,11 @@ ControllerPanel::ControllerPanel(EmuApplication *app_)
         app->updateBindings();
     });
 
+    // Same setting as the Input menu's device list.
     connect(portComboBox, &QComboBox::currentIndexChanged, [&](int index) {
-        this->app->config->port_configuration = index;
-        app->updateBindings();
+        if (index < 0 || index == this->app->config->port_configuration)
+            return;
+        app->setPortConfiguration(index);
     });
 }
 

--- a/qt/src/ControllerPanel.ui
+++ b/qt/src/ControllerPanel.ui
@@ -33,27 +33,47 @@
       <widget class="QComboBox" name="portComboBox">
        <item>
         <property name="text">
-         <string>One Controller</string>
+         <string>SNES Joypad(s)</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Two Controllers</string>
+         <string>SNES Mouse</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Mouse + Controller</string>
+         <string>Super Scope</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>SuperScope + Controller</string>
+         <string>Super Multitap (5-player)</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Controller + Multitap</string>
+         <string>Konami Justifier</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Mouse in alternate port</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Multitaps (8-player)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Dual Justifiers</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>M.A.C.S. Rifle</string>
         </property>
        </item>
       </widget>
@@ -110,6 +130,21 @@
        <item>
         <property name="text">
          <string>SNES Controller 5 (Multitap)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>SNES Controller 6 (Multitaps, 8-player)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>SNES Controller 7 (Multitaps, 8-player)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>SNES Controller 8 (Multitaps, 8-player)</string>
         </property>
        </item>
       </widget>

--- a/qt/src/EmuApplication.cpp
+++ b/qt/src/EmuApplication.cpp
@@ -17,6 +17,7 @@
 #include <thread>
 
 #include "snes9x.h"
+#include "memmap.h"
 #include "controls.h"
 #ifdef RETROACHIEVEMENTS_SUPPORT
 #include "RAIntegrationQt.hpp"
@@ -296,11 +297,141 @@ bool EmuApplication::openFile(const std::string &filename)
 #endif
     auto result = core->openFile(filename);
     unsuspendThread();
+    if (result)
+        applyRomControllerHints();
 #ifdef RETROACHIEVEMENTS_SUPPORT
     if (result)
         RA_OnLoadROM();
 #endif
     return result;
+}
+
+void EmuApplication::setPortConfiguration(int configuration)
+{
+    if (configuration < 0 || configuration >= EmuConfig::eNumPortConfigurations)
+        return;
+    config->port_configuration = configuration;
+    // A manual pick is the new baseline: nothing to restore on the next ROM.
+    port_configuration_before_rom = -1;
+    updateBindings();
+}
+
+void EmuApplication::setSuperScopeCrosshairVisible(bool visible)
+{
+    config->superscope_crosshair_visible = visible;
+    suspendThread();
+    core->setSuperScopeCrosshairVisible(visible);
+    unsuspendThread();
+}
+
+bool EmuApplication::isPortConfigurationValid(int configuration)
+{
+    return (valid_port_configurations >> configuration) & 1;
+}
+
+void EmuApplication::applyRomControllerHints()
+{
+    // Port of win32's S9xPostRomInit(): undo whatever the previous ROM
+    // forced, then let this ROM's NSRT header (or the M.A.C.S. rifle title)
+    // choose the devices and restrict the menu to the ones it supports.
+    using PC = EmuConfig;
+    const int applied = config->port_configuration;
+
+    if (port_configuration_before_rom >= 0)
+        config->port_configuration = port_configuration_before_rom;
+
+    const int previous = config->port_configuration;
+    int &option = config->port_configuration;
+    valid_port_configurations = 0xffff;
+
+    if (!Settings.DisableGameSpecificHacks && strncmp(Memory.ROMName, "MAC:Basic Rifle", 15) == 0)
+        option = PC::eMacsRifle;
+
+    if (!strncmp((const char *)Memory.NSRTHeader + 24, "NSRT", 4))
+    {
+        switch (Memory.NSRTHeader[29])
+        {
+        default: // unknown or unsupported
+            break;
+        case 0x00: // Gamepad / Gamepad
+            option = PC::eJoypads;
+            valid_port_configurations = (1 << PC::eJoypads);
+            break;
+        case 0x10: // Mouse / Gamepad
+            option = PC::eMouse;
+            valid_port_configurations = (1 << PC::eMouse);
+            break;
+        case 0x20: // Mouse_or_Gamepad / Gamepad
+            if (option == PC::eMouseSwapped)
+                option = PC::eMouse;
+            if (option != PC::eMouse)
+                option = PC::eJoypads;
+            valid_port_configurations = (1 << PC::eJoypads) | (1 << PC::eMouse);
+            break;
+        case 0x01: // Gamepad / Mouse
+            option = PC::eMouseSwapped;
+            valid_port_configurations = (1 << PC::eMouseSwapped);
+            break;
+        case 0x22: // Mouse_or_Gamepad / Mouse_or_Gamepad
+            if (option != PC::eMouse && option != PC::eMouseSwapped)
+                option = PC::eJoypads;
+            valid_port_configurations = (1 << PC::eJoypads) | (1 << PC::eMouse) | (1 << PC::eMouseSwapped);
+            break;
+        case 0x03: // Gamepad / Superscope
+            option = PC::eSuperScope;
+            valid_port_configurations = (1 << PC::eSuperScope);
+            break;
+        case 0x04: // Gamepad / Gamepad_or_Superscope
+            if (option == PC::eJustifier || option == PC::eDualJustifiers)
+                option = PC::eSuperScope;
+            if (option != PC::eSuperScope)
+                option = PC::eJoypads;
+            valid_port_configurations = (1 << PC::eJoypads) | (1 << PC::eSuperScope);
+            break;
+        case 0x05: // Gamepad / Justifier
+            if (option != PC::eDualJustifiers)
+                option = PC::eJustifier;
+            valid_port_configurations = (1 << PC::eJustifier) | (1 << PC::eDualJustifiers);
+            break;
+        case 0x06: // Gamepad / Multitap_or_Gamepad
+            option = PC::eMultitap5;
+            valid_port_configurations = (1 << PC::eMultitap5) | (1 << PC::eJoypads);
+            break;
+        case 0x66: // Multitap_or_Gamepad / Multitap_or_Gamepad
+            option = PC::eMultitap8;
+            valid_port_configurations = (1 << PC::eMultitap8) | (1 << PC::eMultitap5) | (1 << PC::eJoypads);
+            break;
+        case 0x24: // Gamepad_or_Mouse / Gamepad_or_Superscope
+            if (option == PC::eJustifier || option == PC::eDualJustifiers)
+                option = PC::eSuperScope;
+            if (option != PC::eSuperScope && option != PC::eMouse)
+                option = PC::eJoypads;
+            valid_port_configurations = (1 << PC::eJoypads) | (1 << PC::eMouse) | (1 << PC::eSuperScope);
+            break;
+        case 0x27: // Gamepad_or_Mouse / Gamepad_or_Mouse_or_Superscope
+            if (option == PC::eJustifier || option == PC::eDualJustifiers)
+                option = PC::eSuperScope;
+            if (option != PC::eSuperScope && option != PC::eMouse && option != PC::eMouseSwapped)
+                option = PC::eJoypads;
+            valid_port_configurations = (1 << PC::eJoypads) | (1 << PC::eMouse) | (1 << PC::eMouseSwapped) | (1 << PC::eSuperScope);
+            break;
+        case 0x08: // Gamepad / Mouse_or_Multitap_or_Gamepad
+            if (option == PC::eMouse)
+                option = PC::eMouseSwapped;
+            if (option == PC::eMultitap8)
+                option = PC::eMultitap5;
+            if (option != PC::eMultitap5 && option != PC::eMouseSwapped)
+                option = PC::eJoypads;
+            valid_port_configurations = (1 << PC::eMouseSwapped) | (1 << PC::eMultitap5) | (1 << PC::eJoypads);
+            break;
+        }
+    }
+
+    // Remember what (if anything) the devices were forced away from.
+    port_configuration_before_rom = previous;
+
+    if (option != applied)
+        updateBindings();
 }
 
 void EmuApplication::mainLoop()
@@ -574,8 +705,7 @@ void EmuApplication::handleBinding(const std::string &name, bool pressed)
             }
             else if (name == "GrabMouse")
             {
-                if (config->port_configuration == EmuConfig::eMousePlusController ||
-                    config->port_configuration == EmuConfig::eSuperScopePlusController)
+                if (EmuConfig::portConfigurationUsesPointer(config->port_configuration))
                     window->toggleMouseGrab();
             }
         }
@@ -736,6 +866,12 @@ void EmuApplication::reportPointer(int x, int y)
     emu_thread->runOnThread([&, x, y] {
         core->reportPointer(x, y);
     });
+}
+
+void EmuApplication::reportPointerAbsolute(int x, int y)
+{
+    if (core->active)
+        core->reportPointerAbsolute(x, y);
 }
 
 void EmuApplication::reportMouseButton(int button, bool pressed)

--- a/qt/src/EmuApplication.hpp
+++ b/qt/src/EmuApplication.hpp
@@ -64,7 +64,19 @@ struct EmuApplication
     void pollJoysticks();
     void updateRumble();
     void reportPointer(int x, int y);
+    void reportPointerAbsolute(int x, int y);
     void reportMouseButton(int button, bool pressed);
+
+    /* Controller-port devices, as win32's Input menu offers them. A ROM's
+     * NSRT header may pick the devices itself and narrow the menu to the ones
+     * the game supports; the choice it displaced comes back on the next load
+     * unless the user has picked something by hand since. */
+    void setPortConfiguration(int configuration);
+    void setSuperScopeCrosshairVisible(bool visible);
+    bool isPortConfigurationValid(int configuration);
+    void applyRomControllerHints();
+    int valid_port_configurations = 0xffff;
+    int port_configuration_before_rom = -1;
     void restartAudio();
     void writeSamples(int16_t *data, int samples);
     void mainLoop();

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -354,7 +354,8 @@ bool EmuConfig::setDefaults(int section)
         automap_gamepads = true;
         enable_rumble = true;
         // Controllers
-        port_configuration = 0;
+        port_configuration = eJoypads;
+        superscope_crosshair_visible = true;
         memset(binding.controller, 0, sizeof(binding.controller));
 
         const char *button_list[] = { "Up", "Down", "Left", "Right", "d", "c", "s", "x", "z", "a", "Return", "Space" };
@@ -651,10 +652,15 @@ void EmuConfig::config(const std::string &filename, bool write)
     BeginSection("Ports");
     Bool("AutomapGamepads", automap_gamepads, "Automatically map newly connected gamepads to a sensible default layout");
     Bool("EnableRumble", enable_rumble, "on to pass rumble-cart motor effects (LRG SNES releases) to the port-1 gamepad");
-    Enum("PortConfiguration", port_configuration, { "OneController", "TwoControllers", "Mouse", "SuperScope", "Multitap" }, "What is plugged into the console's controller ports: OneController, TwoControllers, Mouse, SuperScope, or Multitap");
+    // Names follow the PortConfiguration enum order. The first three
+    // devices keep the values older configs wrote; the two legacy joypad
+    // names (OneController, TwoControllers) simply fall through to the
+    // Joypads default.
+    Enum("PortConfiguration", port_configuration, { "Joypads", "Mouse", "SuperScope", "Multitap", "Justifier", "MouseSwapped", "Multitap8", "DualJustifiers", "MacsRifle" }, "What is plugged into the console's controller ports: Joypads, Mouse, SuperScope, Multitap, Justifier, MouseSwapped, Multitap8, DualJustifiers, or MacsRifle");
+    Bool("SuperScopeCrosshair", superscope_crosshair_visible, "true to draw the Super Scope's crosshair on screen");
     EndSection();
 
-    for (int c = 0; c < 5; c++)
+    for (int c = 0; c < num_controllers; c++)
     {
         BeginSection("Controller_" + std::to_string(c));
 
@@ -754,5 +760,31 @@ void EmuConfig::setVRRConfig(bool enable)
         input_rate = saved_input_rate;
         speed_sync_method = saved_speed_sync_method;
         enable_vsync = saved_enable_vsync;
+    }
+}
+
+bool EmuConfig::portConfigurationUsesPointer(int configuration)
+{
+    switch (configuration)
+    {
+    case eMouse:
+    case eMouseSwapped:
+        return true;
+    default:
+        return portConfigurationUsesGun(configuration);
+    }
+}
+
+bool EmuConfig::portConfigurationUsesGun(int configuration)
+{
+    switch (configuration)
+    {
+    case eSuperScope:
+    case eJustifier:
+    case eDualJustifiers:
+    case eMacsRifle:
+        return true;
+    default:
+        return false;
     }
 }

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -224,15 +224,33 @@ struct EmuConfig
     std::string ra_api_token;
     std::string ra_emulator_name = "SuperSnes9x";
 
+    /* What is plugged into the two controller ports. One entry per item of
+     * win32's Input menu device list, in the same order as its enum, so the
+     * NSRT auto-detection table can be shared verbatim. */
     enum PortConfiguration
     {
-        eOneController = 0,
-        eTwoControllers,
-        eMousePlusController,
-        eSuperScopePlusController,
-        eControllerPlusMultitap
+        eJoypads = 0,
+        eMouse,
+        eSuperScope,
+        eMultitap5,
+        eJustifier,
+        eMouseSwapped,
+        eMultitap8,
+        eDualJustifiers,
+        eMacsRifle,
+        eNumPortConfigurations
     };
     int port_configuration;
+    bool superscope_crosshair_visible;
+
+    // A mouse or light gun is aimed with the host pointer.
+    static bool portConfigurationUsesPointer(int configuration);
+    // Light guns aim at absolute screen positions; the SNES Mouse is relative.
+    static bool portConfigurationUsesGun(int configuration);
+
+    /* Bindings for SNES pads 1-8: two on the console, up to eight with a
+     * multitap in each port, as on win32. */
+    static const int num_controllers = 8;
 
     static const int allowed_bindings = 4;
     static const int num_controller_bindings = 18;
@@ -251,7 +269,7 @@ struct EmuConfig
         struct
         {
             EmuBinding buttons[num_controller_bindings * allowed_bindings];
-        } controller[5];
+        } controller[num_controllers];
 
         EmuBinding shortcuts[num_shortcuts * allowed_bindings];
     } binding;

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -574,6 +574,76 @@ void EmuMainWindow::createWidgets()
 
     menuBar()->addMenu(emulation_menu);
 
+    // win32's Input menu: the configuration dialogs, rumble, and the device
+    // list for the two controller ports.
+    auto input_menu = new QMenu(tr("&Input"));
+
+    // The Controllers and Shortcuts settings panels (indices into the
+    // Options menu's setting_panels list below).
+    auto input_configuration_item = input_menu->addAction(QIcon(iconset + "joypad.svg"), tr("&Input Configuration..."));
+    QObject::connect(input_configuration_item, &QAction::triggered, [&] {
+        if (!g_emu_settings_window)
+            g_emu_settings_window = new EmuSettingsWindow(this, app);
+        g_emu_settings_window->show(4);
+    });
+    auto customize_hotkeys_item = input_menu->addAction(QIcon(iconset + "keyboard.svg"), tr("&Customize Hotkeys..."));
+    QObject::connect(customize_hotkeys_item, &QAction::triggered, [&] {
+        if (!g_emu_settings_window)
+            g_emu_settings_window = new EmuSettingsWindow(this, app);
+        g_emu_settings_window->show(5);
+    });
+
+    input_menu->addSeparator();
+
+    // win32's Input->Enable Rumble (Shake): pass LRG rumble-cart motor
+    // effects to the port-1 gamepad.
+    auto rumble_item = input_menu->addAction(tr("Enable &Rumble (Shake)"));
+    rumble_item->setCheckable(true);
+    rumble_item->setChecked(app->config->enable_rumble);
+    QObject::connect(rumble_item, &QAction::triggered, [&](bool checked) {
+        app->config->enable_rumble = checked;
+    });
+
+    input_menu->addSeparator();
+
+    // What is plugged into the two controller ports. Items a ROM's NSRT
+    // header rules out are greyed.
+    port_configuration_actions.assign(EmuConfig::eNumPortConfigurations, nullptr);
+    auto add_device_item = [&](QMenu *menu, int configuration, const QString &text) {
+        auto action = menu->addAction(text);
+        action->setCheckable(true);
+        QObject::connect(action, &QAction::triggered, [&, configuration] {
+            app->setPortConfiguration(configuration);
+            updatePortConfigurationMenu();
+        });
+        port_configuration_actions[configuration] = action;
+    };
+
+    add_device_item(input_menu, EmuConfig::eJoypads, tr("Use SNES &Joypad(s)"));
+    add_device_item(input_menu, EmuConfig::eMouse, tr("Use SNES &Mouse"));
+
+    auto superscope_menu = input_menu->addMenu(tr("Use Super &Scope"));
+    add_device_item(superscope_menu, EmuConfig::eSuperScope, tr("&Enable"));
+    superscope_crosshair_action = superscope_menu->addAction(tr("Show &Crosshair"));
+    superscope_crosshair_action->setCheckable(true);
+    QObject::connect(superscope_crosshair_action, &QAction::triggered, [&](bool checked) {
+        app->setSuperScopeCrosshairVisible(checked);
+    });
+
+    add_device_item(input_menu, EmuConfig::eMultitap5, tr("Use Super Multi&tap (5-player)"));
+    add_device_item(input_menu, EmuConfig::eJustifier, tr("Use Konami &Justifier"));
+    add_device_item(input_menu, EmuConfig::eMouseSwapped, tr("Use Mouse in &alternate port"));
+    add_device_item(input_menu, EmuConfig::eMultitap8, tr("Use Multitaps (&8-player)"));
+    add_device_item(input_menu, EmuConfig::eDualJustifiers, tr("Use &Dual Justifiers"));
+    add_device_item(input_menu, EmuConfig::eMacsRifle, tr("Use M.A.C.S. &Rifle"));
+
+    QObject::connect(input_menu, &QMenu::aboutToShow, [&] {
+        updatePortConfigurationMenu();
+    });
+    updatePortConfigurationMenu();
+
+    menuBar()->addMenu(input_menu);
+
     // Sound Menu, mirroring win32's Sound menu (Channels popup + Mute).
     auto sound_menu = new QMenu(tr("&Sound"));
 
@@ -708,17 +778,6 @@ void EmuMainWindow::createWidgets()
     });
     options_menu->addAction(shader_settings_item);
     updateShaderSettingsItem();
-
-    options_menu->addSeparator();
-
-    // win32's Input->Enable Rumble (Shake): pass LRG rumble-cart motor
-    // effects to the port-1 gamepad.
-    auto rumble_item = options_menu->addAction(tr("Enable &Rumble (Shake)"));
-    rumble_item->setCheckable(true);
-    rumble_item->setChecked(app->config->enable_rumble);
-    QObject::connect(rumble_item, &QAction::triggered, [&](bool checked) {
-        app->config->enable_rumble = checked;
-    });
 
     menuBar()->addMenu(options_menu);
 
@@ -1132,10 +1191,26 @@ bool EmuMainWindow::event(QEvent *event)
     case QEvent::MouseButtonPress:
     case QEvent::MouseButtonRelease:
     {
-        if (!mouse_grabbed)
+        if (!mouse_grabbed && !gunAimsAtPointer())
             break;
         auto mouse_event = (QMouseEvent *)event;
-        app->reportMouseButton(mouse_event->button(), event->type() == QEvent::MouseButtonPress);
+        int button = 0;
+        switch (mouse_event->button())
+        {
+        case Qt::LeftButton:
+            button = 1;
+            break;
+        case Qt::RightButton:
+            button = 2;
+            break;
+        case Qt::MiddleButton:
+            button = 3;
+            break;
+        default:
+            break;
+        }
+        if (button)
+            app->reportMouseButton(button, event->type() == QEvent::MouseButtonPress);
         break;
     }
     case QEvent::MouseMove:
@@ -1148,6 +1223,10 @@ bool EmuMainWindow::event(QEvent *event)
                 break;
             app->reportPointer(delta.x(), delta.y());
             QCursor::setPos(center);
+        }
+        else if (gunAimsAtPointer())
+        {
+            reportGunAim(((QMouseEvent *)event)->globalPosition().toPoint());
         }
         if (!cursor_visible)
         {
@@ -1315,6 +1394,47 @@ void EmuMainWindow::gameChanging()
 {
     if (cheats_dialog)
         cheats_dialog->close();
+}
+
+bool EmuMainWindow::gunAimsAtPointer()
+{
+    return canvas && app->isCoreActive() &&
+           EmuConfig::portConfigurationUsesGun(app->config->port_configuration);
+}
+
+void EmuMainWindow::reportGunAim(const QPoint &global_pos)
+{
+    // Map the pointer through the letterboxed image onto the SNES screen,
+    // the way the GTK port aims an ungrabbed gun. Outside the image counts
+    // as off-screen, which the core reads as such.
+    auto ratio = canvas->devicePixelRatio();
+    auto image = canvas->applyAspect(QRect(0, 0, canvas->width() * ratio, canvas->height() * ratio));
+    if (image.width() <= 0 || image.height() <= 0)
+        return;
+
+    auto pos = canvas->mapFromGlobal(global_pos) * ratio;
+    int height = app->config->show_overscan ? 239 : 224;
+    int x = (pos.x() - image.x()) * 256 / image.width();
+    int y = (pos.y() - image.y()) * height / image.height();
+    app->reportPointerAbsolute(x, y);
+}
+
+void EmuMainWindow::updatePortConfigurationMenu()
+{
+    for (int i = 0; i < (int)port_configuration_actions.size(); i++)
+    {
+        auto action = port_configuration_actions[i];
+        if (!action)
+            continue;
+        action->setChecked(app->config->port_configuration == i);
+        action->setEnabled(app->isPortConfigurationValid(i));
+    }
+
+    if (superscope_crosshair_action)
+    {
+        superscope_crosshair_action->setChecked(app->config->superscope_crosshair_visible);
+        superscope_crosshair_action->setEnabled(app->config->port_configuration == EmuConfig::eSuperScope);
+    }
 }
 
 void EmuMainWindow::toggleMouseGrab()

--- a/qt/src/EmuMainWindow.hpp
+++ b/qt/src/EmuMainWindow.hpp
@@ -41,6 +41,7 @@ class EmuMainWindow : public QMainWindow
     void updateShaderSettingsItem();
     void gameChanging();
     void toggleMouseGrab();
+    void updatePortConfigurationMenu();
     std::vector<std::string> getDisplayDeviceList();
     EmuApplication *app = nullptr;
     EmuCanvas *canvas = nullptr;
@@ -78,6 +79,12 @@ class EmuMainWindow : public QMainWindow
 
     QTimer mouse_timer;
     bool cursor_visible = true;
+    // Light guns aim at the spot under the (ungrabbed) host pointer.
+    bool gunAimsAtPointer();
+    void reportGunAim(const QPoint &global_pos);
+    // Input menu device list, one per EmuConfig::PortConfiguration.
+    std::vector<QAction *> port_configuration_actions;
+    QAction *superscope_crosshair_action = nullptr;
     QAction *shader_settings_item;
     std::vector<QAction *> core_actions;
     std::vector<QAction *> recent_menu_items;

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -4,6 +4,8 @@
 #include "SoftwareFilters.hpp"
 #include "fscompat.h"
 #include <filesystem>
+#include <algorithm>
+#include <cstring>
 namespace fs = std::filesystem;
 
 #include "snes9x.h"
@@ -15,6 +17,7 @@ namespace fs = std::filesystem;
 #include "snapshot.h"
 #include "screenshot.h"
 #include "controls.h"
+#include "crosshairs.h"
 #include "cheats.h"
 #include "movie.h"
 
@@ -51,10 +54,8 @@ Snes9xController *Snes9xController::get()
 
 void Snes9xController::init()
 {
-    Settings.MouseMaster = true;
-    Settings.SuperScopeMaster = true;
-    Settings.JustifierMaster = true;
-    Settings.MultiPlayer5Master = true;
+    // The controller-device master flags are set per port configuration in
+    // updateBindings().
     Settings.Transparency = true;
     Settings.Stereo = true;
     Settings.ReverseStereo = false;
@@ -875,6 +876,86 @@ bool Snes9xController::acceptsCommand(const char *command)
     return !(cmd.type == S9xNoMapping || cmd.type == S9xBadMapping);
 }
 
+/* The joypad buttons that also drive the device in the neighbouring port,
+ * as win32's S9xPollButton() lets them: pad 1 works the mouse or Justifier
+ * that replaces it, pad 2 fires the gun or second mouse in port 2. In
+ * Dual Justifiers mode pad 2's D-pad also steers the second gun's pseudo
+ * pointer (pseudo pointer 1 = PseudoPointerBase, mapped in updateBindings). */
+struct DeviceButton
+{
+    int configuration;
+    int player;
+    const char *button;
+    const char *command;
+};
+
+static const DeviceButton device_buttons[] = {
+    { EmuConfig::eMouse, 0, "A", "Mouse1 L" },
+    { EmuConfig::eMouse, 0, "L", "Mouse1 L" },
+    { EmuConfig::eMouse, 0, "B", "Mouse1 R" },
+    { EmuConfig::eMouse, 0, "R", "Mouse1 R" },
+
+    { EmuConfig::eMouseSwapped, 1, "A", "Mouse2 L" },
+    { EmuConfig::eMouseSwapped, 1, "L", "Mouse2 L" },
+    { EmuConfig::eMouseSwapped, 1, "B", "Mouse2 R" },
+    { EmuConfig::eMouseSwapped, 1, "R", "Mouse2 R" },
+
+    { EmuConfig::eSuperScope, 1, "A", "Superscope Fire" },
+    { EmuConfig::eSuperScope, 1, "L", "Superscope Fire" },
+    { EmuConfig::eSuperScope, 1, "B", "Superscope Cursor" },
+    { EmuConfig::eSuperScope, 1, "R", "Superscope Cursor" },
+    { EmuConfig::eSuperScope, 1, "Y", "Superscope ToggleTurbo" },
+    { EmuConfig::eSuperScope, 1, "Start", "Superscope Pause" },
+    { EmuConfig::eSuperScope, 1, "Select", "Superscope Pause" },
+    { EmuConfig::eSuperScope, 1, "X", "Superscope AimOffscreen" },
+
+    { EmuConfig::eJustifier, 0, "A", "Justifier1 Trigger" },
+    { EmuConfig::eJustifier, 0, "L", "Justifier1 Trigger" },
+    { EmuConfig::eJustifier, 0, "B", "Justifier1 Start" },
+    { EmuConfig::eJustifier, 0, "R", "Justifier1 Start" },
+    { EmuConfig::eJustifier, 0, "X", "Justifier1 AimOffscreen" },
+    { EmuConfig::eJustifier, 0, "Start", "Justifier1 AimOffscreen" },
+
+    { EmuConfig::eDualJustifiers, 0, "A", "Justifier1 Trigger" },
+    { EmuConfig::eDualJustifiers, 0, "L", "Justifier1 Trigger" },
+    { EmuConfig::eDualJustifiers, 0, "B", "Justifier1 Start" },
+    { EmuConfig::eDualJustifiers, 0, "R", "Justifier1 Start" },
+    { EmuConfig::eDualJustifiers, 0, "X", "Justifier1 AimOffscreen" },
+    { EmuConfig::eDualJustifiers, 0, "Start", "Justifier1 AimOffscreen" },
+    { EmuConfig::eDualJustifiers, 1, "A", "Justifier2 Trigger" },
+    { EmuConfig::eDualJustifiers, 1, "L", "Justifier2 Trigger" },
+    { EmuConfig::eDualJustifiers, 1, "B", "Justifier2 Start" },
+    { EmuConfig::eDualJustifiers, 1, "R", "Justifier2 Start" },
+    { EmuConfig::eDualJustifiers, 1, "X", "Justifier2 AimOffscreen" },
+    { EmuConfig::eDualJustifiers, 1, "Start", "Justifier2 AimOffscreen" },
+    { EmuConfig::eDualJustifiers, 1, "Up", "ButtonToPointer 1u Med" },
+    { EmuConfig::eDualJustifiers, 1, "Down", "ButtonToPointer 1d Med" },
+    { EmuConfig::eDualJustifiers, 1, "Left", "ButtonToPointer 1l Med" },
+    { EmuConfig::eDualJustifiers, 1, "Right", "ButtonToPointer 1r Med" },
+
+    { EmuConfig::eMacsRifle, 1, "A", "MacsRifle Trigger" },
+    { EmuConfig::eMacsRifle, 1, "L", "MacsRifle Trigger" },
+};
+
+static s9xcommand_t joypadCommand(int port_configuration, int player, const char *button)
+{
+    std::string name = "Joypad" + std::to_string(player + 1) + " " + button;
+    bool multi = false;
+
+    for (auto &d : device_buttons)
+    {
+        if (d.configuration != port_configuration || d.player != player || strcmp(d.button, button))
+            continue;
+        name += std::string(",") + d.command;
+        multi = true;
+    }
+
+    if (multi)
+        name = "{" + name + "}";
+
+    return S9xGetCommandT(name.c_str());
+}
+
 void Snes9xController::updateBindings(const EmuConfig *const config)
 {
     const char *snes9x_names[] = {
@@ -900,30 +981,69 @@ void Snes9xController::updateBindings(const EmuConfig *const config)
 
     S9xUnmapAllControls();
 
+    // Mirrors win32's ChangeInputDevice(): raise only the master flag of the
+    // selected device, and seat the devices where they sit on real hardware
+    // (a mouse or pad in port 1, a gun or multitap in port 2). Pad N is
+    // driven by the "SNES Controller N" bindings.
+    Settings.MouseMaster = false;
+    Settings.JustifierMaster = false;
+    Settings.SuperScopeMaster = false;
+    Settings.MultiPlayer5Master = false;
+    Settings.MacsRifleMaster = false;
+
     switch (config->port_configuration)
     {
-    case EmuConfig::eTwoControllers:
-        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
-        S9xSetController(1, CTL_JOYPAD, 1, 1, 1, 1);
-        break;
-    case EmuConfig::eMousePlusController:
+    case EmuConfig::eMouse:
+        Settings.MouseMaster = true;
         S9xSetController(0, CTL_MOUSE, 0, 0, 0, 0);
-        S9xSetController(1, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_JOYPAD, 1, 0, 0, 0);
         break;
-    case EmuConfig::eSuperScopePlusController:
-        S9xSetController(0, CTL_SUPERSCOPE, 0, 0, 0, 0);
-        S9xSetController(1, CTL_JOYPAD, 0, 0, 0, 0);
+    case EmuConfig::eMouseSwapped:
+        Settings.MouseMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_MOUSE, 1, 0, 0, 0);
         break;
-    case EmuConfig::eControllerPlusMultitap:
+    case EmuConfig::eSuperScope:
+        Settings.SuperScopeMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_SUPERSCOPE, 0, 0, 0, 0);
+        break;
+    case EmuConfig::eMultitap5:
+        Settings.MultiPlayer5Master = true;
         S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
         S9xSetController(1, CTL_MP5, 1, 2, 3, 4);
         break;
+    case EmuConfig::eMultitap8:
+        Settings.MultiPlayer5Master = true;
+        S9xSetController(0, CTL_MP5, 0, 1, 2, 3);
+        S9xSetController(1, CTL_MP5, 4, 5, 6, 7);
+        break;
+    case EmuConfig::eJustifier:
+        Settings.JustifierMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_JUSTIFIER, 0, 0, 0, 0);
+        break;
+    case EmuConfig::eDualJustifiers:
+        Settings.JustifierMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_JUSTIFIER, 1, 0, 0, 0);
+        break;
+    case EmuConfig::eMacsRifle:
+        Settings.MacsRifleMaster = true;
+        S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
+        S9xSetController(1, CTL_MACSRIFLE, 0, 0, 0, 0);
+        break;
+    case EmuConfig::eJoypads:
     default:
         S9xSetController(0, CTL_JOYPAD, 0, 0, 0, 0);
-        S9xSetController(1, CTL_NONE, 0, 0, 0, 0);
+        S9xSetController(1, CTL_JOYPAD, 1, 0, 0, 0);
+        break;
     }
 
-    for (int controller_number = 0; controller_number < 5; controller_number++)
+    setSuperScopeCrosshairVisible(config->superscope_crosshair_visible);
+    clamp_pointer = EmuConfig::portConfigurationUsesGun(config->port_configuration);
+
+    for (int controller_number = 0; controller_number < EmuConfig::num_controllers; controller_number++)
     {
         auto &controller = config->binding.controller[controller_number];
         for (int i = 0; i < EmuConfig::num_controller_bindings; i++)
@@ -933,11 +1053,8 @@ void Snes9xController::updateBindings(const EmuConfig *const config)
                 auto binding = controller.buttons[i * EmuConfig::allowed_bindings + b];
                 if (binding.hash() == 0)
                     continue;
-                std::string name = "Joypad" +
-                                    std::to_string(controller_number + 1) + " " +
-                                    snes9x_names[i];
 
-                auto cmd = S9xGetCommandT(name.c_str());
+                auto cmd = joypadCommand(config->port_configuration, controller_number, snes9x_names[i]);
                 S9xMapButton(binding.hash(), cmd, false);
             }
         }
@@ -970,9 +1087,7 @@ void Snes9xController::updateBindings(const EmuConfig *const config)
             auto binding = additional.buttons[i];
             if (binding.hash() == 0)
                 continue;
-            std::string name = std::string("Joypad1 ") +
-                               additional_names[i];
-            auto cmd = S9xGetCommandT(name.c_str());
+            auto cmd = joypadCommand(config->port_configuration, 0, additional_names[i]);
             S9xMapButton(binding.hash(), cmd, false);
         }
     }
@@ -991,20 +1106,35 @@ void Snes9xController::updateBindings(const EmuConfig *const config)
         }
     }
 
-    auto cmd = S9xGetCommandT("Pointer Mouse1+Superscope+Justifier1");
+    // The host pointer aims every device that can sit in a port, whichever
+    // one is plugged in. The second Justifier is the exception: as on win32
+    // it is steered from pad 2's D-pad through a pseudo pointer (see
+    // joypadCommand), so it must not also be claimed by the mouse.
+    auto cmd = S9xGetCommandT("Pointer Mouse1+Mouse2+Superscope+Justifier1+MacsRifle");
     S9xMapPointer(EmuBinding::MOUSE_POINTER, cmd, false);
     mouse_x = mouse_y = 0;
     S9xReportPointer(EmuBinding::MOUSE_POINTER, mouse_x, mouse_y);
 
-    cmd = S9xGetCommandT("{Mouse1 L,Superscope Fire,Justifier1 Trigger}");
+    cmd = S9xGetCommandT("Pointer Justifier2");
+    S9xMapPointer(PseudoPointerBase, cmd, false);
+
+    cmd = S9xGetCommandT("{Mouse1 L,Mouse2 L,Superscope Fire,Justifier1 Trigger,MacsRifle Trigger}");
     S9xMapButton(EmuBinding::MOUSE_BUTTON1, cmd, false);
 
     cmd = S9xGetCommandT("{Justifier1 AimOffscreen Trigger,Superscope AimOffscreen}");
     S9xMapButton(EmuBinding::MOUSE_BUTTON3, cmd, false);
 
-    cmd = S9xGetCommandT("{Mouse1 R,Superscope Cursor,Justifier1 Start}");
+    cmd = S9xGetCommandT("{Mouse1 R,Mouse2 R,Superscope Cursor,Justifier1 Start}");
     S9xMapButton(EmuBinding::MOUSE_BUTTON2, cmd, false);
 
+}
+
+void Snes9xController::setSuperScopeCrosshairVisible(bool visible)
+{
+    if (visible)
+        S9xSetControllerCrosshair(X_SUPERSCOPE, 2, "White", "Black");
+    else
+        S9xSetControllerCrosshair(X_SUPERSCOPE, 0, "Trans", "Trans");
 }
 
 void Snes9xController::reportBinding(EmuBinding b, bool active)
@@ -1021,6 +1151,20 @@ void Snes9xController::reportPointer(int x, int y)
 {
     mouse_x += x;
     mouse_y += y;
+    if (clamp_pointer)
+    {
+        // A light gun can only point at the screen, so keep a grabbed
+        // pointer from wandering off into the void.
+        mouse_x = std::clamp<int16_t>(mouse_x, 0, 256);
+        mouse_y = std::clamp<int16_t>(mouse_y, 0, 239);
+    }
+    S9xReportPointer(EmuBinding::MOUSE_POINTER, mouse_x, mouse_y);
+}
+
+void Snes9xController::reportPointerAbsolute(int x, int y)
+{
+    mouse_x = x;
+    mouse_y = y;
     S9xReportPointer(EmuBinding::MOUSE_POINTER, mouse_x, mouse_y);
 }
 

--- a/qt/src/Snes9xController.hpp
+++ b/qt/src/Snes9xController.hpp
@@ -32,6 +32,8 @@ class Snes9xController
     void reportBinding(EmuBinding b, bool active);
     void reportMouseButton(int button, bool pressed);
     void reportPointer(int x, int y);
+    void reportPointerAbsolute(int x, int y);
+    void setSuperScopeCrosshairVisible(bool visible);
     void updateSoundBufferLevel(int, int);
     bool acceptsCommand(const char *command);
     bool isAbnormalSpeed();
@@ -84,6 +86,8 @@ class Snes9xController
   private:
     void SamplesAvailable();
     void mainLoopWithRunAhead();
+    // Light guns keep the pointer within the screen; the SNES mouse is free.
+    bool clamp_pointer = false;
 
     // Savestate scratch buffer for run-ahead. Sized per ROM (freeze size
     // depends on which special chips the cart uses), so openFile clears it.


### PR DESCRIPTION
## Summary

Ports win32's **Input** menu to the Qt and GTK ports, including the full controller device list that was missing on Linux:

- New top-level **Input** menu between Emulation and Sound (win32 order) with **Input Configuration...**, **Customize Hotkeys...**, **Enable Rumble (Shake)** (moved from Options), and the device list: Use SNES Joypad(s), Use SNES Mouse, Use Super Scope (Enable / Show Crosshair), Use Super Multitap (5-player), Use Konami Justifier, Use Mouse in alternate port, Use Multitaps (8-player), Use Dual Justifiers, Use M.A.C.S. Rifle.
- Device seating mirrors win32's `ChangeInputDevice()`: only the selected device's master flag is raised; mouse or pad in port 1, gun or multitap in port 2; pad N is always driven by the "Controller N" bindings.
- Per-ROM auto-detection ported from `S9xPostRomInit()`: NSRT headers and the "MAC:Basic Rifle" title pick the devices, grey out unsupported menu items, and the displaced choice is restored on the next ROM load unless the user picked something by hand.
- Pad buttons also drive the neighbouring device as on win32 (pad 2 fires the Super Scope / rifle, pad 1 works a mouse or Justifier); in Dual Justifiers mode pad 2's D-pad aims the second gun through a pseudo pointer. Mouse 2 and the rifle are also on the host mouse.

### Qt
- `EmuConfig::PortConfiguration` now holds the nine win32 options in win32 enum order; old `Mouse` / `SuperScope` / `Multitap` config values still map, `OneController` / `TwoControllers` fall back to Joypads.
- Controllers panel combobox lists the same nine devices; eight controller binding sets (was five) so the 8-player multitap is usable.
- Ungrabbed light guns aim at the host pointer through the letterboxed image; the middle mouse button now reaches the core (it was mapped to a nonexistent id).

### GTK
- `ControllerOption` enum plus `S9xApplyControllerOption` / `S9xSetControllerOption` / `S9xAutoDetectControllerOption` replace the old per-port "Controller Ports" submenu (the port-2 "None" choice is gone, as on win32).
- Config gains `Input::ControllerOption` (legacy `ControllerPort0/1` read as a fallback) and `Input::SuperScopeCrosshair`.
- `NUM_JOYPADS` 10 -> 16: pads 6-8 and their "+" alternates are appended so existing slot numbers are unchanged.
- Device switching is locked while a movie is active, as on win32.

### Behaviour changes worth noting
- Qt's "One Controller" option is gone; port 2 always holds a pad.
- Qt's Super Scope moves to port 2 and "Use SNES Mouse" pairs the mouse with pad 2's bindings, matching win32 and real hardware.
- Deliberate deviation: Justifier 1's Start is read from pad 1 B/R, where win32 reads pad 2 (a copy-paste slip in its polling code).

## Test plan
- [x] `ninja snes9x-qt` and `ninja snes9x-gtk` build cleanly with no new warnings
- [x] `gtk-builder-tool validate gtk/src/snes9x.ui`
- [x] Qt binary starts headlessly (`QT_QPA_PLATFORM=offscreen`), writes the new config keys, and loads a ROM
- [ ] Manual: switch devices from the Input menu in both ports and confirm mouse / Super Scope / Justifier / multitap games respond
- [ ] Manual: load an NSRT-headered ROM and confirm the device auto-selects and the menu greys the rest
