### PR TITLE
qt/gtk: add the win32 movie and AVI recording items

### DIFF
--- a/common/recording/avi_recorder.cpp
+++ b/common/recording/avi_recorder.cpp
@@ -1,0 +1,302 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "avi_recorder.hpp"
+#include "avi_writer.hpp"
+
+#include "snes9x.h"
+#include "apu/apu.h"
+#include "display.h"
+#include "sgb/sgb.h"
+
+#include <cstring>
+#include <filesystem>
+#include <vector>
+
+namespace
+{
+/* The APU's true output rate, what the resampler is fed at during a recording
+ * (apu.cpp's kAPUInputRate). */
+constexpr uint32_t kAPUInputRate = 32040;
+
+AVIWriter writer;
+std::string avi_filename;
+S9xAVIOptions avi_options;
+
+/* The frame as last captured, already in the file's 24-bit bottom-up form. */
+std::vector<uint8_t> frame;
+std::vector<int16_t> audio;
+int avi_width = 0;
+int avi_height = 0;
+int avi_pitch = 0;
+int audio_rate = 0;
+
+/* GFX.Screen pixel -> B, G, R bytes. */
+std::vector<uint8_t> pixel_lut;
+
+/* The audio settings forced for the recording (see S9xAVIStart) and what
+ * to put back afterwards. */
+uint32_t saved_input_rate = 0;
+bool saved_dynamic_rate_control = false;
+
+void buildPixelLUT()
+{
+    if (!pixel_lut.empty())
+        return;
+    pixel_lut.resize(65536 * 3);
+    for (uint32_t pixel = 0; pixel < 65536; pixel++)
+    {
+        // GFX.Screen is RGB565 (RGB555 on macOS); widen each component to
+        // 8 bits by repeating its top bits so white stays white. The format
+        // names are not numeric macros, so tell them apart by green's range.
+#if MAX_GREEN == 31
+        uint32_t r = (pixel >> 10) & 0x1f, g = (pixel >> 5) & 0x1f, b = pixel & 0x1f;
+        uint8_t g8 = (uint8_t)((g << 3) | (g >> 2));
+#else
+        uint32_t r = (pixel >> 11) & 0x1f, g = (pixel >> 5) & 0x3f, b = pixel & 0x1f;
+        uint8_t g8 = (uint8_t)((g << 2) | (g >> 4));
+#endif
+        pixel_lut[pixel * 3 + 0] = (uint8_t)((b << 3) | (b >> 2));
+        pixel_lut[pixel * 3 + 1] = g8;
+        pixel_lut[pixel * 3 + 2] = (uint8_t)((r << 3) | (r >> 2));
+    }
+}
+
+void forceAudioSettings()
+{
+    /* The resampler must turn the APU's true output rate into exactly
+     * SoundPlaybackRate samples per emulated second, or the audio track
+     * drifts against the video: a user-tuned input rate or dynamic rate
+     * control would bend it by a fraction of a percent. Remember any change
+     * made meanwhile so it comes back when the recording stops. */
+    if (Settings.SoundInputRate != kAPUInputRate)
+        saved_input_rate = Settings.SoundInputRate;
+    if (Settings.DynamicRateControl)
+        saved_dynamic_rate_control = true;
+
+    if (Settings.SoundInputRate != kAPUInputRate || Settings.DynamicRateControl)
+    {
+        Settings.SoundInputRate = kAPUInputRate;
+        Settings.DynamicRateControl = false;
+        S9xUpdateDynamicRate();
+    }
+}
+
+void restoreAudioSettings()
+{
+    Settings.SoundInputRate = saved_input_rate;
+    Settings.DynamicRateControl = saved_dynamic_rate_control;
+    S9xUpdateDynamicRate();
+}
+} // namespace
+
+bool S9xAVIStart(const std::string &filename, const S9xAVIOptions &options, std::string *error)
+{
+    S9xAVIStop();
+
+    // Same output size as win32: the visible SNES image, or the Game Boy
+    // screen for a BIOS-less Super Game Boy cart, doubled for hi-res.
+    int width = SNES_WIDTH;
+    int height = options.overscan ? SNES_HEIGHT_EXTENDED : SNES_HEIGHT;
+    if (Settings.SuperGameBoy)
+    {
+        width = SGB_GB_SCREEN_W;
+        height = SGB_GB_SCREEN_H;
+    }
+    if (options.hires)
+    {
+        width *= 2;
+        height *= 2;
+    }
+    if (height & 1) // most codecs and players want an even height
+        height++;
+
+    // The exact console frame rates (master clock / dots per frame), so the
+    // audio written per emulated second lines up with the frames.
+    uint32_t fps_rate = Settings.PAL ? 21281370 : 21477272;
+    uint32_t fps_scale = Settings.PAL ? 1364 * 312 : 1364 * 262;
+
+    audio_rate = (options.include_audio && Settings.SoundPlaybackRate > 0) ? (int)Settings.SoundPlaybackRate : 0;
+
+    if (!writer.open(filename, width, height, fps_rate, fps_scale, audio_rate, 2))
+    {
+        if (error)
+            *error = "Failed to create AVI file.";
+        return false;
+    }
+
+    avi_filename = filename;
+    avi_options = options;
+    avi_width = writer.width();
+    avi_height = writer.height();
+    avi_pitch = writer.pitch();
+    frame.assign((size_t)avi_pitch * avi_height, 0);
+    audio.clear();
+    buildPixelLUT();
+
+    saved_input_rate = Settings.SoundInputRate;
+    saved_dynamic_rate_control = Settings.DynamicRateControl;
+    forceAudioSettings();
+
+    std::string message = "Recording AVI: " + std::filesystem::path(filename).filename().string();
+    S9xSetInfoString(message.c_str());
+    return true;
+}
+
+void S9xAVIStop(const char *message)
+{
+    if (!writer.isOpen())
+        return;
+
+    writer.close();
+    restoreAudioSettings();
+    frame.clear();
+    audio.clear();
+
+    S9xSetInfoString(message ? message : "AVI recording stopped.");
+}
+
+bool S9xAVIRecording()
+{
+    return writer.isOpen();
+}
+
+const std::string &S9xAVIFilename()
+{
+    return avi_filename;
+}
+
+/* Converts the screen into the file's frame. A hi-res (512-wide) or
+ * interlaced (448/478-line) frame is averaged down to the normal size, and
+ * a normal frame is doubled up to the hi-res size, as win32 does; anything
+ * outside the source is black. */
+void S9xAVICaptureFrame(const uint16_t *screen, int pitch_bytes, int width, int height)
+{
+    if (!writer.isOpen() || !screen || width <= 0 || height <= 0)
+        return;
+
+    const int src_ppl = pitch_bytes / 2;
+
+    // Axis mapping: -1 = average two source pixels, 0 = one to one,
+    // 1 = repeat each source pixel twice.
+    auto axis_mode = [](int src, int dst) {
+        if (src > dst * 3 / 2)
+            return -1;
+        if (src * 3 / 2 < dst)
+            return 1;
+        return 0;
+    };
+    const int x_mode = axis_mode(width, avi_width);
+    const int y_mode = axis_mode(height, avi_height);
+
+    const uint8_t *lut = pixel_lut.data();
+
+    for (int y = 0; y < avi_height; y++)
+    {
+        // Bottom-up rows
+        uint8_t *dst = frame.data() + (size_t)(avi_height - 1 - y) * avi_pitch;
+
+        int sy0, sy1;
+        if (y_mode < 0)
+        {
+            sy0 = y * 2;
+            sy1 = y * 2 + 1;
+        }
+        else if (y_mode > 0)
+            sy0 = sy1 = y / 2;
+        else
+            sy0 = sy1 = y;
+
+        if (sy0 >= height)
+        {
+            memset(dst, 0, avi_pitch);
+            continue;
+        }
+        if (sy1 >= height)
+            sy1 = sy0;
+
+        const uint16_t *row0 = screen + (size_t)sy0 * src_ppl;
+        const uint16_t *row1 = screen + (size_t)sy1 * src_ppl;
+
+        if (x_mode == 0 && y_mode == 0)
+        {
+            int copy_width = width < avi_width ? width : avi_width;
+            for (int x = 0; x < copy_width; x++)
+            {
+                const uint8_t *p = lut + row0[x] * 3;
+                dst[0] = p[0];
+                dst[1] = p[1];
+                dst[2] = p[2];
+                dst += 3;
+            }
+            if (copy_width < avi_width)
+                memset(dst, 0, (size_t)(avi_width - copy_width) * 3);
+            continue;
+        }
+
+        for (int x = 0; x < avi_width; x++)
+        {
+            int sx0, sx1;
+            if (x_mode < 0)
+            {
+                sx0 = x * 2;
+                sx1 = x * 2 + 1;
+            }
+            else if (x_mode > 0)
+                sx0 = sx1 = x / 2;
+            else
+                sx0 = sx1 = x;
+
+            if (sx0 >= width)
+            {
+                memset(dst, 0, (size_t)(avi_width - x) * 3);
+                break;
+            }
+            if (sx1 >= width)
+                sx1 = sx0;
+
+            const uint8_t *p0 = lut + row0[sx0] * 3;
+            const uint8_t *p1 = lut + row0[sx1] * 3;
+            const uint8_t *p2 = lut + row1[sx0] * 3;
+            const uint8_t *p3 = lut + row1[sx1] * 3;
+            dst[0] = (uint8_t)((p0[0] + p1[0] + p2[0] + p3[0] + 2) >> 2);
+            dst[1] = (uint8_t)((p0[1] + p1[1] + p2[1] + p3[1] + 2) >> 2);
+            dst[2] = (uint8_t)((p0[2] + p1[2] + p2[2] + p3[2] + 2) >> 2);
+            dst += 3;
+        }
+    }
+}
+
+void S9xAVIEndFrame()
+{
+    if (!writer.isOpen())
+        return;
+
+    // Like win32, a change of sound format ends the recording rather than
+    // corrupting it.
+    if (audio_rate && (int)Settings.SoundPlaybackRate != audio_rate)
+    {
+        S9xAVIStop("AVI recording stopped (configuration settings changed).");
+        return;
+    }
+    forceAudioSettings();
+
+    writer.addVideoFrame(frame.data());
+
+    if (audio_rate && !audio.empty())
+        writer.addAudio(audio.data(), (int)(audio.size() / 2));
+    audio.clear();
+
+    if (writer.failed())
+        S9xAVIStop("AVI recording stopped (write error).");
+}
+
+void S9xAVIAddSamples(const int16_t *samples, int count)
+{
+    if (!writer.isOpen() || !audio_rate || count <= 0)
+        return;
+    audio.insert(audio.end(), samples, samples + (count & ~1));
+}

--- a/common/recording/avi_recorder.hpp
+++ b/common/recording/avi_recorder.hpp
@@ -1,0 +1,41 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+/* AVI recording for the Qt and GTK ports: the counterpart of the win32
+ * port's File->AVI Recording (DoAVIOpen/DoAVIVideoFrame in win32.cpp), built
+ * on the portable AVIWriter instead of Video for Windows.
+ *
+ * The port feeds it from three places:
+ *   - S9xAVICaptureFrame() from S9xDeinitUpdate(), with the screen exactly
+ *     as it is about to be displayed (after the overscan offset, before any
+ *     hi-res effect or software filter changes it);
+ *   - S9xAVIEndFrame() once per emulated frame from the main loop, which
+ *     writes the last captured frame (again, if the frame was skipped, so the
+ *     file never drifts from the audio) and the audio gathered since;
+ *   - S9xAVIAddSamples() from the samples-available handler with every mixed
+ *     sample, before the sound device gets to drop any.
+ *
+ * All calls belong on the thread that runs the emulation. */
+struct S9xAVIOptions
+{
+    bool hires = false;        // 2x output (512x448) like win32's "Hi-Res AVI Recording"
+    bool overscan = false;     // 239 visible lines instead of 224
+    bool include_audio = true; // win32 records a silent movie while muted
+};
+
+bool S9xAVIStart(const std::string &filename, const S9xAVIOptions &options, std::string *error = nullptr);
+void S9xAVIStop(const char *message = nullptr);
+bool S9xAVIRecording();
+const std::string &S9xAVIFilename();
+
+void S9xAVICaptureFrame(const uint16_t *screen, int pitch_bytes, int width, int height);
+void S9xAVIEndFrame();
+void S9xAVIAddSamples(const int16_t *samples, int count);

--- a/common/recording/avi_writer.cpp
+++ b/common/recording/avi_writer.cpp
@@ -1,0 +1,501 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "avi_writer.hpp"
+
+#include <cstring>
+
+#ifdef _WIN32
+#define avi_fseek _fseeki64
+#define avi_ftell _ftelli64
+#else
+#define avi_fseek fseeko
+#define avi_ftell ftello
+#endif
+
+namespace
+{
+/* One RIFF segment stays below this so its 32-bit size field (and the
+ * players that stop trusting it past 2 GB) never overflow. Same limit as
+ * ffmpeg's AVI muxer. */
+constexpr uint64_t kMaxSegmentSize = 0x40000000;
+/* Super index entries reserved per stream: one per segment, so this is the
+ * longest recording in gigabytes. */
+constexpr uint32_t kSuperIndexEntries = 256;
+
+constexpr uint32_t AVIF_HASINDEX = 0x00000010;
+constexpr uint32_t AVIF_ISINTERLEAVED = 0x00000100;
+constexpr uint32_t AVIF_TRUSTCKTYPE = 0x00000800;
+constexpr uint32_t AVIIF_KEYFRAME = 0x00000010;
+
+constexpr uint8_t AVI_INDEX_OF_INDEXES = 0x00;
+constexpr uint8_t AVI_INDEX_OF_CHUNKS = 0x01;
+
+uint32_t fourcc(const char *s)
+{
+    return (uint32_t)(uint8_t)s[0] | ((uint32_t)(uint8_t)s[1] << 8) |
+           ((uint32_t)(uint8_t)s[2] << 16) | ((uint32_t)(uint8_t)s[3] << 24);
+}
+} // namespace
+
+AVIWriter::~AVIWriter()
+{
+    close();
+}
+
+void AVIWriter::write(const void *data, size_t size)
+{
+    if (!file || write_failed || size == 0)
+        return;
+    if (fwrite(data, 1, size, file) != size)
+        write_failed = true;
+    file_size += size;
+}
+
+void AVIWriter::write8(uint8_t v)
+{
+    write(&v, 1);
+}
+
+void AVIWriter::write16(uint16_t v)
+{
+    uint8_t b[2] = { (uint8_t)v, (uint8_t)(v >> 8) };
+    write(b, 2);
+}
+
+void AVIWriter::write32(uint32_t v)
+{
+    uint8_t b[4] = { (uint8_t)v, (uint8_t)(v >> 8), (uint8_t)(v >> 16), (uint8_t)(v >> 24) };
+    write(b, 4);
+}
+
+void AVIWriter::write64(uint64_t v)
+{
+    write32((uint32_t)v);
+    write32((uint32_t)(v >> 32));
+}
+
+void AVIWriter::writeFourCC(const char *s)
+{
+    write(s, 4);
+}
+
+int64_t AVIWriter::tell()
+{
+    return file ? (int64_t)avi_ftell(file) : 0;
+}
+
+void AVIWriter::seek(int64_t pos)
+{
+    if (file && avi_fseek(file, pos, SEEK_SET) != 0)
+        write_failed = true;
+}
+
+/* Overwrites bytes written earlier; unlike write() this adds nothing to the
+ * running size. */
+void AVIWriter::patch(int64_t pos, const void *data, size_t size)
+{
+    if (!file || write_failed)
+        return;
+    int64_t here = tell();
+    seek(pos);
+    if (fwrite(data, 1, size, file) != size)
+        write_failed = true;
+    seek(here);
+}
+
+void AVIWriter::patch32(int64_t pos, uint32_t v)
+{
+    uint8_t b[4] = { (uint8_t)v, (uint8_t)(v >> 8), (uint8_t)(v >> 16), (uint8_t)(v >> 24) };
+    patch(pos, b, 4);
+}
+
+int64_t AVIWriter::beginList(const char *type)
+{
+    writeFourCC("LIST");
+    int64_t size_pos = tell();
+    write32(0);
+    writeFourCC(type);
+    return size_pos;
+}
+
+int64_t AVIWriter::beginChunk(const char *id)
+{
+    writeFourCC(id);
+    int64_t size_pos = tell();
+    write32(0);
+    return size_pos;
+}
+
+/* Fills in the size of a chunk or list begun above and pads it to an even
+ * length, which RIFF requires (the size field excludes the pad byte). */
+void AVIWriter::endChunk(int64_t size_pos)
+{
+    int64_t end = tell();
+    uint32_t size = (uint32_t)(end - (size_pos + 4));
+    patch32(size_pos, size);
+    if (size & 1)
+        write8(0);
+}
+
+bool AVIWriter::open(const std::string &filename, int width, int height,
+                     uint32_t fps_rate, uint32_t fps_scale,
+                     int audio_rate, int channels)
+{
+    close();
+
+    if (width <= 0 || height <= 0 || fps_rate == 0 || fps_scale == 0)
+        return false;
+
+    file = fopen(filename.c_str(), "wb");
+    if (!file)
+        return false;
+    setvbuf(file, nullptr, _IOFBF, 1 << 20);
+
+    write_failed = false;
+    file_size = 0;
+
+    video_width = width;
+    video_height = height;
+    video_pitch = (width * 3 + 3) & ~3; // DIB rows are 4-byte aligned
+    video_rate = fps_rate;
+    video_scale = fps_scale;
+
+    has_audio = audio_rate > 0 && channels > 0;
+    audio_sample_rate = has_audio ? audio_rate : 0;
+    audio_channels = has_audio ? channels : 0;
+
+    video = Stream{};
+    video.chunk_id = fourcc("00db");
+    audio = Stream{};
+    audio.chunk_id = fourcc("01wb");
+
+    segment_count = 0;
+    first_segment_frames = 0;
+    legacy_entries.clear();
+
+    startSegment();
+
+    if (write_failed)
+    {
+        fclose(file);
+        file = nullptr;
+        return false;
+    }
+    return true;
+}
+
+void AVIWriter::writeSuperIndex(Stream &stream)
+{
+    int64_t size_pos = beginChunk("indx");
+    stream.super_index_pos = tell();
+    stream.super_entries = 0;
+    write16(4);                    // wLongsPerEntry
+    write8(0);                     // bIndexSubType
+    write8(AVI_INDEX_OF_INDEXES);  // bIndexType
+    write32(0);                    // nEntriesInUse, patched per segment
+    write32(stream.chunk_id);      // dwChunkId
+    write32(0);                    // dwReserved[3]
+    write32(0);
+    write32(0);
+    for (uint32_t i = 0; i < kSuperIndexEntries; i++)
+    {
+        write64(0); // qwOffset
+        write32(0); // dwSize
+        write32(0); // dwDuration
+    }
+    endChunk(size_pos);
+}
+
+void AVIWriter::writeHeaders()
+{
+    const uint32_t block_align = (uint32_t)audio_channels * 2;
+    const uint64_t frame_size = (uint64_t)video_pitch * video_height;
+    const double fps = (double)video_rate / video_scale;
+    uint32_t max_bytes_per_sec = (uint32_t)(frame_size * fps);
+    if (has_audio)
+        max_bytes_per_sec += (uint32_t)audio_sample_rate * block_align;
+
+    int64_t hdrl_pos = beginList("hdrl");
+
+    // MainAVIHeader
+    int64_t avih_pos = beginChunk("avih");
+    write32((uint32_t)(1000000.0 * video_scale / video_rate)); // dwMicroSecPerFrame
+    write32(max_bytes_per_sec);                                // dwMaxBytesPerSec
+    write32(0);                                                // dwPaddingGranularity
+    write32(AVIF_HASINDEX | AVIF_ISINTERLEAVED | AVIF_TRUSTCKTYPE); // dwFlags
+    avih_total_frames_pos = tell();
+    write32(0);                     // dwTotalFrames: frames in the first segment
+    write32(0);                     // dwInitialFrames
+    write32(has_audio ? 2 : 1);     // dwStreams
+    write32((uint32_t)frame_size);  // dwSuggestedBufferSize
+    write32((uint32_t)video_width); // dwWidth
+    write32((uint32_t)video_height); // dwHeight
+    write32(0);                     // dwReserved[4]
+    write32(0);
+    write32(0);
+    write32(0);
+    endChunk(avih_pos);
+
+    // Video stream
+    int64_t strl_pos = beginList("strl");
+    int64_t strh_pos = beginChunk("strh");
+    writeFourCC("vids");             // fccType
+    writeFourCC("DIB ");             // fccHandler
+    write32(0);                      // dwFlags
+    write16(0);                      // wPriority
+    write16(0);                      // wLanguage
+    write32(0);                      // dwInitialFrames
+    write32(video_scale);            // dwScale
+    write32(video_rate);             // dwRate
+    write32(0);                      // dwStart
+    video.strh_length_pos = tell();
+    write32(0);                      // dwLength: total frames, patched on close
+    write32((uint32_t)frame_size);   // dwSuggestedBufferSize
+    write32(0xFFFFFFFF);             // dwQuality
+    write32(0);                      // dwSampleSize
+    write16(0);                      // rcFrame
+    write16(0);
+    write16((uint16_t)video_width);
+    write16((uint16_t)video_height);
+    endChunk(strh_pos);
+
+    int64_t strf_pos = beginChunk("strf");
+    write32(40);                       // biSize
+    write32((uint32_t)video_width);    // biWidth
+    write32((uint32_t)video_height);   // biHeight (positive: bottom-up)
+    write16(1);                        // biPlanes
+    write16(24);                       // biBitCount
+    write32(0);                        // biCompression = BI_RGB
+    write32((uint32_t)frame_size);     // biSizeImage
+    write32(0);                        // biXPelsPerMeter
+    write32(0);                        // biYPelsPerMeter
+    write32(0);                        // biClrUsed
+    write32(0);                        // biClrImportant
+    endChunk(strf_pos);
+
+    writeSuperIndex(video);
+    endChunk(strl_pos);
+
+    // Audio stream
+    if (has_audio)
+    {
+        strl_pos = beginList("strl");
+        strh_pos = beginChunk("strh");
+        writeFourCC("auds");                               // fccType
+        write32(0);                                        // fccHandler
+        write32(0);                                        // dwFlags
+        write16(0);                                        // wPriority
+        write16(0);                                        // wLanguage
+        write32(0);                                        // dwInitialFrames
+        write32(block_align);                              // dwScale
+        write32((uint32_t)audio_sample_rate * block_align); // dwRate
+        write32(0);                                        // dwStart
+        audio.strh_length_pos = tell();
+        write32(0);                                        // dwLength: sample frames, patched on close
+        write32((uint32_t)audio_sample_rate * block_align); // dwSuggestedBufferSize
+        write32(0xFFFFFFFF);                               // dwQuality
+        write32(block_align);                              // dwSampleSize
+        write16(0);                                        // rcFrame
+        write16(0);
+        write16(0);
+        write16(0);
+        endChunk(strh_pos);
+
+        strf_pos = beginChunk("strf");
+        write16(1);                                        // wFormatTag = WAVE_FORMAT_PCM
+        write16((uint16_t)audio_channels);                 // nChannels
+        write32((uint32_t)audio_sample_rate);              // nSamplesPerSec
+        write32((uint32_t)audio_sample_rate * block_align); // nAvgBytesPerSec
+        write16((uint16_t)block_align);                    // nBlockAlign
+        write16(16);                                       // wBitsPerSample
+        write16(0);                                        // cbSize
+        endChunk(strf_pos);
+
+        writeSuperIndex(audio);
+        endChunk(strl_pos);
+    }
+
+    // OpenDML extended header: the frame count across every segment.
+    int64_t odml_pos = beginList("odml");
+    int64_t dmlh_pos = beginChunk("dmlh");
+    dmlh_total_frames_pos = tell();
+    write32(0);
+    for (int i = 0; i < 61; i++) // reserved, sized like other writers
+        write32(0);
+    endChunk(dmlh_pos);
+    endChunk(odml_pos);
+
+    endChunk(hdrl_pos);
+}
+
+void AVIWriter::startSegment()
+{
+    riff_start = tell();
+    writeFourCC("RIFF");
+    write32(0); // patched in endSegment
+    writeFourCC(segment_count == 0 ? "AVI " : "AVIX");
+
+    if (segment_count == 0)
+        writeHeaders();
+
+    movi_size_pos = beginList("movi");
+    movi_pos = movi_size_pos + 4;
+
+    video.segment_entries.clear();
+    video.segment_length = 0;
+    audio.segment_entries.clear();
+    audio.segment_length = 0;
+}
+
+/* AVISTDINDEX for one stream, covering the chunks of the current segment;
+ * its position and extent are then recorded in the header's super index. */
+void AVIWriter::writeStandardIndex(Stream &stream)
+{
+    const char *id = (&stream == &video) ? "ix00" : "ix01";
+
+    int64_t chunk_start = tell();
+    int64_t size_pos = beginChunk(id);
+    write16(2);                       // wLongsPerEntry
+    write8(0);                        // bIndexSubType
+    write8(AVI_INDEX_OF_CHUNKS);      // bIndexType
+    write32((uint32_t)stream.segment_entries.size()); // nEntriesInUse
+    write32(stream.chunk_id);         // dwChunkId
+    write64((uint64_t)movi_pos);      // qwBaseOffset
+    write32(0);                       // dwReserved3
+    for (auto &entry : stream.segment_entries)
+    {
+        write32(entry.offset);
+        write32(entry.size); // bit 31 clear: every chunk is a keyframe
+    }
+    endChunk(size_pos);
+    int64_t chunk_end = tell();
+
+    if (stream.super_entries >= kSuperIndexEntries)
+    {
+        write_failed = true; // recording longer than the reserved index
+        return;
+    }
+
+    // AVISUPERINDEX entry: qwOffset, dwSize, dwDuration
+    const uint64_t offset = (uint64_t)chunk_start;
+    const uint32_t size = (uint32_t)(chunk_end - chunk_start);
+    const uint32_t duration = (uint32_t)stream.segment_length;
+    uint8_t entry[16];
+    for (int i = 0; i < 8; i++)
+        entry[i] = (uint8_t)(offset >> (8 * i));
+    for (int i = 0; i < 4; i++)
+    {
+        entry[8 + i] = (uint8_t)(size >> (8 * i));
+        entry[12 + i] = (uint8_t)(duration >> (8 * i));
+    }
+    patch(stream.super_index_pos + 24 + (int64_t)stream.super_entries * 16, entry, 16);
+    stream.super_entries++;
+    patch32(stream.super_index_pos + 4, stream.super_entries); // nEntriesInUse
+}
+
+/* The AVI 1.0 index of the first segment, for players without OpenDML. */
+void AVIWriter::writeLegacyIndex()
+{
+    int64_t size_pos = beginChunk("idx1");
+    for (auto &entry : legacy_entries)
+    {
+        write32(entry.chunk_id);
+        write32(AVIIF_KEYFRAME);
+        write32(entry.offset);
+        write32(entry.size);
+    }
+    endChunk(size_pos);
+    legacy_entries.clear();
+}
+
+void AVIWriter::endSegment()
+{
+    writeStandardIndex(video);
+    if (has_audio)
+        writeStandardIndex(audio);
+    endChunk(movi_size_pos);
+
+    if (segment_count == 0)
+    {
+        first_segment_frames = (uint32_t)video.segment_length;
+        writeLegacyIndex();
+    }
+
+    patch32(riff_start + 4, (uint32_t)(tell() - (riff_start + 8)));
+    segment_count++;
+}
+
+/* Bytes the end of the current segment still needs: its standard indexes
+ * (and, in the first segment, the idx1 index). */
+uint64_t AVIWriter::segmentReserve() const
+{
+    uint64_t reserve = 32 + 8 * (video.segment_entries.size() + 1);
+    if (has_audio)
+        reserve += 32 + 8 * (audio.segment_entries.size() + 1);
+    if (segment_count == 0)
+        reserve += 8 + 16 * (legacy_entries.size() + 1);
+    return reserve + 1024;
+}
+
+void AVIWriter::writeChunk(Stream &stream, const void *data, uint32_t size, uint64_t length)
+{
+    if (!file || write_failed)
+        return;
+
+    uint64_t segment_size = (uint64_t)(tell() - riff_start);
+    if (segment_size + size + 8 + segmentReserve() > kMaxSegmentSize)
+    {
+        endSegment();
+        startSegment();
+    }
+
+    int64_t chunk_pos = tell();
+    uint32_t id = stream.chunk_id;
+    write32(id);
+    write32(size);
+    write(data, size);
+    if (size & 1)
+        write8(0);
+
+    stream.segment_entries.push_back({ (uint32_t)(chunk_pos + 8 - movi_pos), size });
+    if (segment_count == 0)
+        legacy_entries.push_back({ id, (uint32_t)(chunk_pos - movi_pos), size });
+
+    stream.segment_length += length;
+    stream.total_length += length;
+}
+
+void AVIWriter::addVideoFrame(const uint8_t *bgr_bottom_up)
+{
+    writeChunk(video, bgr_bottom_up, (uint32_t)frameSize(), 1);
+}
+
+void AVIWriter::addAudio(const int16_t *samples, int frames)
+{
+    if (!has_audio || frames <= 0)
+        return;
+    writeChunk(audio, samples, (uint32_t)frames * audio_channels * 2, (uint64_t)frames);
+}
+
+void AVIWriter::close()
+{
+    if (!file)
+        return;
+
+    if (!write_failed)
+    {
+        endSegment();
+        patch32(avih_total_frames_pos, first_segment_frames);
+        patch32(dmlh_total_frames_pos, (uint32_t)video.total_length);
+        patch32(video.strh_length_pos, (uint32_t)video.total_length);
+        if (has_audio)
+            patch32(audio.strh_length_pos, (uint32_t)audio.total_length);
+    }
+
+    fclose(file);
+    file = nullptr;
+}

--- a/common/recording/avi_writer.hpp
+++ b/common/recording/avi_writer.hpp
@@ -1,0 +1,130 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+/* A small AVI writer for the ports that have no Video for Windows: one
+ * uncompressed 24-bit bottom-up RGB video stream and an optional 16-bit PCM
+ * audio stream.
+ *
+ * The file is written as OpenDML ("AVI 2.0"): the first RIFF "AVI " segment
+ * carries the headers, a legacy idx1 index and up to 1 GB of data, and the
+ * recording then continues in RIFF "AVIX" segments, each with its own
+ * standard index that the super index in the header points at. That keeps a
+ * long uncompressed recording in a single file rather than the 2 GB splits the
+ * win32 VfW writer makes. Every common player and ffmpeg read this layout. */
+class AVIWriter
+{
+  public:
+    AVIWriter() = default;
+    ~AVIWriter();
+    AVIWriter(const AVIWriter &) = delete;
+    AVIWriter &operator=(const AVIWriter &) = delete;
+
+    /* fps = fps_rate / fps_scale. audio_rate of 0 records no audio stream. */
+    bool open(const std::string &filename, int width, int height,
+              uint32_t fps_rate, uint32_t fps_scale,
+              int audio_rate = 0, int audio_channels = 2);
+
+    /* Exactly frameSize() bytes: pitch()-byte rows, bottom row first, BGR. */
+    void addVideoFrame(const uint8_t *bgr_bottom_up);
+    /* Interleaved 16-bit samples; `frames` sample frames (one per channel). */
+    void addAudio(const int16_t *samples, int frames);
+
+    void close();
+
+    bool isOpen() const { return file != nullptr; }
+    /* A write failed (disk full, ...); nothing more is written. */
+    bool failed() const { return write_failed; }
+
+    int width() const { return video_width; }
+    int height() const { return video_height; }
+    int pitch() const { return video_pitch; }
+    int frameSize() const { return video_pitch * video_height; }
+    uint32_t videoFrames() const { return video.total_length; }
+    uint64_t audioFrames() const { return audio.total_length; }
+    uint64_t bytesWritten() const { return file_size; }
+
+  private:
+    struct IndexEntry
+    {
+        uint32_t offset; // of the chunk data, relative to the movi list
+        uint32_t size;   // of the chunk data
+    };
+
+    struct Stream
+    {
+        uint32_t chunk_id = 0;
+        int64_t strh_length_pos = 0;
+        int64_t super_index_pos = 0;
+        uint32_t super_entries = 0;
+        std::vector<IndexEntry> segment_entries;
+        uint64_t segment_length = 0; // frames or sample frames in this segment
+        uint64_t total_length = 0;
+    };
+
+    void write(const void *data, size_t size);
+    void write8(uint8_t v);
+    void write16(uint16_t v);
+    void write32(uint32_t v);
+    void write64(uint64_t v);
+    void writeFourCC(const char *fourcc);
+    void patch(int64_t pos, const void *data, size_t size);
+    void patch32(int64_t pos, uint32_t v);
+    int64_t tell();
+    void seek(int64_t pos);
+
+    int64_t beginList(const char *type);
+    int64_t beginChunk(const char *id);
+    void endChunk(int64_t size_pos);
+
+    void writeHeaders();
+    void writeSuperIndex(Stream &stream);
+    void writeStandardIndex(Stream &stream);
+    void writeLegacyIndex();
+    void startSegment();
+    void endSegment();
+    uint64_t segmentReserve() const;
+    void writeChunk(Stream &stream, const void *data, uint32_t size, uint64_t length);
+
+    FILE *file = nullptr;
+    bool write_failed = false;
+    uint64_t file_size = 0;
+
+    int video_width = 0;
+    int video_height = 0;
+    int video_pitch = 0;
+    uint32_t video_rate = 0;
+    uint32_t video_scale = 0;
+
+    int audio_sample_rate = 0;
+    int audio_channels = 0;
+    bool has_audio = false;
+
+    Stream video;
+    Stream audio;
+
+    int segment_count = 0;
+    int64_t riff_start = 0;
+    int64_t movi_size_pos = 0;
+    int64_t movi_pos = 0; // position of the "movi" FOURCC, the index base
+    int64_t avih_total_frames_pos = 0;
+    int64_t dmlh_total_frames_pos = 0;
+    uint32_t first_segment_frames = 0;
+
+    struct LegacyEntry
+    {
+        uint32_t chunk_id;
+        uint32_t offset; // of the chunk header, relative to the movi list
+        uint32_t size;
+    };
+    std::vector<LegacyEntry> legacy_entries;
+};

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -305,6 +305,12 @@ list(APPEND SOURCES
     src/gtk_config.h
     src/gtk_control.cpp
     src/gtk_control.h
+    src/gtk_movie.cpp
+    src/gtk_movie.h
+    ../common/recording/avi_writer.cpp
+    ../common/recording/avi_writer.hpp
+    ../common/recording/avi_recorder.cpp
+    ../common/recording/avi_recorder.hpp
     src/gtk_display.cpp
     src/gtk_display_driver_gtk.cpp
     src/gtk_display_driver_gtk.h

--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -111,6 +111,10 @@ int Snes9xConfig::load_defaults()
     sound_playback_rate = 7;
     sound_input_rate = 32040;
     auto_input_rate = false;
+    movie_default_read_only = true;
+    movie_default_from_reset = false;
+    movie_default_clear_sram = false;
+    avi_hires = false;
     master_volume_regular = 100;
     master_volume_fast_forward = 100;
     sgb_mix_volume_spc = 50;
@@ -398,6 +402,9 @@ int Snes9xConfig::save_config_file()
     outint("RewindGranularity", rewind_granularity, "Only save rewind snapshots every N frames");
     outint("CurrentSaveSlot", current_save_slot, "Currently selected save-state slot within the bank (remembered automatically)");
     outint("CurrentSaveBank", current_save_bank, "Currently selected save-state bank (remembered automatically)");
+    outbool("MovieDefaultReadOnly", movie_default_read_only, "Last state of the Play Movie dialog's Open Read-Only box (remembered automatically)");
+    outbool("MovieDefaultStartFromReset", movie_default_from_reset, "Last state of the Record Movie dialog's Record from reset choice (remembered automatically)");
+    outbool("MovieDefaultClearSRAM", movie_default_clear_sram, "Last state of the Record Movie dialog's Clear SRAM box (remembered automatically)");
 
     section = "Emulation";
     outbool("EmulateTransparency", Settings.Transparency, "Render the SNES color/transparency effects (turn off only for troubleshooting)");
@@ -411,6 +418,7 @@ int Snes9xConfig::save_config_file()
     outbool("BlockInvalidVRAMAccess", Settings.BlockInvalidVRAMAccessMaster, "Emulate the real hardware's VRAM access restrictions (on for accuracy; off only for a few broken ROMs/hacks)");
     outbool("AllowDPadContradictions", Settings.UpAndDown, "Allow the D-Pad to press both up + down at the same time, or left + right");
     outint("RunAhead", Settings.RunAhead, "Number of frames to run ahead for reduced input latency (0 = off, 1-4)");
+    outbool("AVIHiRes", avi_hires, "true to record AVI in Hi-Res scale (512x448 instead of 256x224)");
 
     section = "Hacks";
     outint("SuperFXClockMultiplier", Settings.SuperFXClockMultiplier, "SuperFX (GSU) chip speed as a percentage of normal (50-400; 100 = accurate). Higher reduces slowdown in Star Fox and other SuperFX games");
@@ -629,6 +637,9 @@ int Snes9xConfig::load_config_file()
     inint("RewindGranularity", rewind_granularity);
     inint("CurrentSaveSlot", current_save_slot);
     inint("CurrentSaveBank", current_save_bank);
+    inbool("MovieDefaultReadOnly", movie_default_read_only);
+    inbool("MovieDefaultStartFromReset", movie_default_from_reset);
+    inbool("MovieDefaultClearSRAM", movie_default_clear_sram);
 
     /* Older configs stored a flat 0-999 slot index. Split it into a bank and
      * an in-bank slot so the selection survives the upgrade. */
@@ -654,6 +665,7 @@ int Snes9xConfig::load_config_file()
     inbool("DisplayIndicators", Settings.DisplayIndicators);
     inbool("SnapshotScreenshots", Settings.SnapshotScreenshots);
     inint("RunAhead", Settings.RunAhead);
+    inbool("AVIHiRes", avi_hires);
     if (Settings.RunAhead < 0)
         Settings.RunAhead = 0;
     if (Settings.RunAhead > 4)

--- a/gtk/src/gtk_config.h
+++ b/gtk/src/gtk_config.h
@@ -173,6 +173,16 @@ class Snes9xConfig
     int current_save_slot;
     int current_save_bank;
 
+    /* Last choices made in the movie dialogs, remembered like win32's
+     * MovieDefault* settings. */
+    bool movie_default_read_only;
+    bool movie_default_from_reset;
+    bool movie_default_clear_sram;
+
+    /* File->AVI Recording writes 512x448 frames instead of 256x224, like
+     * win32's "Hi-Res AVI Recording" option. */
+    bool avi_hires;
+
     XRRScreenResources *xrr_screen_resources;
     XRRCrtcInfo *xrr_crtc_info;
 

--- a/gtk/src/gtk_control.cpp
+++ b/gtk/src/gtk_control.cpp
@@ -599,6 +599,14 @@ void S9xHandlePortCommand(s9xcommand_t cmd, int16 data1, int16 data2)
         {
             top_level->movie_seek_dialog();
         }
+        else if (cmd.port[0] == PORT_RECORD_MOVIE)
+        {
+            top_level->record_movie_dialog();
+        }
+        else if (cmd.port[0] == PORT_PLAY_MOVIE)
+        {
+            top_level->play_movie_dialog();
+        }
         else if (cmd.port[0] == PORT_SWAP_CONTROLLERS)
         {
             swap_controllers_1_2();
@@ -727,6 +735,16 @@ s9xcommand_t S9xGetPortCommandT(const char *name)
     else if (!strcasecmp(name, "GTK_seek_to_frame"))
     {
         cmd.port[0] = PORT_SEEK_TO_FRAME;
+    }
+    // The core's own versions of these are stubs; the port shows the File
+    // menu's dialogs instead. The config keys stay the same.
+    else if (!strcasecmp(name, "BeginRecordingMovie"))
+    {
+        cmd.port[0] = PORT_RECORD_MOVIE;
+    }
+    else if (!strcasecmp(name, "LoadMovie"))
+    {
+        cmd.port[0] = PORT_PLAY_MOVIE;
     }
     else if (!strcasecmp(name, "GTK_quit"))
     {

--- a/gtk/src/gtk_control.h
+++ b/gtk/src/gtk_control.h
@@ -116,7 +116,9 @@ enum {
     PORT_DIALOGSAVE         = 48,
     PORT_DIALOGLOAD         = 49,
     PORT_FILESAVE           = 50,
-    PORT_FILELOAD           = 51
+    PORT_FILELOAD           = 51,
+    PORT_RECORD_MOVIE       = 52,
+    PORT_PLAY_MOVIE         = 53
 };
 
 typedef struct BindingLink

--- a/gtk/src/gtk_display.cpp
+++ b/gtk/src/gtk_display.cpp
@@ -15,6 +15,7 @@
 #include "snes9x.h"
 #include "gfx.h"
 #include "netplay.h"
+#include "common/recording/avi_recorder.hpp"
 
 #if defined(USE_XV) && defined(GDK_WINDOWING_X11)
 #include "gtk_display_driver_xv.h"
@@ -875,6 +876,11 @@ bool8 S9xDeinitUpdate(int width, int height)
     }
 
     uint16_t *screen_view = GFX.Screen + (yoffset * (int)GFX.RealPPL);
+
+    // The AVI gets the frame as the SNES drew it, before the hi-res effect
+    // and software filter reshape it for the window.
+    if (!Settings.Paused && !NetPlay.Paused)
+        S9xAVICaptureFrame(screen_view, GFX.Pitch, width, height);
 
     if (!Settings.Paused && !NetPlay.Paused)
 

--- a/gtk/src/gtk_movie.cpp
+++ b/gtk/src/gtk_movie.cpp
@@ -1,0 +1,440 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "gtk_movie.h"
+#include "gtk_compat.h"
+#include "gtk_s9x.h"
+#include "gtk_s9xwindow.h"
+#include "gtk_config.h"
+
+#include "fmt/format.h"
+#include <array>
+#include <filesystem>
+
+#include "snes9x.h"
+#include "memmap.h"
+#include "movie.h"
+#include "snapshot.h"
+#include "fscompat.h"
+
+namespace
+{
+constexpr int kMovieJoypads = 8;
+
+/* <ROM name>.smv in the export folder, where both dialogs start. */
+std::string default_movie_path()
+{
+    if (Memory.ROMFilename.empty())
+        return {};
+    return S9xGetFilename(".smv", SCREENSHOT_DIR);
+}
+
+std::string rom_description(uint32_t crc32, const char *name)
+{
+    std::string rom_name(name);
+    while (!rom_name.empty() && rom_name.back() == ' ')
+        rom_name.pop_back();
+    return fmt::format("crc32={:08X}, name={}", crc32, rom_name);
+}
+
+Glib::ustring metadata_to_ustring(const wchar_t *metadata)
+{
+    Glib::ustring text;
+    for (; *metadata; metadata++)
+        text.push_back((gunichar)*metadata);
+    return text;
+}
+
+std::wstring ustring_to_metadata(const Glib::ustring &text)
+{
+    std::wstring metadata;
+    for (gunichar c : text)
+        metadata.push_back((wchar_t)c);
+    return metadata;
+}
+
+Gtk::Frame *make_joypad_frame(std::array<Gtk::CheckButton *, kMovieJoypads> &boxes, bool sensitive)
+{
+    auto frame = Gtk::manage(new Gtk::Frame(_("Record Controllers")));
+    auto grid = Gtk::manage(new Gtk::Grid);
+    grid->set_border_width(5);
+    grid->set_column_spacing(10);
+    grid->set_row_spacing(2);
+    for (int i = 0; i < kMovieJoypads; i++)
+    {
+        boxes[i] = Gtk::manage(new Gtk::CheckButton(fmt::format(fmt::runtime(_("Joypad {}")), i + 1)));
+        boxes[i]->set_sensitive(sensitive);
+        grid->attach(*boxes[i], i % 4, i / 4, 1, 1);
+    }
+    frame->add(*grid);
+    return frame;
+}
+
+std::string browse_for_movie(Gtk::Window &parent, const std::string &current, bool save)
+{
+    Gtk::FileChooserDialog dialog(parent, save ? _("Record Movie") : _("Open Movie"),
+                                  save ? Gtk::FILE_CHOOSER_ACTION_SAVE : Gtk::FILE_CHOOSER_ACTION_OPEN);
+    dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
+    dialog.add_button(save ? _("_Save") : _("_Open"), Gtk::RESPONSE_ACCEPT);
+
+    auto filter = Gtk::FileFilter::create();
+    filter->set_name(_("SuperSnes9x Movie Files"));
+    filter->add_pattern("*.smv");
+    filter->add_pattern("*.SMV");
+    dialog.add_filter(filter);
+    auto all = Gtk::FileFilter::create();
+    all->set_name(_("All Files"));
+    all->add_pattern("*");
+    dialog.add_filter(all);
+
+    std::filesystem::path path(current);
+    if (!current.empty() && std::filesystem::is_directory(path.parent_path()))
+        dialog.set_current_folder(path.parent_path().string());
+    else
+        dialog.set_current_folder(S9xGetDirectory(SCREENSHOT_DIR));
+    if (save)
+    {
+        dialog.set_do_overwrite_confirmation(true);
+        if (!path.filename().empty())
+            dialog.set_current_name(path.filename().string());
+    }
+
+    if (dialog.run() != Gtk::RESPONSE_ACCEPT)
+        return {};
+    return dialog.get_filename();
+}
+} // namespace
+
+std::string S9xMovieErrorString(int result, bool brief)
+{
+    switch (result)
+    {
+    case FILE_NOT_FOUND:
+        return brief ? _("File not found.")
+                     : _("The movie file was not found or could not be opened.");
+    case WRONG_FORMAT:
+        return brief ? _("Unrecognized format.")
+                     : _("The movie file is corrupt or in the wrong format.");
+    case WRONG_VERSION:
+        return brief ? _("Unsupported movie version.")
+                     : _("Unsupported movie version. You need a different version of SuperSnes9x to play this movie.");
+    default:
+        return _("Could not open movie file.");
+    }
+}
+
+bool S9xPlayMovieDialog(MoviePlayChoice &choice)
+{
+    Gtk::Dialog dialog(_("Play Movie"), *top_level->window.get(), true);
+    dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
+    auto ok_button = dialog.add_button(_("_OK"), Gtk::RESPONSE_ACCEPT);
+    dialog.set_default_response(Gtk::RESPONSE_ACCEPT);
+
+    auto vbox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 6));
+    vbox->set_border_width(8);
+
+    auto path_box = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 6));
+    path_box->pack_start(*Gtk::manage(new Gtk::Label(_("Movie File:"))), false, false);
+    Gtk::Entry path_entry;
+    path_entry.set_width_chars(45);
+    path_entry.set_activates_default(true);
+    path_box->pack_start(path_entry, true, true);
+    Gtk::Button browse_button(_("_Browse…"), true);
+    path_box->pack_start(browse_button, false, false);
+    vbox->pack_start(*path_box, false, false);
+
+    Gtk::CheckButton read_only_box(_("Open Read-Only"));
+    read_only_box.set_active(gui_config->movie_default_read_only);
+    vbox->pack_start(read_only_box, false, false);
+
+    Gtk::Label movie_rom_label, current_rom_label;
+    movie_rom_label.set_xalign(0.0);
+    current_rom_label.set_xalign(0.0);
+    vbox->pack_start(movie_rom_label, false, false);
+    vbox->pack_start(current_rom_label, false, false);
+
+    auto middle = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 12));
+
+    auto info_grid = Gtk::manage(new Gtk::Grid);
+    info_grid->set_column_spacing(6);
+    info_grid->set_row_spacing(2);
+    Gtk::Label date_label, length_label, frames_label, rerecord_label;
+    const std::pair<const char *, Gtk::Label *> rows[] = {
+        { _("Recording Date:"), &date_label },
+        { _("Length:"), &length_label },
+        { _("Frames:"), &frames_label },
+        { _("Re-record Count:"), &rerecord_label },
+    };
+    int row = 0;
+    for (auto &[name, label] : rows)
+    {
+        auto title = Gtk::manage(new Gtk::Label(name));
+        title->set_xalign(1.0);
+        label->set_xalign(0.0);
+        label->set_width_chars(24);
+        info_grid->attach(*title, 0, row, 1, 1);
+        info_grid->attach(*label, 1, row, 1, 1);
+        row++;
+    }
+    middle->pack_start(*info_grid, true, true);
+
+    // How the movie was recorded: shown for information, as on win32.
+    auto options_frame = Gtk::manage(new Gtk::Frame(_("Record Options")));
+    auto options_box = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 2));
+    options_box->set_border_width(5);
+    Gtk::RadioButtonGroup start_group;
+    Gtk::RadioButton from_reset_radio(start_group, _("Record from reset"));
+    Gtk::RadioButton from_now_radio(start_group, _("Record from now"));
+    from_reset_radio.set_sensitive(false);
+    from_now_radio.set_sensitive(false);
+    options_box->pack_start(from_reset_radio, false, false);
+    options_box->pack_start(from_now_radio, false, false);
+    options_frame->add(*options_box);
+    middle->pack_start(*options_frame, false, false);
+    vbox->pack_start(*middle, false, false);
+
+    std::array<Gtk::CheckButton *, kMovieJoypads> joypad_boxes{};
+    vbox->pack_start(*make_joypad_frame(joypad_boxes, false), false, false);
+
+    auto info_box = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 6));
+    Gtk::Label info_title_label(_("Author Info:"));
+    info_title_label.set_xalign(1.0);
+    info_title_label.set_yalign(0.0);
+    Gtk::Label info_label;
+    info_label.set_xalign(0.0);
+    info_label.set_yalign(0.0);
+    info_label.set_line_wrap(true);
+    info_label.set_selectable(true);
+    Gtk::Frame info_frame;
+    info_frame.add(info_label);
+    info_frame.set_size_request(-1, 48);
+    info_box->pack_start(info_title_label, false, false);
+    info_box->pack_start(info_frame, true, true);
+    vbox->pack_start(*info_box, false, false);
+
+    Gtk::Label warning_label;
+    warning_label.set_xalign(0.0);
+    vbox->pack_start(warning_label, false, false);
+
+    dialog.get_content_area()->pack_start(*vbox, true, true);
+
+    auto refresh = [&] {
+        MovieInfo info{};
+        int result = FILE_NOT_FOUND;
+        std::string path = path_entry.get_text();
+        if (!path.empty())
+            result = S9xMovieGetInfo(path.c_str(), &info);
+
+        if (result != FILE_NOT_FOUND)
+        {
+            auto created = Glib::DateTime::create_now_local((gint64)info.TimeCreated);
+            date_label.set_text(created ? created.format("%c") : Glib::ustring());
+
+            uint32_t fps = Memory.ROMFramesPerSecond ? Memory.ROMFramesPerSecond : 60;
+            uint32_t seconds = (info.LengthFrames + fps / 2) / fps;
+            length_label.set_text(fmt::format("{:02d}:{:02d}:{:02d}", seconds / 3600, (seconds / 60) % 60, seconds % 60));
+            frames_label.set_text(std::to_string(info.LengthFrames));
+            rerecord_label.set_text(std::to_string(info.RerecordCount));
+        }
+        else
+        {
+            date_label.set_text("");
+            length_label.set_text("");
+            frames_label.set_text("");
+            rerecord_label.set_text("");
+        }
+
+        current_rom_label.set_text(fmt::format(fmt::runtime(_("Current ROM: {}")),
+                                               rom_description(Memory.ROMCRC32, Memory.ROMName)));
+
+        if (result == SUCCESS)
+        {
+            info_title_label.set_text(_("Author Info:"));
+            info_label.set_text(metadata_to_ustring(info.Metadata));
+
+            // A movie that was saved read-only cannot be recorded into.
+            read_only_box.set_sensitive(!info.ReadOnly);
+            if (info.ReadOnly)
+                read_only_box.set_active(true);
+
+            for (int i = 0; i < kMovieJoypads; i++)
+                joypad_boxes[i]->set_active(info.ControllersMask & (1 << i));
+            if (info.Opts & MOVIE_OPT_FROM_RESET)
+                from_reset_radio.set_active(true);
+            else
+                from_now_radio.set_active(true);
+
+            const bool has_rom_info = info.SyncFlags & MOVIE_SYNC_HASROMINFO;
+            if (has_rom_info)
+                movie_rom_label.set_text(fmt::format(fmt::runtime(_("Movie's ROM: {}")),
+                                                     rom_description(info.ROMCRC32, info.ROMName)));
+            else
+                movie_rom_label.set_text(_("Movie's ROM: (not stored in movie file)"));
+
+            const bool mismatch = has_rom_info && info.ROMCRC32 != Memory.ROMCRC32;
+            if (mismatch)
+            {
+                current_rom_label.set_text(current_rom_label.get_text() + _(" <-- MISMATCH !!!"));
+                warning_label.set_text(_("WARNING: You don't have the right ROM loaded!"));
+            }
+            else
+                warning_label.set_text(_("Press OK to start playing the movie."));
+
+            ok_button->set_sensitive(true);
+        }
+        else
+        {
+            info_title_label.set_text(_("Error Info:"));
+            info_label.set_text(path.empty() ? "" : S9xMovieErrorString(result, false));
+            warning_label.set_text(path.empty() ? "" : S9xMovieErrorString(result, true));
+
+            read_only_box.set_sensitive(false);
+            for (auto box : joypad_boxes)
+                box->set_active(false);
+
+            // Show where the movie was looked for, as win32 does.
+            std::error_code ec;
+            auto folder = std::filesystem::absolute(path, ec).parent_path().string();
+            movie_rom_label.set_text(path.empty() ? std::string()
+                                                  : fmt::format(fmt::runtime(_("Path: {}")), folder));
+
+            ok_button->set_sensitive(false);
+        }
+    };
+
+    browse_button.signal_clicked().connect([&] {
+        auto filename = browse_for_movie(dialog, path_entry.get_text(), false);
+        if (!filename.empty())
+            path_entry.set_text(filename);
+    });
+    path_entry.signal_changed().connect(refresh);
+
+    path_entry.set_text(default_movie_path());
+    refresh();
+
+    dialog.show_all();
+    if (dialog.run() != Gtk::RESPONSE_ACCEPT)
+        return false;
+
+    choice.path = path_entry.get_text();
+    choice.read_only = read_only_box.get_active();
+    gui_config->movie_default_read_only = choice.read_only;
+    return !choice.path.empty();
+}
+
+bool S9xRecordMovieDialog(bool sram_exists, MovieRecordChoice &choice)
+{
+    Gtk::Dialog dialog(_("Record Movie"), *top_level->window.get(), true);
+    dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
+    dialog.add_button(_("_OK"), Gtk::RESPONSE_ACCEPT);
+    dialog.set_default_response(Gtk::RESPONSE_ACCEPT);
+
+    auto vbox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 6));
+    vbox->set_border_width(8);
+
+    auto grid = Gtk::manage(new Gtk::Grid);
+    grid->set_column_spacing(6);
+    grid->set_row_spacing(4);
+    auto path_label = Gtk::manage(new Gtk::Label(_("Movie File:")));
+    path_label->set_xalign(1.0);
+    Gtk::Entry path_entry;
+    path_entry.set_width_chars(45);
+    path_entry.set_hexpand(true);
+    path_entry.set_activates_default(true);
+    Gtk::Button browse_button(_("_Browse…"), true);
+    grid->attach(*path_label, 0, 0, 1, 1);
+    grid->attach(path_entry, 1, 0, 1, 1);
+    grid->attach(browse_button, 2, 0, 1, 1);
+    auto metadata_label = Gtk::manage(new Gtk::Label(_("Author Info:")));
+    metadata_label->set_xalign(1.0);
+    Gtk::Entry metadata_entry;
+    metadata_entry.set_max_length(MOVIE_MAX_METADATA - 1);
+    metadata_entry.set_activates_default(true);
+    grid->attach(*metadata_label, 0, 1, 1, 1);
+    grid->attach(metadata_entry, 1, 1, 2, 1);
+    vbox->pack_start(*grid, false, false);
+
+    auto middle = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 12));
+
+    auto options_frame = Gtk::manage(new Gtk::Frame(_("Record Options")));
+    auto options_box = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 2));
+    options_box->set_border_width(5);
+    Gtk::RadioButtonGroup start_group;
+    Gtk::RadioButton from_reset_radio(start_group, _("Record from reset"));
+    Gtk::RadioButton from_now_radio(start_group, _("Record from now"));
+    Gtk::CheckButton clear_sram_box(_("Clear SRAM"));
+    options_box->pack_start(from_reset_radio, false, false);
+    options_box->pack_start(from_now_radio, false, false);
+    options_box->pack_start(clear_sram_box, false, false);
+    options_frame->add(*options_box);
+    middle->pack_start(*options_frame, false, false);
+
+    std::array<Gtk::CheckButton *, kMovieJoypads> joypad_boxes{};
+    middle->pack_start(*make_joypad_frame(joypad_boxes, true), true, true);
+    vbox->pack_start(*middle, false, false);
+
+    dialog.get_content_area()->pack_start(*vbox, true, true);
+
+    auto update_clear_sram = [&] {
+        clear_sram_box.set_sensitive(sram_exists && from_reset_radio.get_active());
+    };
+
+    browse_button.signal_clicked().connect([&] {
+        auto filename = browse_for_movie(dialog, path_entry.get_text(), true);
+        if (!filename.empty())
+            path_entry.set_text(filename);
+    });
+    from_reset_radio.signal_toggled().connect(update_clear_sram);
+
+    path_entry.set_text(default_movie_path());
+    joypad_boxes[0]->set_active(true);
+    if (gui_config->movie_default_from_reset)
+        from_reset_radio.set_active(true);
+    else
+        from_now_radio.set_active(true);
+    // Without a battery save there is nothing to clear, so the box is shown
+    // checked and disabled, as on win32.
+    clear_sram_box.set_active(sram_exists ? gui_config->movie_default_clear_sram : true);
+    update_clear_sram();
+
+    dialog.show_all();
+
+    while (true)
+    {
+        if (dialog.run() != Gtk::RESPONSE_ACCEPT)
+            return false;
+
+        uint8_t mask = 0;
+        for (int i = 0; i < kMovieJoypads; i++)
+            if (joypad_boxes[i]->get_active())
+                mask |= 1 << i;
+
+        std::string path = path_entry.get_text();
+        const char *problem = nullptr;
+        if (path.empty())
+            problem = _("Choose a file name for the movie.");
+        else if (mask == 0)
+            problem = _("Select at least one controller to record.");
+        if (problem)
+        {
+            Gtk::MessageDialog msg(dialog, problem, false, Gtk::MESSAGE_WARNING, Gtk::BUTTONS_OK, true);
+            msg.run();
+            continue;
+        }
+
+        choice.path = path;
+        choice.metadata = ustring_to_metadata(metadata_entry.get_text());
+        choice.controllers_mask = mask;
+        choice.from_reset = from_reset_radio.get_active();
+        choice.clear_sram = sram_exists && choice.from_reset && clear_sram_box.get_active();
+
+        // Remember the choices for next time, like win32's MovieDefault* settings.
+        gui_config->movie_default_from_reset = choice.from_reset;
+        if (sram_exists && choice.from_reset)
+            gui_config->movie_default_clear_sram = clear_sram_box.get_active();
+        return true;
+    }
+}

--- a/gtk/src/gtk_movie.h
+++ b/gtk/src/gtk_movie.h
@@ -1,0 +1,36 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+/* The win32 "Play Movie" and "Record Movie" dialogs (File->Movie Play... and
+ * File->Movie Record...). Each returns false when cancelled. */
+
+struct MoviePlayChoice
+{
+    std::string path;
+    bool read_only = true;
+};
+
+struct MovieRecordChoice
+{
+    std::string path;
+    std::wstring metadata;
+    uint8_t controllers_mask = 1;
+    bool from_reset = false;
+    bool clear_sram = false;
+};
+
+bool S9xPlayMovieDialog(MoviePlayChoice &choice);
+/* sram_exists: whether the game has a battery save on disk, the thing the
+ * "Clear SRAM" option would delete. */
+bool S9xRecordMovieDialog(bool sram_exists, MovieRecordChoice &choice);
+
+/* The message for a movie.cpp result code, as win32 words it. */
+std::string S9xMovieErrorString(int result, bool brief);

--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -664,6 +664,7 @@ void Snes9xPreferences::move_settings_to_dialog()
     set_spin  ("rewind_buffer_size",        config->rewind_buffer_size);
     set_spin  ("rewind_granularity",        config->rewind_granularity);
     set_spin  ("run_ahead_frames",          Settings.RunAhead);
+    set_check ("avi_hires",                 config->avi_hires);
     set_spin  ("superfx_multiplier",        Settings.SuperFXClockMultiplier);
     set_combo ("splash_background",         config->splash_image);
     set_check ("force_enable_icons",        config->enable_icons);
@@ -853,6 +854,7 @@ void Snes9xPreferences::get_settings_from_dialog()
     config->rewind_buffer_size        = get_spin("rewind_buffer_size");
     config->rewind_granularity        = get_spin("rewind_granularity");
     Settings.RunAhead                 = get_spin("run_ahead_frames");
+    config->avi_hires                 = get_check("avi_hires");
     config->joystick_threshold        = get_spin("joystick_threshold");
 
 #ifdef ALLOW_CPU_OVERCLOCK

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -23,6 +23,7 @@
 #include "apu/apu.h"
 #include "netplay.h"
 #include "movie.h"
+#include "common/recording/avi_recorder.hpp"
 #include "controls.h"
 #include "snapshot.h"
 #include "gfx.h"
@@ -144,6 +145,10 @@ int main(int argc, char *argv[])
 
 int S9xOpenROM(const char *rom_filename)
 {
+    // A recording belongs to one game: the next one may have another frame
+    // rate or screen size. (LoadROM itself ends any movie.)
+    S9xAVIStop();
+
     if (gui_config->rom_loaded)
     {
         S9xAutoSaveSRAM();
@@ -412,6 +417,7 @@ static void game_loop()
             S9xMainLoop();
         }
 
+        S9xAVIEndFrame();
         S9xUpdateRumble();
 
 #ifdef RETROACHIEVEMENTS_SUPPORT
@@ -677,6 +683,8 @@ static void check_pointer_timer()
 /* Final exit point, issues exit (0) */
 void S9xExit()
 {
+    S9xAVIStop();
+
     gui_config->save_config_file();
 
 #ifdef RETROACHIEVEMENTS_SUPPORT

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -28,6 +28,7 @@
 #include "gtk_control.h"
 #include "gtk_cheat.h"
 #include "gtk_netplay.h"
+#include "gtk_movie.h"
 #include "gtk_retroachievements.h"
 #include "retroachievements.h"
 #include "gtk_s9xwindow.h"
@@ -37,6 +38,7 @@
 #include <array>
 #include <cctype>
 #include <filesystem>
+#include <unistd.h>
 #include <utility>
 
 #include "snes9x.h"
@@ -44,6 +46,8 @@
 #include "ppu.h"
 #include "controls.h"
 #include "movie.h"
+#include "snapshot.h"
+#include "common/recording/avi_recorder.hpp"
 #include "apu/apu.h"
 #include "memmap.h"
 #include "cpuexec.h"
@@ -177,14 +181,24 @@ void Snes9xWindow::connect_signals()
         open_rom_dialog();
     });
 
-    get_object<Gtk::MenuItem>("reset_item")->signal_activate().connect([&] {
+    // As on win32's Emulation->Reset: a movie being recorded gets the reset
+    // as an input event, and a movie being played back ends.
+    auto movie_reset_hook = [] {
+        S9xMovieUpdateOnReset();
+        if (S9xMoviePlaying())
+            S9xMovieStop(true);
+    };
+
+    get_object<Gtk::MenuItem>("reset_item")->signal_activate().connect([&, movie_reset_hook] {
+        movie_reset_hook();
         S9xSoftReset();
 #ifdef RETROACHIEVEMENTS_SUPPORT
         RA_OnReset();
 #endif
     });
 
-    get_object<Gtk::MenuItem>("hard_reset_item")->signal_activate().connect([&] {
+    get_object<Gtk::MenuItem>("hard_reset_item")->signal_activate().connect([&, movie_reset_hook] {
+        movie_reset_hook();
         S9xReset();
 #ifdef RETROACHIEVEMENTS_SUPPORT
         RA_OnReset();
@@ -321,15 +335,11 @@ void Snes9xWindow::connect_signals()
     });
 
     get_object<Gtk::MenuItem>("open_movie_item")->signal_activate().connect([&] {
-        if (S9xMovieActive())
-            S9xMovieStop(false);
-
-        S9xMovieOpen(open_movie_dialog(true).c_str(), false);
+        play_movie_dialog();
     });
 
     get_object<Gtk::MenuItem>("stop_recording_item")->signal_activate().connect([&] {
-        if (S9xMovieActive())
-            S9xMovieStop(false);
+        stop_movie();
     });
 
     get_object<Gtk::MenuItem>("jump_to_frame_item")->signal_activate().connect([&] {
@@ -337,10 +347,15 @@ void Snes9xWindow::connect_signals()
     });
 
     get_object<Gtk::MenuItem>("record_movie_item")->signal_activate().connect([&] {
-        if (S9xMovieActive())
-            S9xMovieStop(false);
+        record_movie_dialog();
+    });
 
-        S9xMovieCreate(open_movie_dialog(false).c_str(), 0xFF, MOVIE_OPT_FROM_RESET, nullptr, 0);
+    get_object<Gtk::MenuItem>("avi_recording_item")->signal_activate().connect([&] {
+        toggle_avi_recording();
+    });
+
+    get_object<Gtk::Menu>("file_menu_item_menu")->signal_show().connect([this] {
+        update_movie_menu();
     });
 
     get_object<Gtk::MenuItem>("cheats_item")->signal_activate().connect([&] {
@@ -907,54 +922,151 @@ void Snes9xWindow::open_multicart_dialog()
     unpause_from_focus_change();
 }
 
-std::string Snes9xWindow::open_movie_dialog(bool readonly)
+void Snes9xWindow::play_movie_dialog()
 {
-    this->pause_from_focus_change();
+    if (!config->rom_loaded)
+        return;
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    if (!RA_WarnDisableHardcore(_("Movie playback")))
+        return;
+#endif
 
-    std::string title;
-    Gtk::FileChooserAction action;
+    pause_from_focus_change();
 
-    if (readonly)
+    MoviePlayChoice choice;
+    if (S9xPlayMovieDialog(choice))
     {
-        title = _("Open SNES Movie");
-        action = Gtk::FILE_CHOOSER_ACTION_OPEN;
-    }
-    else
-    {
-        title = _("New SNES Movie");
-        action = Gtk::FILE_CHOOSER_ACTION_SAVE;
+        if (S9xMovieActive())
+            S9xMovieStop(true);
+
+        int result = S9xMovieOpen(choice.path.c_str(), choice.read_only);
+        if (result != SUCCESS)
+        {
+            Gtk::MessageDialog msg(*window.get(), S9xMovieErrorString(result, false), false,
+                                   Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
+            msg.run();
+        }
     }
 
-    Gtk::FileChooserDialog dialog(*window.get(), title, action);
+    unpause_from_focus_change();
+}
+
+void Snes9xWindow::record_movie_dialog()
+{
+    if (!config->rom_loaded)
+        return;
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    if (!RA_WarnDisableHardcore(_("Movie recording")))
+        return;
+#endif
+
+    pause_from_focus_change();
+
+    // Written out first so the dialog can tell whether there is a battery
+    // save that "Clear SRAM" would remove, as win32 does.
+    auto sram_filename = S9xGetFilename(".srm", SRAM_DIR);
+    Memory.SaveSRAM(sram_filename.c_str());
+    const bool sram_exists = access(sram_filename.c_str(), R_OK | W_OK) == 0;
+
+    MovieRecordChoice choice;
+    if (S9xRecordMovieDialog(sram_exists, choice))
+    {
+        if (S9xMovieActive())
+            S9xMovieStop(true);
+
+        if (choice.from_reset && choice.clear_sram)
+        {
+            // A movie from reset with clean SRAM: drop the battery save on
+            // disk and reload, which leaves the SRAM zeroed. Same as win32.
+            std::error_code ec;
+            std::filesystem::remove(sram_filename, ec);
+            std::filesystem::remove(S9xGetFilename(".srm", ROMFILENAME_DIR), ec);
+            Memory.LoadSRAM(sram_filename.c_str());
+        }
+
+        // win32 pads the author text to 32 characters; keep the files identical.
+        std::wstring metadata = choice.metadata;
+        while (metadata.size() < 32)
+            metadata += L' ';
+        if (metadata.size() > MOVIE_MAX_METADATA)
+            metadata.resize(MOVIE_MAX_METADATA);
+
+        int result = S9xMovieCreate(choice.path.c_str(), choice.controllers_mask,
+                                    choice.from_reset ? MOVIE_OPT_FROM_RESET : MOVIE_OPT_FROM_SNAPSHOT,
+                                    metadata.c_str(), (int)metadata.size());
+        if (result != SUCCESS)
+        {
+            Gtk::MessageDialog msg(*window.get(), S9xMovieErrorString(result, false), false,
+                                   Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
+            msg.run();
+        }
+    }
+
+    unpause_from_focus_change();
+}
+
+void Snes9xWindow::stop_movie()
+{
+    if (S9xMovieActive())
+        S9xMovieStop(false);
+}
+
+void Snes9xWindow::toggle_avi_recording()
+{
+    if (!config->rom_loaded)
+        return;
+
+    if (S9xAVIRecording())
+    {
+        S9xAVIStop();
+        return;
+    }
+
+    pause_from_focus_change();
+
+    Gtk::FileChooserDialog dialog(*window.get(), _("Record AVI"), Gtk::FILE_CHOOSER_ACTION_SAVE);
     dialog.add_button(Gtk::StockID("gtk-cancel"), Gtk::RESPONSE_CANCEL);
-    if (readonly)
-        dialog.add_button(Gtk::StockID("gtk-open"), Gtk::RESPONSE_ACCEPT);
-    else
-        dialog.add_button(Gtk::StockID("gtk-save"), Gtk::RESPONSE_ACCEPT);
-
-    if (!readonly)
-    {
-        auto default_name = S9xGetFilename(".smv", s9x_getdirtype::ROM_DIR);
-        dialog.set_current_name(default_name);
-
-    }
+    dialog.add_button(Gtk::StockID("gtk-save"), Gtk::RESPONSE_ACCEPT);
+    dialog.set_do_overwrite_confirmation(true);
+    dialog.set_current_folder(S9xGetDirectory(SCREENSHOT_DIR));
+    dialog.set_current_name(S9xBasename(S9xGetFilename(".avi", SCREENSHOT_DIR)));
 
     auto filter = Gtk::FileFilter::create();
-    filter->set_name(_("SNES Movies"));
-    filter->add_pattern("*.smv");
-    filter->add_pattern("*.SMV");
+    filter->set_name(_("AVI Files"));
+    filter->add_pattern("*.avi");
+    filter->add_pattern("*.AVI");
     dialog.add_filter(filter);
     dialog.add_filter(get_all_files_filter());
 
-    dialog.set_current_folder(S9xGetDirectory(SRAM_DIR));
     auto result = dialog.run();
     dialog.hide();
-    this->unpause_from_focus_change();
 
     if (result == Gtk::RESPONSE_ACCEPT)
-        return dialog.get_filename();
+    {
+        S9xAVIOptions options;
+        options.hires = config->avi_hires;
+        options.overscan = config->overscan;
+        // Like win32, a muted emulator records a silent movie.
+        options.include_audio = !config->mute_sound;
 
-    return std::string{};
+        std::string error;
+        if (!S9xAVIStart(dialog.get_filename(), options, &error))
+        {
+            Gtk::MessageDialog msg(*window.get(), error, false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
+            msg.run();
+        }
+    }
+
+    unpause_from_focus_change();
+}
+
+/* Movie Stop only applies to a running movie, and the AVI item reads Start
+ * or Stop for whichever comes next, as on win32. */
+void Snes9xWindow::update_movie_menu()
+{
+    enable_widget("stop_recording_item", config->rom_loaded && S9xMovieActive());
+    get_object<Gtk::MenuItem>("avi_recording_item")->set_label(S9xAVIRecording() ? _("Stop _AVI Recording")
+                                                                                : _("Start _AVI Recording…"));
 }
 
 std::string Snes9xWindow::open_rom_dialog(bool run)
@@ -1516,6 +1628,7 @@ void Snes9xWindow::configure_widgets()
         "stop_recording_item",
         "open_movie_item",
         "jump_to_frame_item",
+        "avi_recording_item",
         "cheats_item",
         "rom_info_item",
         "run_ahead_item"

--- a/gtk/src/gtk_s9xwindow.h
+++ b/gtk/src/gtk_s9xwindow.h
@@ -57,7 +57,12 @@ class Snes9xWindow : public GtkBuilderWindow
     void save_memory_pack();
     bool try_open_rom(const std::string &filename);
     std::string prompt_rename_msu1_pack(const std::string &filename);
-    std::string open_movie_dialog(bool readonly);
+    /* File->Movie Play/Record/Stop and AVI Recording, as on win32. */
+    void play_movie_dialog();
+    void record_movie_dialog();
+    void stop_movie();
+    void toggle_avi_recording();
+    void update_movie_menu();
     void movie_seek_dialog();
     void open_multicart_dialog();
     void open_voicekun_dialog();

--- a/gtk/src/gtk_sound.cpp
+++ b/gtk/src/gtk_sound.cpp
@@ -12,6 +12,7 @@
 #include "snes9x.h"
 #include "apu/apu.h"
 #include "sgb/sgb.h"
+#include "common/recording/avi_recorder.hpp"
 
 #ifdef USE_PORTAUDIO
 #include "common/audio/s9x_sound_driver_portaudio.hpp"
@@ -192,15 +193,18 @@ void S9xSamplesAvailable(void *userdata)
     if (space_free < samples)
         samples = space_free & ~1;
 
-    if (samples == 0)
+    // An AVI takes every sample; the device only gets what it has room for.
+    const int mixed = S9xAVIRecording() ? S9xGetSampleCount() : samples;
+
+    if (mixed == 0)
     {
         if (!sgb_bios)
             S9xClearSamples();
         return;
     }
 
-    if ((int)temp_buffer.size() < samples)
-        temp_buffer.resize(samples);
+    if ((int)temp_buffer.size() < mixed)
+        temp_buffer.resize(mixed);
 
     // Sync per-source SGB BIOS-mix gains into the apu globals before mixing.
     // (Cheap; lets the user adjust SPC/GB live without going through a
@@ -234,8 +238,16 @@ void S9xSamplesAvailable(void *userdata)
     else
         S9xSpcSyncReset();
 
-    S9xMixSamples((uint8_t *)temp_buffer.data(), samples);
-    S9xMixSpcOverGB(temp_buffer.data(), samples);
+    S9xMixSamples((uint8_t *)temp_buffer.data(), mixed);
+    S9xMixSpcOverGB(temp_buffer.data(), mixed);
+    S9xAVIAddSamples(temp_buffer.data(), mixed);
+
+    if (samples == 0)
+    {
+        if (clear_leftover_samples)
+            S9xClearSamples();
+        return;
+    }
 
     // Master volume — Regular during normal play, FastForward in turbo/rewind.
     // Scaling is in-place; no driver here exposes a host-side volume API.

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1549,6 +1549,74 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkSeparatorMenuItem" id="movie_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="open_movie_item">
+                        <property name="label" translatable="yes">Movie _Play…</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="use_underline">True</property>
+                        <property name="image">image8</property>
+                        <property name="use_stock">False</property>
+                        <signal name="activate" handler="open_movie" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="record_movie_item">
+                        <property name="label" translatable="yes">Movie _Record…</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="use_underline">True</property>
+                        <property name="image">image19</property>
+                        <property name="use_stock">False</property>
+                        <signal name="activate" handler="record_movie" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="stop_recording_item">
+                        <property name="label" translatable="yes">Movie S_top</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="use_underline">True</property>
+                        <property name="image">image9</property>
+                        <property name="use_stock">False</property>
+                        <signal name="activate" handler="stop_recording" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="jump_to_frame_item">
+                        <property name="label" translatable="yes">_Jump to Frame…</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="use_underline">True</property>
+                        <property name="image">image10</property>
+                        <property name="use_stock">False</property>
+                        <signal name="activate" handler="jump_to_frame" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="avi_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="avi_recording_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Start _AVI Recording…</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem" id="separatormenuitem2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -1602,60 +1670,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="open_movie_item">
-                        <property name="label" translatable="yes">Load _Movie…</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image8</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="open_movie" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="record_movie_item">
-                        <property name="label" translatable="yes">R_ecord Movie…</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image19</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="record_movie" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="stop_recording_item">
-                        <property name="label" translatable="yes">_Stop Recording</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image9</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="stop_recording" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="jump_to_frame_item">
-                        <property name="label" translatable="yes">_Jump to Frame…</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image10</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="jump_to_frame" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
                       </object>
                     </child>
                     <child>
@@ -5631,6 +5645,58 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="avisettingsframe">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="border_width">5</property>
+                                <property name="label_xalign">0</property>
+                                <property name="shadow_type">none</property>
+                                <child>
+                                  <object class="GtkAlignment" id="alignmentavisettings">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
+                                    <child>
+                                      <object class="GtkVBox" id="vboxavisettings">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="border_width">5</property>
+                                        <property name="spacing">5</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="avi_hires">
+                                            <property name="label" translatable="yes">Hi-Res AVI Recording</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Record File → AVI Recording at twice the SNES resolution (512x448) so hi-res and interlaced games keep their detail. Doubles the file size.</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="labelavisettingsframe">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">&lt;b&gt;AVI Recording&lt;/b&gt;</property>
+                                    <property name="use_markup">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="hacksettingsframe">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -5822,7 +5888,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                           </object>

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -309,6 +309,12 @@ list(APPEND QT_GUI_SOURCES
     src/StatePreviewDialog.hpp
     src/ColorCorrectionDialog.cpp
     src/ColorCorrectionDialog.hpp
+    src/MovieDialogs.cpp
+    src/MovieDialogs.hpp
+    ../common/recording/avi_writer.cpp
+    ../common/recording/avi_writer.hpp
+    ../common/recording/avi_recorder.cpp
+    ../common/recording/avi_recorder.hpp
     src/SoftwareScalers.cpp
     src/SoftwareFilters.cpp
     src/SoftwareFilters.hpp

--- a/qt/src/EmuApplication.cpp
+++ b/qt/src/EmuApplication.cpp
@@ -495,10 +495,14 @@ void EmuApplication::updateBindings()
             if (binding.type != EmuBinding::None)
             {
                 /* The core's QuickSave/QuickLoad commands address absolute
-                 * slots; handle them here so they apply to the current bank. */
-                bool bank_relative = strncmp(name, "QuickSave", 9) == 0 ||
-                                     strncmp(name, "QuickLoad", 9) == 0;
-                auto handler = (!bank_relative && core->acceptsCommand(name)) ? Core : UI;
+                 * slots; handle them here so they apply to the current bank.
+                 * The movie commands open the dialogs of the File menu. */
+                bool ui_handled = strncmp(name, "QuickSave", 9) == 0 ||
+                                  strncmp(name, "QuickLoad", 9) == 0 ||
+                                  strcmp(name, "BeginRecordingMovie") == 0 ||
+                                  strcmp(name, "LoadMovie") == 0 ||
+                                  strcmp(name, "EndRecordingMovie") == 0;
+                auto handler = (!ui_handled && core->acceptsCommand(name)) ? Core : UI;
                 bindings.insert({ binding.hash(), { name, handler } });
             }
         }
@@ -707,6 +711,18 @@ void EmuApplication::handleBinding(const std::string &name, bool pressed)
             {
                 if (EmuConfig::portConfigurationUsesPointer(config->port_configuration))
                     window->toggleMouseGrab();
+            }
+            else if (name == "BeginRecordingMovie")
+            {
+                window->recordMovieDialog();
+            }
+            else if (name == "LoadMovie")
+            {
+                window->playMovieDialog();
+            }
+            else if (name == "EndRecordingMovie")
+            {
+                stopMovie();
             }
         }
     }
@@ -1004,6 +1020,70 @@ void EmuApplication::saveMemoryPack()
 bool EmuApplication::hasMemoryPack()
 {
     return core->hasMemoryPack();
+}
+
+int EmuApplication::playMovie(const std::string &filename, bool read_only)
+{
+    int result = 0;
+    emu_thread->runOnThread([&] {
+        result = core->openMovie(filename, read_only);
+    }, true);
+    return result;
+}
+
+int EmuApplication::recordMovie(const std::string &filename, uint8_t controllers_mask,
+                                bool from_reset, bool clear_sram, const std::wstring &metadata)
+{
+    int result = 0;
+    emu_thread->runOnThread([&] {
+        result = core->createMovie(filename, controllers_mask, from_reset, clear_sram, metadata);
+    }, true);
+    return result;
+}
+
+void EmuApplication::stopMovie()
+{
+    emu_thread->runOnThread([&] {
+        core->stopMovie();
+    });
+}
+
+bool EmuApplication::isMovieActive()
+{
+    return core->movieActive();
+}
+
+bool EmuApplication::movieSRAMExists()
+{
+    bool exists = false;
+    emu_thread->runOnThread([&] {
+        exists = core->saveAndCheckSRAM();
+    }, true);
+    return exists;
+}
+
+bool EmuApplication::startAVIRecording(const std::string &filename, std::string &error)
+{
+    bool result = false;
+    emu_thread->runOnThread([&] {
+        // Like win32, a muted emulator records a silent movie.
+        result = core->startAVIRecording(filename, config->avi_hires, !config->mute_audio, error);
+    }, true);
+    return result;
+}
+
+void EmuApplication::stopAVIRecording()
+{
+    emu_thread->runOnThread([&] {
+        core->stopAVIRecording();
+    }, true);
+    // The recording pinned the audio input rate; put the configured one back.
+    updateSettings();
+}
+
+bool EmuApplication::isAVIRecording()
+{
+    return core->aviRecording();
 }
 
 uint8_t EmuApplication::getSoundChannelMask()

--- a/qt/src/EmuApplication.hpp
+++ b/qt/src/EmuApplication.hpp
@@ -100,6 +100,19 @@ struct EmuApplication
     void saveSRAM();
     void saveMemoryPack();
     bool hasMemoryPack();
+
+    /* File->Movie Play/Record/Stop and AVI Recording, run on the emulation
+     * thread. The movie results are movie.cpp's SUCCESS / FILE_NOT_FOUND /
+     * WRONG_FORMAT / WRONG_VERSION. */
+    int playMovie(const std::string &filename, bool read_only);
+    int recordMovie(const std::string &filename, uint8_t controllers_mask,
+                    bool from_reset, bool clear_sram, const std::wstring &metadata);
+    void stopMovie();
+    bool isMovieActive();
+    bool movieSRAMExists();
+    bool startAVIRecording(const std::string &filename, std::string &error);
+    void stopAVIRecording();
+    bool isAVIRecording();
     uint8_t getSoundChannelMask();
     void setSoundChannelMask(uint8_t mask);
     void startGame();

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -338,6 +338,8 @@ bool EmuConfig::setDefaults(int section)
 
         run_ahead_frames = 0;
 
+        avi_hires = false;
+
         allow_invalid_vram_access = false;
         snapshot_screenshots = true;
         allow_opposing_dpad_directions = false;
@@ -505,6 +507,9 @@ void EmuConfig::config(const std::string &filename, bool write)
     Int("CheatDialogHeight", cheat_dialog_height);
     Int("CurrentSaveSlot", current_save_slot, "Currently selected save-state slot within the bank (remembered automatically)");
     Int("CurrentSaveBank", current_save_bank, "Currently selected save-state bank (remembered automatically)");
+    Bool("MovieDefaultReadOnly", movie_default_read_only, "Last state of the Play Movie dialog's Open Read-Only box (remembered automatically)");
+    Bool("MovieDefaultStartFromReset", movie_default_from_reset, "Last state of the Record Movie dialog's Record from reset choice (remembered automatically)");
+    Bool("MovieDefaultClearSRAM", movie_default_clear_sram, "Last state of the Record Movie dialog's Clear SRAM box (remembered automatically)");
 
     if (!write)
     {
@@ -612,6 +617,7 @@ void EmuConfig::config(const std::string &filename, bool write)
     Int("RewindBufferSize", rewind_buffer_size, "Memory (in MB) reserved for rewind; 0 disables rewind");
     Int("RewindFrameInterval", rewind_frame_interval, "Save a rewind snapshot every N frames");
     Int("RunAhead", run_ahead_frames, "Number of frames to run ahead for reduced input latency (0 = off, 1-4)");
+    Bool("AVIHiRes", avi_hires, "true to record AVI in Hi-Res scale (512x448 instead of 256x224)");
     Bool("AllowInvalidVRAMAccess", allow_invalid_vram_access, "Let games make the VRAM accesses real hardware blocks (off for accuracy; on only for a few broken hacks)");
     Bool("SnapshotScreenshots", snapshot_screenshots, "Store a screenshot inside each save state, for the save/load-with-preview dialog");
     Bool("AllowOpposingDpadDirections", allow_opposing_dpad_directions, "Allow the D-Pad to press both left+right or up+down at once");

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -41,6 +41,12 @@ struct EmuConfig
     int current_save_bank = 0;
     std::vector<std::string> recently_used;
 
+    // Last choices made in the movie dialogs, remembered like win32's
+    // MovieDefault* settings.
+    bool movie_default_read_only = true;
+    bool movie_default_from_reset = false;
+    bool movie_default_clear_sram = false;
+
     // General
     bool fullscreen_on_open;
     bool disable_screensaver;
@@ -163,6 +169,10 @@ struct EmuConfig
     int rewind_frame_interval;
 
     int run_ahead_frames;
+
+    // File->AVI Recording writes 512x448 frames instead of 256x224, like
+    // win32's "Hi-Res AVI Recording" option.
+    bool avi_hires;
 
     // Emulation/Hacks
 

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -15,6 +15,7 @@
 
 #include "CheatsDialog.hpp"
 #include "ColorCorrectionDialog.hpp"
+#include "MovieDialogs.hpp"
 #include "StatePreviewDialog.hpp"
 #include "EmuApplication.hpp"
 #include "EmuConfig.hpp"
@@ -41,6 +42,9 @@
 #include "display.h"
 #include "msu1.h"
 #include "voicekun.h"
+#include "movie.h"
+#include "snapshot.h"
+#include "fscompat.h"
 
 #include <QMessageBox>
 #include <QDesktopServices>
@@ -418,6 +422,42 @@ void EmuMainWindow::createWidgets()
     });
 
     file_menu->addMenu(save_other_menu);
+    file_menu->addSeparator();
+
+    // win32's movie items: play back or record an input movie (.smv).
+    auto movie_play_item = file_menu->addAction(tr("Movie &Play..."));
+    connect(movie_play_item, &QAction::triggered, [&] {
+        playMovieDialog();
+    });
+    core_actions.push_back(movie_play_item);
+
+    auto movie_record_item = file_menu->addAction(tr("Movie &Record..."));
+    connect(movie_record_item, &QAction::triggered, [&] {
+        recordMovieDialog();
+    });
+    core_actions.push_back(movie_record_item);
+
+    movie_stop_action = file_menu->addAction(tr("Movie &Stop"));
+    connect(movie_stop_action, &QAction::triggered, [&] {
+        app->stopMovie();
+    });
+    core_actions.push_back(movie_stop_action);
+
+    file_menu->addSeparator();
+
+    // One item that starts or stops, relabelled like win32's.
+    avi_recording_action = file_menu->addAction(tr("Start &AVI Recording..."));
+    connect(avi_recording_action, &QAction::triggered, [&] {
+        toggleAVIRecording();
+    });
+    core_actions.push_back(avi_recording_action);
+
+    connect(file_menu, &QMenu::aboutToShow, this, [this] {
+        movie_stop_action->setEnabled(app->isCoreActive() && app->isMovieActive());
+        avi_recording_action->setText(app->isAVIRecording() ? tr("Stop &AVI Recording")
+                                                            : tr("Start &AVI Recording..."));
+    });
+
     file_menu->addSeparator();
 
     auto languages = EmuPoTranslator::availableLanguages();
@@ -980,6 +1020,87 @@ void EmuMainWindow::chooseState(bool save)
         app->loadState(filename.toStdString());
     else
         app->saveState(filename.toStdString());
+
+    app->unpause();
+}
+
+void EmuMainWindow::playMovieDialog()
+{
+    if (!app->isCoreActive())
+        return;
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    if (!RA_WarnDisableHardcore("Movie playback"))
+        return;
+#endif
+
+    app->pause();
+
+    PlayMovieDialog dialog(app, this);
+    if (dialog.exec() && !dialog.path().empty())
+    {
+        app->config->movie_default_read_only = dialog.readOnly();
+        int result = app->playMovie(dialog.path(), dialog.readOnly());
+        if (result != SUCCESS)
+            QMessageBox::warning(this, tr("Play Movie"), movieErrorString(result, false));
+    }
+
+    app->unpause();
+}
+
+void EmuMainWindow::recordMovieDialog()
+{
+    if (!app->isCoreActive())
+        return;
+#ifdef RETROACHIEVEMENTS_SUPPORT
+    if (!RA_WarnDisableHardcore("Movie recording"))
+        return;
+#endif
+
+    app->pause();
+
+    // Written out first so the dialog can tell whether there is a battery
+    // save that "Clear SRAM" would remove, as win32 does.
+    bool sram_exists = app->movieSRAMExists();
+
+    RecordMovieDialog dialog(app, this, sram_exists);
+    if (dialog.exec() && !dialog.path().empty())
+    {
+        int result = app->recordMovie(dialog.path(), dialog.controllersMask(),
+                                      dialog.fromReset(), dialog.clearSRAM(), dialog.metadata());
+        if (result != SUCCESS)
+            QMessageBox::warning(this, tr("Record Movie"), movieErrorString(result, false));
+    }
+
+    app->unpause();
+}
+
+void EmuMainWindow::toggleAVIRecording()
+{
+    if (!app->isCoreActive())
+        return;
+
+    if (app->isAVIRecording())
+    {
+        app->stopAVIRecording();
+        return;
+    }
+
+    app->pause();
+
+    QFileDialog dialog(this, tr("Record AVI"));
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setDefaultSuffix("avi");
+    dialog.setDirectory(QString::fromStdString(S9xGetDirectory(SCREENSHOT_DIR)));
+    dialog.selectFile(QString::fromStdString(S9xBasename(S9xGetFilename(".avi", SCREENSHOT_DIR))));
+    dialog.setNameFilters({ tr("AVI Files (*.avi)"), tr("All Files (*)") });
+
+    if (dialog.exec() && !dialog.selectedFiles().empty())
+    {
+        std::string error;
+        if (!app->startAVIRecording(dialog.selectedFiles()[0].toStdString(), error))
+            QMessageBox::warning(this, tr("Record AVI"), QString::fromStdString(error));
+    }
 
     app->unpause();
 }

--- a/qt/src/EmuMainWindow.hpp
+++ b/qt/src/EmuMainWindow.hpp
@@ -36,6 +36,9 @@ class EmuMainWindow : public QMainWindow
     bool isActivelyDrawing();
     void openFile();
     bool openFile(const std::string &filename);
+    void playMovieDialog();
+    void recordMovieDialog();
+    void toggleAVIRecording();
     void recreateUIAssets();
     void shaderChanged();
     void updateShaderSettingsItem();
@@ -86,6 +89,8 @@ class EmuMainWindow : public QMainWindow
     std::vector<QAction *> port_configuration_actions;
     QAction *superscope_crosshair_action = nullptr;
     QAction *shader_settings_item;
+    QAction *movie_stop_action = nullptr;
+    QAction *avi_recording_action = nullptr;
     std::vector<QAction *> core_actions;
     std::vector<QAction *> recent_menu_items;
 

--- a/qt/src/EmulationPanel.cpp
+++ b/qt/src/EmulationPanel.cpp
@@ -36,6 +36,7 @@ EmulationPanel::EmulationPanel(EmuApplication *app_)
     connect_spin(spinBox_rewind_frames, &app->config->rewind_frame_interval);
     connect_spin(spinBox_run_ahead_frames, &app->config->run_ahead_frames);
     connect_spin(spinBox_fast_forward_skip_frames, &app->config->fast_forward_skip_frames);
+    connect_checkbox(checkBox_avi_hires, &app->config->avi_hires);
 
     connect_checkbox(checkBox_allow_invalid_vram_access, &app->config->allow_invalid_vram_access);
     connect_checkbox(checkBox_allow_opposing_dpad_directions, &app->config->allow_opposing_dpad_directions);
@@ -56,6 +57,7 @@ void EmulationPanel::showEvent(QShowEvent *event)
     spinBox_rewind_buffer_size->setValue(config->rewind_buffer_size);
     spinBox_rewind_frames->setValue(config->rewind_frame_interval);
     spinBox_run_ahead_frames->setValue(config->run_ahead_frames);
+    checkBox_avi_hires->setChecked(config->avi_hires);
 
     // A game on the allow-invalid-VRAM list overrides the preference for
     // itself; show that and disable the box so the automatic choice is visible

--- a/qt/src/EmulationPanel.ui
+++ b/qt/src/EmulationPanel.ui
@@ -293,6 +293,25 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_5">
+     <property name="title">
+      <string>AVI Recording</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <widget class="QCheckBox" name="checkBox_avi_hires">
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Record File → AVI Recording at twice the SNES resolution (512x448, or 512x478 with overscan shown) so hi-res and interlaced games keep their detail. Doubles the file size.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Hi-Res AVI Recording</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Hacks</string>

--- a/qt/src/MovieDialogs.cpp
+++ b/qt/src/MovieDialogs.cpp
@@ -1,0 +1,398 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "MovieDialogs.hpp"
+#include "EmuApplication.hpp"
+#include "EmuConfig.hpp"
+
+#include <QDateTime>
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QMessageBox>
+#include <QVBoxLayout>
+
+#include "snes9x.h"
+#include "memmap.h"
+#include "movie.h"
+#include "snapshot.h"
+#include "fscompat.h"
+
+QString movieErrorString(int result, bool brief)
+{
+    switch (result)
+    {
+    case FILE_NOT_FOUND:
+        return brief ? QObject::tr("File not found.")
+                     : QObject::tr("The movie file was not found or could not be opened.");
+    case WRONG_FORMAT:
+        return brief ? QObject::tr("Unrecognized format.")
+                     : QObject::tr("The movie file is corrupt or in the wrong format.");
+    case WRONG_VERSION:
+        return brief ? QObject::tr("Unsupported movie version.")
+                     : QObject::tr("Unsupported movie version. You need a different version of SuperSnes9x to play this movie.");
+    default:
+        return QObject::tr("Could not open movie file.");
+    }
+}
+
+/* <ROM name>.smv in the export folder, the default both dialogs start from. */
+static QString defaultMoviePath()
+{
+    if (Memory.ROMFilename.empty())
+        return {};
+    return QString::fromStdString(S9xGetFilename(".smv", SCREENSHOT_DIR));
+}
+
+static QString romDescription(uint32_t crc32, const char *name)
+{
+    return QObject::tr("crc32=%1, name=%2")
+        .arg(QString::number(crc32, 16).rightJustified(8, '0').toUpper())
+        .arg(QString::fromLatin1(name).trimmed());
+}
+
+static QGroupBox *makeJoypadGroup(std::array<QCheckBox *, kMovieJoypads> &boxes, bool enabled)
+{
+    auto group = new QGroupBox(QObject::tr("Record Controllers"));
+    auto grid = new QGridLayout(group);
+    for (int i = 0; i < kMovieJoypads; i++)
+    {
+        boxes[i] = new QCheckBox(QObject::tr("Joypad %1").arg(i + 1));
+        boxes[i]->setEnabled(enabled);
+        grid->addWidget(boxes[i], i / 4, i % 4);
+    }
+    return group;
+}
+
+PlayMovieDialog::PlayMovieDialog(EmuApplication *app, QWidget *parent)
+    : QDialog(parent), app(app)
+{
+    setWindowTitle(tr("Play Movie"));
+
+    auto layout = new QVBoxLayout(this);
+
+    auto path_row = new QHBoxLayout;
+    path_row->addWidget(new QLabel(tr("Movie File:")));
+    path_edit = new QLineEdit;
+    path_edit->setMinimumWidth(320);
+    path_row->addWidget(path_edit, 1);
+    auto browse_button = new QPushButton(tr("&Browse..."));
+    path_row->addWidget(browse_button);
+    layout->addLayout(path_row);
+
+    read_only_box = new QCheckBox(tr("Open Read-Only"));
+    read_only_box->setChecked(app->config->movie_default_read_only);
+    layout->addWidget(read_only_box);
+
+    movie_rom_label = new QLabel;
+    current_rom_label = new QLabel;
+    layout->addWidget(movie_rom_label);
+    layout->addWidget(current_rom_label);
+
+    auto middle = new QHBoxLayout;
+
+    auto info_grid = new QGridLayout;
+    const std::pair<QString, QLabel **> rows[] = {
+        { tr("Recording Date:"), &date_label },
+        { tr("Length:"), &length_label },
+        { tr("Frames:"), &frames_label },
+        { tr("Re-record Count:"), &rerecord_label },
+    };
+    int row = 0;
+    for (auto &[name, label] : rows)
+    {
+        auto title = new QLabel(name);
+        title->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        *label = new QLabel;
+        (*label)->setMinimumWidth((*label)->fontMetrics().horizontalAdvance("0000-00-00 00:00:00 "));
+        info_grid->addWidget(title, row, 0);
+        info_grid->addWidget(*label, row, 1);
+        row++;
+    }
+    middle->addLayout(info_grid, 1);
+
+    // How the movie was recorded: shown for information, as on win32.
+    auto options_group = new QGroupBox(tr("Record Options"));
+    auto options_layout = new QVBoxLayout(options_group);
+    from_reset_radio = new QRadioButton(tr("Record from reset"));
+    from_now_radio = new QRadioButton(tr("Record from now"));
+    from_reset_radio->setEnabled(false);
+    from_now_radio->setEnabled(false);
+    options_layout->addWidget(from_reset_radio);
+    options_layout->addWidget(from_now_radio);
+    middle->addWidget(options_group);
+
+    layout->addLayout(middle);
+
+    layout->addWidget(makeJoypadGroup(joypad_boxes, false));
+
+    auto info_row = new QHBoxLayout;
+    info_title_label = new QLabel(tr("Author Info:"));
+    info_title_label->setAlignment(Qt::AlignRight | Qt::AlignTop);
+    info_label = new QLabel;
+    info_label->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
+    info_label->setWordWrap(true);
+    info_label->setMinimumHeight(info_label->fontMetrics().height() * 3);
+    info_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    info_row->addWidget(info_title_label);
+    info_row->addWidget(info_label, 1);
+    layout->addLayout(info_row);
+
+    auto bottom = new QHBoxLayout;
+    warning_label = new QLabel;
+    bottom->addWidget(warning_label, 1);
+    auto buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    ok_button = buttons->button(QDialogButtonBox::Ok);
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    bottom->addWidget(buttons);
+    layout->addLayout(bottom);
+
+    connect(browse_button, &QPushButton::clicked, this, &PlayMovieDialog::browse);
+    connect(path_edit, &QLineEdit::textChanged, this, &PlayMovieDialog::refreshInfo);
+
+    path_edit->setText(defaultMoviePath());
+    refreshInfo();
+}
+
+std::string PlayMovieDialog::path() const
+{
+    return path_edit->text().toStdString();
+}
+
+bool PlayMovieDialog::readOnly() const
+{
+    return read_only_box->isChecked();
+}
+
+void PlayMovieDialog::browse()
+{
+    QFileInfo current(path_edit->text());
+    QString start = current.dir().exists() ? current.dir().path()
+                                           : QString::fromStdString(S9xGetDirectory(SCREENSHOT_DIR));
+
+    QFileDialog dialog(this, tr("Open Movie"));
+    dialog.setFileMode(QFileDialog::ExistingFile);
+    dialog.setDirectory(start);
+    dialog.setNameFilters({ tr("SuperSnes9x Movie Files (*.smv)"), tr("All Files (*)") });
+    if (dialog.exec() && !dialog.selectedFiles().empty())
+        path_edit->setText(dialog.selectedFiles()[0]);
+}
+
+void PlayMovieDialog::refreshInfo()
+{
+    MovieInfo info{};
+    int result = FILE_NOT_FOUND;
+    auto path = path_edit->text().toStdString();
+    if (!path.empty())
+        result = S9xMovieGetInfo(path.c_str(), &info);
+
+    const bool header_ok = result != FILE_NOT_FOUND;
+
+    if (header_ok)
+    {
+        date_label->setText(QDateTime::fromSecsSinceEpoch(info.TimeCreated).toString(Qt::TextDate));
+
+        uint32_t fps = Memory.ROMFramesPerSecond ? Memory.ROMFramesPerSecond : 60;
+        uint32_t seconds = (info.LengthFrames + fps / 2) / fps;
+        length_label->setText(QString("%1:%2:%3")
+                                  .arg(seconds / 3600, 2, 10, QChar('0'))
+                                  .arg((seconds / 60) % 60, 2, 10, QChar('0'))
+                                  .arg(seconds % 60, 2, 10, QChar('0')));
+        frames_label->setText(QString::number(info.LengthFrames));
+        rerecord_label->setText(QString::number(info.RerecordCount));
+    }
+    else
+    {
+        date_label->clear();
+        length_label->clear();
+        frames_label->clear();
+        rerecord_label->clear();
+    }
+
+    current_rom_label->setText(tr("Current ROM: %1").arg(romDescription(Memory.ROMCRC32, Memory.ROMName)));
+
+    if (result == SUCCESS)
+    {
+        info_title_label->setText(tr("Author Info:"));
+        info_label->setText(QString::fromWCharArray(info.Metadata).trimmed());
+
+        // A movie that was saved read-only cannot be recorded into.
+        read_only_box->setEnabled(!info.ReadOnly);
+        if (info.ReadOnly)
+            read_only_box->setChecked(true);
+
+        for (int i = 0; i < kMovieJoypads; i++)
+            joypad_boxes[i]->setChecked(info.ControllersMask & (1 << i));
+        from_reset_radio->setChecked(info.Opts & MOVIE_OPT_FROM_RESET);
+        from_now_radio->setChecked(!(info.Opts & MOVIE_OPT_FROM_RESET));
+
+        const bool has_rom_info = info.SyncFlags & MOVIE_SYNC_HASROMINFO;
+        if (has_rom_info)
+            movie_rom_label->setText(tr("Movie's ROM: %1").arg(romDescription(info.ROMCRC32, info.ROMName)));
+        else
+            movie_rom_label->setText(tr("Movie's ROM: (not stored in movie file)"));
+
+        const bool mismatch = has_rom_info && info.ROMCRC32 != Memory.ROMCRC32;
+        if (mismatch)
+        {
+            current_rom_label->setText(current_rom_label->text() + tr(" <-- MISMATCH !!!"));
+            warning_label->setText(tr("WARNING: You don't have the right ROM loaded!"));
+        }
+        else
+            warning_label->setText(tr("Press OK to start playing the movie."));
+
+        ok_button->setEnabled(true);
+    }
+    else
+    {
+        info_title_label->setText(tr("Error Info:"));
+        info_label->setText(path.empty() ? QString() : movieErrorString(result, false));
+        warning_label->setText(path.empty() ? QString() : movieErrorString(result, true));
+
+        read_only_box->setEnabled(false);
+        for (auto box : joypad_boxes)
+            box->setChecked(false);
+        from_reset_radio->setChecked(false);
+        from_now_radio->setChecked(false);
+
+        // Show where the movie was looked for, as win32 does.
+        QFileInfo file(QString::fromStdString(path));
+        movie_rom_label->setText(tr("Path: %1").arg(file.dir().absolutePath()));
+
+        ok_button->setEnabled(false);
+    }
+}
+
+RecordMovieDialog::RecordMovieDialog(EmuApplication *app, QWidget *parent, bool sram_exists)
+    : QDialog(parent), app(app), sram_exists(sram_exists)
+{
+    setWindowTitle(tr("Record Movie"));
+
+    auto layout = new QVBoxLayout(this);
+
+    auto grid = new QGridLayout;
+    grid->addWidget(new QLabel(tr("Movie File:")), 0, 0);
+    path_edit = new QLineEdit;
+    path_edit->setMinimumWidth(320);
+    grid->addWidget(path_edit, 0, 1);
+    auto browse_button = new QPushButton(tr("&Browse..."));
+    grid->addWidget(browse_button, 0, 2);
+
+    grid->addWidget(new QLabel(tr("Author Info:")), 1, 0);
+    metadata_edit = new QLineEdit;
+    metadata_edit->setMaxLength(MOVIE_MAX_METADATA - 1);
+    grid->addWidget(metadata_edit, 1, 1, 1, 2);
+    layout->addLayout(grid);
+
+    auto middle = new QHBoxLayout;
+
+    auto options_group = new QGroupBox(tr("Record Options"));
+    auto options_layout = new QVBoxLayout(options_group);
+    from_reset_radio = new QRadioButton(tr("Record from reset"));
+    from_now_radio = new QRadioButton(tr("Record from now"));
+    clear_sram_box = new QCheckBox(tr("Clear SRAM"));
+    options_layout->addWidget(from_reset_radio);
+    options_layout->addWidget(from_now_radio);
+    options_layout->addWidget(clear_sram_box);
+    middle->addWidget(options_group);
+
+    middle->addWidget(makeJoypadGroup(joypad_boxes, true), 1);
+    layout->addLayout(middle);
+
+    auto buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(buttons);
+
+    connect(browse_button, &QPushButton::clicked, this, &RecordMovieDialog::browse);
+    connect(from_reset_radio, &QRadioButton::toggled, this, &RecordMovieDialog::updateClearSRAM);
+
+    path_edit->setText(defaultMoviePath());
+    joypad_boxes[0]->setChecked(true);
+    from_reset_radio->setChecked(app->config->movie_default_from_reset);
+    from_now_radio->setChecked(!app->config->movie_default_from_reset);
+    // Without a battery save there is nothing to clear, so the box is shown
+    // checked and disabled, as on win32.
+    clear_sram_box->setChecked(sram_exists ? app->config->movie_default_clear_sram : true);
+    updateClearSRAM();
+}
+
+std::string RecordMovieDialog::path() const
+{
+    return path_edit->text().toStdString();
+}
+
+std::wstring RecordMovieDialog::metadata() const
+{
+    return metadata_edit->text().toStdWString();
+}
+
+uint8_t RecordMovieDialog::controllersMask() const
+{
+    uint8_t mask = 0;
+    for (int i = 0; i < kMovieJoypads; i++)
+        if (joypad_boxes[i]->isChecked())
+            mask |= 1 << i;
+    return mask;
+}
+
+bool RecordMovieDialog::fromReset() const
+{
+    return from_reset_radio->isChecked();
+}
+
+bool RecordMovieDialog::clearSRAM() const
+{
+    return sram_exists && fromReset() && clear_sram_box->isChecked();
+}
+
+void RecordMovieDialog::browse()
+{
+    QFileInfo current(path_edit->text());
+    QString start = current.dir().exists() ? current.dir().path()
+                                           : QString::fromStdString(S9xGetDirectory(SCREENSHOT_DIR));
+
+    QFileDialog dialog(this, tr("Record Movie"));
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setDefaultSuffix("smv");
+    dialog.setDirectory(start);
+    if (!current.fileName().isEmpty())
+        dialog.selectFile(current.fileName());
+    dialog.setNameFilters({ tr("SuperSnes9x Movie Files (*.smv)"), tr("All Files (*)") });
+    if (dialog.exec() && !dialog.selectedFiles().empty())
+        path_edit->setText(dialog.selectedFiles()[0]);
+}
+
+void RecordMovieDialog::updateClearSRAM()
+{
+    clear_sram_box->setEnabled(sram_exists && from_reset_radio->isChecked());
+}
+
+void RecordMovieDialog::accept()
+{
+    if (path_edit->text().trimmed().isEmpty())
+    {
+        QMessageBox::warning(this, tr("Record Movie"), tr("Choose a file name for the movie."));
+        return;
+    }
+    if (controllersMask() == 0)
+    {
+        QMessageBox::warning(this, tr("Record Movie"), tr("Select at least one controller to record."));
+        return;
+    }
+
+    // Remember the choices for next time, like win32's MovieDefault* settings.
+    app->config->movie_default_from_reset = fromReset();
+    if (sram_exists && fromReset())
+        app->config->movie_default_clear_sram = clear_sram_box->isChecked();
+
+    QDialog::accept();
+}

--- a/qt/src/MovieDialogs.hpp
+++ b/qt/src/MovieDialogs.hpp
@@ -1,0 +1,92 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#include <QCheckBox>
+#include <QDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QRadioButton>
+
+#include <array>
+#include <string>
+
+class EmuApplication;
+
+/* The number of joypads a movie can record: one bit each in the SMV header's
+ * controller mask. */
+constexpr int kMovieJoypads = 8;
+
+/* File->Movie Play...: win32's "Play Movie" dialog. Shows what the chosen
+ * .smv holds (date, length, ROM, author) and whether it matches the loaded
+ * ROM before the movie is opened. */
+class PlayMovieDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+    PlayMovieDialog(EmuApplication *app, QWidget *parent);
+
+    std::string path() const;
+    bool readOnly() const;
+
+  private:
+    void browse();
+    void refreshInfo();
+
+    EmuApplication *app;
+    QLineEdit *path_edit;
+    QCheckBox *read_only_box;
+    QLabel *date_label;
+    QLabel *length_label;
+    QLabel *frames_label;
+    QLabel *rerecord_label;
+    QLabel *movie_rom_label;
+    QLabel *current_rom_label;
+    QLabel *info_title_label;
+    QLabel *info_label;
+    QLabel *warning_label;
+    QRadioButton *from_reset_radio;
+    QRadioButton *from_now_radio;
+    std::array<QCheckBox *, kMovieJoypads> joypad_boxes{};
+    QPushButton *ok_button;
+};
+
+/* File->Movie Record...: win32's "Record Movie" dialog. */
+class RecordMovieDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+    /* sram_exists: whether the loaded game has a battery save on disk, which
+     * is what the "Clear SRAM" option would delete. */
+    RecordMovieDialog(EmuApplication *app, QWidget *parent, bool sram_exists);
+
+    std::string path() const;
+    std::wstring metadata() const;
+    uint8_t controllersMask() const;
+    bool fromReset() const;
+    bool clearSRAM() const;
+
+  private:
+    void browse();
+    void updateClearSRAM();
+    void accept() override;
+
+    EmuApplication *app;
+    bool sram_exists;
+    QLineEdit *path_edit;
+    QLineEdit *metadata_edit;
+    QRadioButton *from_reset_radio;
+    QRadioButton *from_now_radio;
+    QCheckBox *clear_sram_box;
+    std::array<QCheckBox *, kMovieJoypads> joypad_boxes{};
+};
+
+/* The message for a movie.cpp result code, as win32 words it. */
+QString movieErrorString(int result, bool brief);

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -20,6 +20,7 @@ namespace fs = std::filesystem;
 #include "crosshairs.h"
 #include "cheats.h"
 #include "movie.h"
+#include "common/recording/avi_recorder.hpp"
 
 #ifdef KAILLERA_SUPPORT
 #include "kaillera_client.h"
@@ -304,6 +305,9 @@ bool Snes9xController::openFile(const std::string &filename)
 {
     if (active)
         S9xAutoSaveSRAM();
+    // A recording belongs to one game: the next one may have another frame
+    // rate or screen size. (LoadROM itself ends any movie.)
+    S9xAVIStop();
     active = false;
     auto result = Memory.LoadROM(filename.c_str());
     if (result)
@@ -466,6 +470,8 @@ void Snes9xController::mainLoop()
         mainLoopWithRunAhead();
     else
         S9xMainLoop();
+
+    S9xAVIEndFrame();
 }
 
 void Snes9xController::setPaused(bool paused)
@@ -525,6 +531,11 @@ bool8 S9xDeinitUpdate(int width, int height)
     }
 
     uint16_t *screen_view = GFX.Screen + (yoffset * (int)GFX.RealPPL);
+
+    // The AVI gets the frame as the SNES drew it, before the hi-res effect
+    // and software filter reshape it for the window.
+    if (!Settings.Paused)
+        S9xAVICaptureFrame(screen_view, GFX.Pitch, width, height);
 
     auto hires_effect = Snes9xController::get()->high_resolution_effect;
     if (!Settings.Paused)
@@ -781,7 +792,9 @@ bool S9xPollPointer(unsigned int, short *, short *)
 void Snes9xController::SamplesAvailable()
 {
     static std::vector<int16_t> data;
-    if (sound_output_function)
+    // An AVI takes every sample, whether or not a sound device is there to
+    // play it.
+    if (sound_output_function || S9xAVIRecording())
     {
         // SGB BIOS mode fires this ~per scanline with only a few GB samples;
         // writing those dribbles starves the driver into static. Like win32,
@@ -807,7 +820,9 @@ void Snes9xController::SamplesAvailable()
 
         S9xMixSamples((uint8_t *)data.data(), samples);
         S9xMixSpcOverGB(data.data(), samples);
-        sound_output_function(data.data(), samples);
+        S9xAVIAddSamples(data.data(), samples);
+        if (sound_output_function)
+            sound_output_function(data.data(), samples);
     }
     else
     {
@@ -1252,13 +1267,24 @@ bool Snes9xController::isAbnormalSpeed()
     return (Settings.TurboMode || rewinding);
 }
 
+/* As on win32's Emulation->Reset: a movie being recorded gets the reset as
+ * an input event, and a movie being played back ends. */
+static void movieResetHook()
+{
+    S9xMovieUpdateOnReset();
+    if (S9xMoviePlaying())
+        S9xMovieStop(true);
+}
+
 void Snes9xController::reset()
 {
+    movieResetHook();
     S9xReset();
 }
 
 void Snes9xController::softReset()
 {
+    movieResetHook();
     S9xSoftReset();
 }
 
@@ -1333,6 +1359,91 @@ bool Snes9xController::hasMemoryPack()
     // Only BS-X and Sufami-style multicarts carry a memory pack; this is the
     // same test CMemory::SaveMPAK makes before it agrees to write one.
     return active && (Settings.BS || (Multi.cartSizeB && Multi.cartType == 3));
+}
+
+int Snes9xController::openMovie(const std::string &filename, bool read_only)
+{
+    if (!active)
+        return FILE_NOT_FOUND;
+    if (S9xMovieActive())
+        S9xMovieStop(true);
+    return S9xMovieOpen(filename.c_str(), read_only);
+}
+
+int Snes9xController::createMovie(const std::string &filename, uint8_t controllers_mask,
+                                  bool from_reset, bool clear_sram, const std::wstring &metadata)
+{
+    if (!active)
+        return FILE_NOT_FOUND;
+    if (S9xMovieActive())
+        S9xMovieStop(true);
+
+    if (from_reset && clear_sram)
+    {
+        // A movie from reset with clean SRAM: drop the battery save on disk
+        // and reload, which leaves the SRAM zeroed. Same as win32.
+        std::error_code ec;
+        fs::remove(S9xGetFilename(".srm", SRAM_DIR), ec);
+        fs::remove(S9xGetFilename(".srm", ROMFILENAME_DIR), ec);
+        Memory.LoadSRAM(S9xGetFilename(".srm", SRAM_DIR).c_str());
+    }
+
+    // win32 pads the author text to 32 characters; keep the files identical.
+    std::wstring padded = metadata;
+    while (padded.size() < 32)
+        padded += L' ';
+    if (padded.size() > MOVIE_MAX_METADATA)
+        padded.resize(MOVIE_MAX_METADATA);
+
+    return S9xMovieCreate(filename.c_str(), controllers_mask,
+                          from_reset ? MOVIE_OPT_FROM_RESET : MOVIE_OPT_FROM_SNAPSHOT,
+                          padded.c_str(), (int)padded.size());
+}
+
+void Snes9xController::stopMovie()
+{
+    if (S9xMovieActive())
+        S9xMovieStop(false);
+}
+
+bool Snes9xController::movieActive()
+{
+    return active && S9xMovieActive();
+}
+
+bool Snes9xController::saveAndCheckSRAM()
+{
+    if (!active)
+        return false;
+    auto filename = S9xGetFilename(".srm", SRAM_DIR);
+    Memory.SaveSRAM(filename.c_str());
+    std::error_code ec;
+    return fs::exists(filename, ec) &&
+           (fs::status(filename, ec).permissions() & fs::perms::owner_write) != fs::perms::none;
+}
+
+bool Snes9xController::startAVIRecording(const std::string &filename, bool hires, bool include_audio, std::string &error)
+{
+    if (!active)
+    {
+        error = "No game is running.";
+        return false;
+    }
+    S9xAVIOptions options;
+    options.hires = hires;
+    options.overscan = Settings.ShowOverscan;
+    options.include_audio = include_audio;
+    return S9xAVIStart(filename, options, &error);
+}
+
+void Snes9xController::stopAVIRecording()
+{
+    S9xAVIStop();
+}
+
+bool Snes9xController::aviRecording()
+{
+    return S9xAVIRecording();
 }
 
 void Snes9xController::setMessage(const std::string &message)

--- a/qt/src/Snes9xController.hpp
+++ b/qt/src/Snes9xController.hpp
@@ -27,6 +27,22 @@ class Snes9xController
     bool saveSRAM();
     bool saveMemoryPack();
     bool hasMemoryPack();
+
+    /* File->Movie Play/Record/Stop, as on win32. The open/create results are
+     * movie.cpp's SUCCESS/FILE_NOT_FOUND/WRONG_FORMAT/WRONG_VERSION. */
+    int openMovie(const std::string &filename, bool read_only);
+    int createMovie(const std::string &filename, uint8_t controllers_mask,
+                    bool from_reset, bool clear_sram, const std::wstring &metadata);
+    void stopMovie();
+    bool movieActive();
+    /* Writes the battery save out so the Record Movie dialog can tell whether
+     * there is one to clear; returns whether it exists and is writable. */
+    bool saveAndCheckSRAM();
+
+    /* File->AVI Recording. */
+    bool startAVIRecording(const std::string &filename, bool hires, bool include_audio, std::string &error);
+    void stopAVIRecording();
+    bool aviRecording();
     void updateSettings(EmuConfig *config);
     void updateBindings(const EmuConfig * const config);
     void reportBinding(EmuBinding b, bool active);


### PR DESCRIPTION
## Summary

Brings the win32 File menu's movie and AVI recording features to the Qt and GTK ports.

- **File → Movie Play... / Movie Record... / Movie Stop** in both ports, in the win32 order after Save Other. Movie Stop is only enabled while a movie runs.
- **Play Movie** and **Record Movie** dialogs mirror win32's: movie info (date, length, frames, re-record count), movie ROM vs current ROM with the MISMATCH warning, author info, Open Read-Only, record from reset or now, Clear SRAM (only offered when a battery save exists, deleted and reloaded as on win32) and Joypad 1-8 selection. The last dialog choices are remembered (`MovieDefault*` keys).
- **File → Start/Stop AVI Recording**, one item that relabels itself, as on win32.
- **Hi-Res AVI Recording** option in Options → Emulation (Qt) and Preferences → Emulation (GTK), config key `Emulation::AVIHiRes` like win32.
- GTK's old file-chooser-only movie items move from the Emulation menu into the File menu (ids unchanged, so existing accelerator bindings still apply).
- Emulation → Reset now logs the reset into a recording movie and ends a playing one, as win32 does. The existing BeginRecordingMovie / LoadMovie / EndRecordingMovie hotkeys open the dialogs or stop instead of hitting the core's stub commands.
- RetroAchievements hardcore mode gates movie play/record like the other state-changing actions.

## AVI implementation

win32 records through Video for Windows, so this adds a portable writer in `common/recording/`:

- `avi_writer`: uncompressed BGR24 video + PCM16 audio, written as OpenDML (AVI 2.0) with 1 GB `AVIX` segments and `indx`/`ix##` indexes, so a long recording stays a single file instead of win32's 2 GB `_partN` splits. Verified with a structural checker and GStreamer's demuxer, including a two-segment 1.4 GB file.
- `avi_recorder`: captures the frame in `S9xDeinitUpdate` before hi-res effects and software filters, writes one file frame per emulated frame from the port main loop (skipped frames during fast-forward are duplicated so the audio never drifts), and taps every mixed sample in the samples-available handler before the sound device can drop any. While recording, the audio input rate is pinned to the APU's true 32040 Hz and dynamic rate control is off so the file's audio and video timelines stay locked; the previous values come back on stop. Host audio keeps playing, unlike win32 which closes the device.

## Deviations from win32

- An AVI recording stops automatically on ROM load or a playback-rate change (win32 keeps recording across ROM loads).
- Movies and AVIs default to the export folder (`<rom>.smv` / `<rom>.avi`); the Linux ports have no dedicated Movies folder.
- Eight joypad checkboxes instead of five, matching the SMV controller mask.

## Testing

- Both ports build (`ninja` in `qt/build`, `ninja snes9x-gtk` in `gtk/build`).
- AVI writer output validated structurally and with `gst-discoverer-1.0` (256x224 with audio, 512x448 without audio, and a 1.4 GB two-segment file).
- The dialogs were not exercised interactively here; a manual pass over record/play/stop and AVI start/stop (with fast-forward during recording) on each port is recommended.
