### PR TITLE
qt/gtk: add the win32 Show Audio Waveform viewer

### DIFF
--- a/apu/apu.cpp
+++ b/apu/apu.cpp
@@ -351,6 +351,11 @@ bool8 S9xMixSamples(uint8 *dest, int sample_count)
         memset(out, 0, sample_count << 1);
         S9xClearSamples();
         spc::sound_in_sync = true;
+        // Flat-line the viewer's SPC lane while muted instead of freezing
+        // it on stale audio; the host pushes the (zeroed) mix itself.
+        if (audiowave::enabled)
+            audiowave::push_silence(audiowave::buf_spc, audiowave::wpos_spc,
+                                    sample_count / 2);
         CaptureLastOut(out, sample_count);
         return true;
     }
@@ -363,6 +368,13 @@ bool8 S9xMixSamples(uint8 *dest, int sample_count)
     }
 
     spc::resampler.read((short *)out, sample_count);
+
+    // The viewer's SPC lane: the SGB BIOS mix path feeds it from
+    // S9xPullSpcOutput, so the plain SNES path has to do it here, before
+    // MSU1 / Voicer-kun audio is layered on top.
+    if (audiowave::enabled)
+        audiowave::push(audiowave::buf_spc, audiowave::wpos_spc,
+                        out, sample_count / 2);
 
     if (Settings.MSU1)
     {

--- a/common/audio/audio_waveform.cpp
+++ b/common/audio/audio_waveform.cpp
@@ -1,0 +1,806 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "audio_waveform.hpp"
+
+#include "snes9x.h"
+#include "apu/apu.h"
+#include "memmap.h"
+#include "ppu.h"
+#include "sgb/sgb.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstring>
+
+namespace audiowave
+{
+
+/* Logic-Pro-style track colors: each group (SPC / GB / MIX) and each member
+ * (V1-8 / CH1-4) has its own. */
+const TrackInfo kTracks[kSourceCount] = {
+    { "SPC", { 91, 124, 235 } },
+    { "GB", { 166, 168, 60 } },
+    { "MIX", { 148, 156, 172 } },
+    { "CH1", { 102, 187, 106 } },
+    { "CH2", { 38, 166, 154 } },
+    { "CH3", { 212, 177, 6 } },
+    { "CH4", { 239, 112, 67 } },
+    { "V1", { 91, 141, 239 } },
+    { "V2", { 79, 195, 247 } },
+    { "V3", { 77, 208, 165 } },
+    { "V4", { 139, 195, 74 } },
+    { "V5", { 212, 196, 65 } },
+    { "V6", { 240, 154, 62 } },
+    { "V7", { 229, 100, 110 } },
+    { "V8", { 176, 106, 212 } },
+};
+
+const char *const kScaleLabels[kScaleCount] = {
+    "linear", "2x", "4x", "8x", "16x", "auto-fit", "log dB", "sqrt",
+};
+
+const RefreshOption kRefreshOptions[kRefreshCount] = {
+    { 500, 2, "2 Hz (500 ms)" },
+    { 200, 5, "5 Hz (200 ms)" },
+    { 100, 10, "10 Hz (100 ms)" },
+    { 50, 20, "20 Hz (50 ms)" },
+    { 33, 30, "30 Hz (33 ms)" },
+    { 16, 60, "60 Hz (16 ms)" },
+};
+
+/* Green to -12 dB, yellow to -3 dB, red above. */
+const MeterSegment kMeterSegments[3] = {
+    { 0.75f, { 80, 200, 90 } },
+    { 0.9375f, { 220, 200, 70 } },
+    { 1.0f, { 230, 80, 70 } },
+};
+
+Color shade(Color c, int pct)
+{
+    return { (uint8_t)(c.r * pct / 100), (uint8_t)(c.g * pct / 100),
+             (uint8_t)(c.b * pct / 100) };
+}
+
+Color tint(Color c, int pct)
+{
+    return { (uint8_t)(c.r + (255 - c.r) * pct / 100),
+             (uint8_t)(c.g + (255 - c.g) * pct / 100),
+             (uint8_t)(c.b + (255 - c.b) * pct / 100) };
+}
+
+bool is_group(int src)
+{
+    return src == kSPC || src == kGB;
+}
+
+static int64_t now_milliseconds()
+{
+    using namespace std::chrono;
+    return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+/* ---- Channel audibility ------------------------------------------------ */
+
+namespace
+{
+uint8_t user_spc = 255;
+uint8_t user_gb = 0x0F;
+uint8_t solo_spc = 0;      // V1-8 solo bits
+uint8_t solo_gb = 0;       // CH1-4 solo bits
+bool solo_spc_group = false; // SPC group solo (all voices)
+bool solo_gb_group = false;  // GB group solo (all channels)
+std::function<bool()> master_mute_get;
+std::function<void(bool)> master_mute_set;
+
+bool master_muted()
+{
+    if (master_mute_get)
+        return master_mute_get();
+    return (Settings.Mute & 1) != 0;
+}
+} // namespace
+
+uint8_t spc_mask()
+{
+    return user_spc;
+}
+
+uint8_t gb_mask()
+{
+    return user_gb;
+}
+
+void set_master_mute_hooks(std::function<bool()> get, std::function<void(bool)> set)
+{
+    master_mute_get = std::move(get);
+    master_mute_set = std::move(set);
+}
+
+void effective_masks(uint8_t *spc, uint8_t *gb)
+{
+    const uint8_t spc_solo = solo_spc | (solo_spc_group ? 0xFF : 0);
+    const uint8_t gb_solo = (uint8_t)((solo_gb | (solo_gb_group ? 0x0F : 0)) & 0x0F);
+    const bool any_solo = (spc_solo | gb_solo) != 0;
+    *spc = user_spc & (any_solo ? spc_solo : 0xFF);
+    *gb = user_gb & (any_solo ? gb_solo : 0x0F);
+}
+
+void apply()
+{
+    uint8_t spc, gb;
+    effective_masks(&spc, &gb);
+    S9xSetSoundControl(spc);
+    S9xSGBSetSoundChannelMask(gb);
+}
+
+void set_channel_mask(uint8_t mask)
+{
+    user_spc = mask;
+    // Channels 1-4 double as the GB APU's CH1-CH4 (pulse A, pulse B, wave,
+    // noise) so the menu also works for GB/SGB games. The viewer can
+    // retarget the GB mask on its own; the menu re-syncs it.
+    user_gb = mask & 0x0F;
+    apply();
+}
+
+void enable_all_channels()
+{
+    user_spc = 255;
+    user_gb = 0x0F;
+    // Enable All means audibly all-on: drop any engaged viewer solo too, or
+    // the solo mask would keep everything else silent.
+    solo_spc = solo_gb = 0;
+    solo_spc_group = solo_gb_group = false;
+    apply();
+}
+
+void toggle_channel(int channel)
+{
+    if (channel == 8)
+        enable_all_channels();
+    else
+        set_channel_mask(user_spc ^ (1 << channel));
+}
+
+bool is_muted(int src)
+{
+    switch (src)
+    {
+    case kSPC:
+        return (user_spc & 0xFF) == 0;
+    case kGB:
+        return (user_gb & 0x0F) == 0;
+    case kMix:
+        return master_muted();
+    default:
+        if (src >= kSPCVoice1)
+            return !(user_spc & (1 << (src - kSPCVoice1)));
+        return !(user_gb & (1 << (src - kGBChannel1)));
+    }
+}
+
+bool is_soloed(int src)
+{
+    switch (src)
+    {
+    case kSPC:
+        return solo_spc_group;
+    case kGB:
+        return solo_gb_group;
+    case kMix:
+        return false;
+    default:
+        if (src >= kSPCVoice1)
+            return (solo_spc >> (src - kSPCVoice1)) & 1;
+        return (solo_gb >> (src - kGBChannel1)) & 1;
+    }
+}
+
+bool is_audible(int src)
+{
+    uint8_t spc, gb;
+    effective_masks(&spc, &gb);
+    switch (src)
+    {
+    case kSPC:
+        return spc != 0;
+    case kGB:
+        return gb != 0;
+    case kMix:
+        return !master_muted();
+    default:
+        if (src >= kSPCVoice1)
+            return (spc >> (src - kSPCVoice1)) & 1;
+        return (gb >> (src - kGBChannel1)) & 1;
+    }
+}
+
+void toggle_mute(int src)
+{
+    static uint8_t saved_spc = 255; // group mute keeps the per-member pattern
+    static uint8_t saved_gb = 0x0F;
+    switch (src)
+    {
+    case kSPC:
+        if (user_spc & 0xFF)
+        {
+            saved_spc = user_spc;
+            user_spc = 0;
+        }
+        else
+            user_spc = saved_spc ? saved_spc : 255;
+        break;
+    case kGB:
+        if (user_gb & 0x0F)
+        {
+            saved_gb = user_gb;
+            user_gb = 0;
+        }
+        else
+            user_gb = saved_gb ? saved_gb : 0x0F;
+        break;
+    case kMix:
+        if (master_mute_set)
+            master_mute_set(!master_muted());
+        return;
+    default:
+        if (src >= kSPCVoice1)
+            user_spc ^= 1 << (src - kSPCVoice1);
+        else
+            user_gb ^= 1 << (src - kGBChannel1);
+        break;
+    }
+    apply();
+}
+
+void toggle_solo(int src)
+{
+    switch (src)
+    {
+    case kSPC:
+        solo_spc_group = !solo_spc_group;
+        break;
+    case kGB:
+        solo_gb_group = !solo_gb_group;
+        break;
+    case kMix:
+        return; // the master bus has nothing to solo against
+    default:
+        if (src >= kSPCVoice1)
+            solo_spc ^= 1 << (src - kSPCVoice1);
+        else
+            solo_gb ^= 1 << (src - kGBChannel1);
+        break;
+    }
+    apply();
+}
+
+void clear_solo()
+{
+    solo_spc = solo_gb = 0;
+    solo_spc_group = solo_gb_group = false;
+    apply();
+}
+
+/* ---- Recorder ---------------------------------------------------------- */
+
+Recorder::~Recorder()
+{
+    abort();
+    discard();
+}
+
+int Recorder::sample_rate(int src)
+{
+    if (src < kGBChannel1)
+        return Settings.SoundPlaybackRate;
+    if (src >= kSPCVoice1)
+        return 32000;
+    return (int)S9xSGBGetAudioRate();
+}
+
+int Recorder::channels(int src)
+{
+    return (src >= kGBChannel1 && src < kSPCVoice1) ? 1 : 2;
+}
+
+bool Recorder::start(int track)
+{
+    if (src >= 0)
+        return false;
+    discard();
+    file = std::tmpfile();
+    if (!file)
+        return false;
+    src = track;
+    frames = 0;
+    cursor = -1;
+    start_ms = now_milliseconds();
+    pump(); // latches the cursor
+    return true;
+}
+
+void Recorder::pump()
+{
+    if (src < 0 || !file)
+        return;
+    int16_t buf[4096 * 2];
+    for (;;)
+    {
+        int n;
+        if (src >= kGBChannel1 && src < kSPCVoice1)
+            n = S9xSGBReadChannelWaveformNew(src - kGBChannel1, &cursor, buf, 4096);
+        else
+            n = S9xAudioWaveformReadNew(src < kGBChannel1 ? src : src - 4, &cursor, buf, 4096);
+        if (n <= 0)
+            break;
+        fwrite(buf, channels(src) * sizeof(int16_t), n, file);
+        frames += n;
+        if (n < 4096)
+            break;
+    }
+}
+
+void Recorder::abort()
+{
+    if (src < 0)
+        return;
+    if (file)
+        fclose(file);
+    file = nullptr;
+    src = -1;
+}
+
+int Recorder::stop()
+{
+    if (src < 0)
+        return -1;
+    pump();
+    stopped_src = src;
+    src = -1;
+    return stopped_src;
+}
+
+void Recorder::discard()
+{
+    if (src >= 0)
+        return; // still armed
+    if (file)
+        fclose(file);
+    file = nullptr;
+    stopped_src = -1;
+    frames = 0;
+}
+
+bool Recorder::write_wav(const std::string &path)
+{
+    if (stopped_src < 0 || !file)
+        return false;
+    const int rate = sample_rate(stopped_src);
+    const int chans = channels(stopped_src);
+
+    FILE *out = fopen(path.c_str(), "wb");
+    if (!out)
+        return false;
+
+    const uint32_t data_bytes = frames * chans * 2;
+    const uint32_t byte_rate = (uint32_t)rate * chans * 2;
+    const uint16_t block = (uint16_t)(chans * 2);
+    const uint16_t bits = 16, fmt = 1, nch = (uint16_t)chans;
+    const uint32_t riff_size = 36 + data_bytes, fmt_size = 16;
+    const uint32_t rate32 = (uint32_t)rate;
+    fwrite("RIFF", 1, 4, out);
+    fwrite(&riff_size, 4, 1, out);
+    fwrite("WAVE", 1, 4, out);
+    fwrite("fmt ", 1, 4, out);
+    fwrite(&fmt_size, 4, 1, out);
+    fwrite(&fmt, 2, 1, out);
+    fwrite(&nch, 2, 1, out);
+    fwrite(&rate32, 4, 1, out);
+    fwrite(&byte_rate, 4, 1, out);
+    fwrite(&block, 2, 1, out);
+    fwrite(&bits, 2, 1, out);
+    fwrite("data", 1, 4, out);
+    fwrite(&data_bytes, 4, 1, out);
+
+    rewind(file);
+    char copy[16384];
+    size_t got;
+    while ((got = fread(copy, 1, sizeof(copy), file)) > 0)
+        fwrite(copy, 1, got, out);
+    const bool ok = ferror(out) == 0;
+    fclose(out);
+    discard();
+    return ok;
+}
+
+int Recorder::elapsed_seconds() const
+{
+    if (src < 0)
+        return 0;
+    return (int)((now_milliseconds() - start_ms) / 1000);
+}
+
+/* ---- Viewer ------------------------------------------------------------ */
+
+/* Ring I/O rates and emulation speed, remeasured every 500 ms for the
+ * "stats for nerds" labels. */
+struct Viewer::Stats
+{
+    int64_t last_ms = 0;
+    uint32_t last_frames = 0;
+    double fps = 0.0;
+    uint32_t gb_pushed0 = 0, gb_dropped0 = 0, gb_drained0 = 0;
+    unsigned int spc_pushed0 = 0, spc_consumed0 = 0;
+    uint64_t cycles_snes0 = 0, cycles_gb0 = 0;
+    long lines0 = 0;
+    double gb_in = 0, gb_out = 0, gb_drop = 0, spc_in = 0, spc_out = 0;
+    double snes_mhz = 0, gb_mhz = 0, lines_k = 0;
+
+    void update(int64_t now)
+    {
+        if (now - last_ms < 500)
+            return;
+        const double dt = (now - last_ms) / 1000.0;
+        fps = (IPPU.TotalEmulatedFrames - last_frames) * 1000.0 / (double)(now - last_ms);
+        uint32_t gp = 0, gd = 0, gr = 0;
+        unsigned int sp = 0, sc = 0;
+        S9xSGBGetAudioRingStats(&gp, &gd, &gr);
+        S9xSpcIoMeters(&sp, &sc);
+        gb_in = (gp - gb_pushed0) / dt;
+        gb_drop = (gd - gb_dropped0) / dt;
+        gb_out = (gr - gb_drained0) / dt;
+        spc_in = (sp - spc_pushed0) / 2.0 / dt;
+        spc_out = (sc - spc_consumed0) / 2.0 / dt;
+        gb_pushed0 = gp;
+        gb_dropped0 = gd;
+        gb_drained0 = gr;
+        spc_pushed0 = sp;
+        spc_consumed0 = sc;
+        uint64_t csn = 0, cgb = 0;
+        S9xSGBGetCycleMeters(&csn, &cgb);
+        snes_mhz = (csn - cycles_snes0) / dt / 1e6;
+        gb_mhz = (cgb - cycles_gb0) / dt / 1e6;
+        cycles_snes0 = csn;
+        cycles_gb0 = cgb;
+        const long ln = S9xApuScanlineMeter();
+        lines_k = (ln - lines0) / dt / 1000.0;
+        lines0 = ln;
+        last_frames = IPPU.TotalEmulatedFrames;
+        last_ms = now;
+    }
+};
+
+Viewer::Viewer()
+    : stats(new Stats)
+{
+}
+
+Viewer::~Viewer()
+{
+    close();
+    delete stats;
+}
+
+void Viewer::open()
+{
+    if (opened)
+        return;
+    opened = true;
+    S9xAudioWaveformEnable(true);
+    // Fresh splice-health counts per viewer session: the diagnostic question
+    // is "is it climbing right now", not the lifetime total.
+    S9xSGBMixGBPadSamples = 0;
+    S9xSGBMixSPCShortSamples = 0;
+    memset(meter, 0, sizeof(meter));
+    memset(meter_peak, 0, sizeof(meter_peak));
+    memset(meter_peak_ms, 0, sizeof(meter_peak_ms));
+    meter_ms = 0;
+}
+
+void Viewer::close()
+{
+    if (!opened)
+        return;
+    opened = false;
+    recorder.abort();
+    S9xAudioWaveformEnable(false);
+    if (reset_on_close)
+    {
+        // Mutes and solos were listening experiments: restore the all-on
+        // state Sound > Channels starts with.
+        enable_all_channels();
+    }
+    else
+    {
+        // Keep what's audible right now: bake engaged solos into the plain
+        // channel masks (there is no UI left to unsolo once the viewer is
+        // gone), so Sound > Channels keeps showing them.
+        uint8_t spc, gb;
+        effective_masks(&spc, &gb);
+        user_spc = spc;
+        user_gb = gb;
+        solo_spc = solo_gb = 0;
+        solo_spc_group = solo_gb_group = false;
+        apply();
+    }
+}
+
+int Viewer::build_order(int order[kSourceCount])
+{
+    const bool gb_core = Settings.SuperGameBoy || Settings.SGB_BIOSModeActive;
+    const bool spc_core = !Settings.SuperGameBoy;
+    // Solos on tracks that just left the layout (ROM swap while the viewer
+    // is open) would silently suppress the remaining core: drop them.
+    if (!gb_core && (solo_gb || solo_gb_group))
+    {
+        solo_gb = 0;
+        solo_gb_group = false;
+        apply();
+    }
+    if (!spc_core && (solo_spc || solo_spc_group))
+    {
+        solo_spc = 0;
+        solo_spc_group = false;
+        apply();
+    }
+    int n = 0;
+    if (spc_core)
+    {
+        order[n++] = kSPC;
+        if (spc_open)
+            for (int v = 0; v < 8; v++)
+                order[n++] = kSPCVoice1 + v;
+    }
+    if (gb_core)
+    {
+        order[n++] = kGB;
+        if (gb_open)
+            for (int c = 0; c < 4; c++)
+                order[n++] = kGBChannel1 + c;
+    }
+    order[n++] = kMix;
+    return n;
+}
+
+int Viewer::fetch(int src, int16_t *lr, int max_frames)
+{
+    if (src < kGBChannel1)
+        return S9xAudioWaveformSnapshot(src, lr, max_frames);
+    if (src >= kSPCVoice1)
+        return S9xAudioWaveformSnapshot(src - 4, lr, max_frames); // voice rings are streams 3..10
+    // The GB channel rings are mono: expand in place to the stereo layout,
+    // filling from the back so the copy never overtakes the source.
+    const int n = S9xSGBGetChannelWaveform(src - kGBChannel1, lr, max_frames);
+    for (int i = n - 1; i >= 0; i--)
+    {
+        lr[i * 2 + 1] = lr[i];
+        lr[i * 2 + 0] = lr[i];
+    }
+    return n;
+}
+
+int Viewer::sample_rate(int src) const
+{
+    if (src < kGBChannel1)
+        return S9xAudioWaveformSampleRate();
+    if (src >= kSPCVoice1)
+        return 32000;
+    return (int)S9xSGBGetAudioRate();
+}
+
+void Viewer::begin_paint()
+{
+    now_ms = now_milliseconds();
+    stats->update(now_ms);
+    float dt = (now_ms - meter_ms) / 1000.0f;
+    if (dt < 0.0f || dt > 1.0f)
+        dt = 0.1f;
+    meter_decay = (float)pow(0.5, dt / 0.15); // 150 ms half-life
+}
+
+void Viewer::end_paint()
+{
+    meter_ms = now_ms; // shared meter-decay clock
+}
+
+std::string Viewer::info_text(int src) const
+{
+    char text[192];
+    switch (src)
+    {
+    case kSPC:
+    {
+        const double ratio = S9xSpcGetTimeRatio();
+        const double hz = (ratio > 0.0) ? (Settings.SoundInputRate / ratio) : 0.0;
+        if (nerd_stats)
+            snprintf(text, sizeof(text),
+                     "SPC %.0f Hz (ratio %.5f)  emu %.1f fps  shown %u/%d  |  in %.1fk out %.1fk",
+                     hz, ratio, stats->fps, IPPU.DisplayedRenderedFrameCount,
+                     Memory.ROMFramesPerSecond, stats->spc_in / 1000.0, stats->spc_out / 1000.0);
+        else
+            snprintf(text, sizeof(text), "SPC %.0f Hz", hz);
+        return text;
+    }
+    case kGB:
+        if (nerd_stats)
+            snprintf(text, sizeof(text),
+                     "GB %d Hz  |  in %.1fk out %.1fk drop %.0f/s  |  snes %.2fM  gb %.2fM  ln %.1fk",
+                     S9xSGBGetAudioRate(), stats->gb_in / 1000.0, stats->gb_out / 1000.0,
+                     stats->gb_drop, stats->snes_mhz, stats->gb_mhz, stats->lines_k);
+        else
+            snprintf(text, sizeof(text), "GB %d Hz", S9xSGBGetAudioRate());
+        return text;
+    case kMix:
+        if (!nerd_stats)
+            return {};
+        snprintf(text, sizeof(text),
+                 "gbPad %ld  spcShort %ld  spcDrop %ld  |  gbFill %d  spcFill %d/%d  xS %.3f",
+                 S9xSGBMixGBPadSamples, S9xSGBMixSPCShortSamples, S9xSpcDroppedSamples(),
+                 S9xGetSampleCount(), S9xSpcSpaceFilled(), S9xSpcResamplerCapacity(),
+                 S9xSpcGetDrcScale());
+        return text;
+    case kGBChannel1:
+        return "pulse A (sweep)";
+    case kGBChannel1 + 1:
+        return "pulse B";
+    case kGBChannel1 + 2:
+        return "wave";
+    case kGBChannel1 + 3:
+        return "noise";
+    default:
+        return {};
+    }
+}
+
+std::string Viewer::axis_label(int division, int frames, int sample_rate)
+{
+    const double seconds = sample_rate > 0 ? ((double)frames / sample_rate) : 0.0;
+    char text[32];
+    snprintf(text, sizeof(text), "%.0f ms", seconds * 1000.0 * division / 7.0);
+    return text;
+}
+
+/* Map one normalized magnitude (0..1) into lane space under the current
+ * mode. Every mode is monotonic, so mapping just the min/max envelope
+ * endpoints of each pixel column stays valid. */
+static double scale_amplitude(int mode, double a, double peak)
+{
+    switch (mode)
+    {
+    default:
+    case kScaleLinear:
+        return a;
+    case kScaleX2:
+    case kScaleX4:
+    case kScaleX8:
+    case kScaleX16:
+    {
+        const double v = a * (double)(1 << (mode - kScaleLinear));
+        return v > 1.0 ? 1.0 : v;
+    }
+    case kScaleAuto:
+        return peak > 0.0 ? a / peak : 0.0;
+    case kScaleLog:
+    {
+        if (a <= 0.0)
+            return 0.0;
+        const double v = 1.0 + (20.0 * log10(a)) / 60.0;
+        return v < 0.0 ? 0.0 : v;
+    }
+    case kScaleSqrt:
+        return sqrt(a);
+    }
+}
+
+void Viewer::build_envelope(const int16_t *lr, int n, int width, int lane_height,
+                            std::vector<int> &y_min, std::vector<int> &y_max) const
+{
+    y_min.clear();
+    y_max.clear();
+    if (n <= 1 || width <= 0 || lane_height <= 4)
+        return;
+    y_min.resize(width);
+    y_max.resize(width);
+
+    // auto-fit normalizes to this lane's visible peak; the 1%-FS floor keeps
+    // idle noise from being blown up into a full-height smear
+    double peak_norm = 1.0;
+    if (scale == kScaleAuto)
+    {
+        int pk = 328;
+        for (int s = 0; s < n; s++)
+        {
+            int v = ((int)lr[s * 2] + (int)lr[s * 2 + 1]) / 2;
+            if (v < 0)
+                v = -v;
+            if (v > pk)
+                pk = v;
+        }
+        peak_norm = pk / 32768.0;
+    }
+
+    const int mid = lane_height / 2;
+    const int span = lane_height - 4;
+    int prev_min = 0, prev_max = 0;
+    for (int i = 0; i < width; i++)
+    {
+        int s0 = (i * n) / width;
+        int s1 = ((i + 1) * n) / width;
+        if (s1 <= s0)
+            s1 = s0 + 1;
+        int mn = 32767, mx = -32768;
+        for (int s = s0; s < s1 && s < n; s++)
+        {
+            const int v = ((int)lr[s * 2] + (int)lr[s * 2 + 1]) / 2;
+            if (v < mn)
+                mn = v;
+            if (v > mx)
+                mx = v;
+        }
+        const double hi = mx >= 0 ? scale_amplitude(scale, mx / 32768.0, peak_norm)
+                                  : -scale_amplitude(scale, -mx / 32768.0, peak_norm);
+        const double lo = mn >= 0 ? scale_amplitude(scale, mn / 32768.0, peak_norm)
+                                  : -scale_amplitude(scale, -mn / 32768.0, peak_norm);
+        int top = mid - (int)(hi * span / 2);
+        int bottom = mid - (int)(lo * span / 2);
+        if (bottom <= top)
+            bottom = top + 1;
+        if (i > 0)
+        {
+            if (top > prev_max)
+                top = prev_max;
+            if (bottom < prev_min)
+                bottom = prev_min;
+        }
+        prev_min = top;
+        prev_max = bottom;
+        y_min[i] = top;
+        y_max[i] = bottom;
+    }
+}
+
+void Viewer::meter_levels(int src, const int16_t *lr, int n, float level[2], float peak[2])
+{
+    int pk[2] = { 0, 0 };
+    const int window = (n > 1200) ? 1200 : n;
+    for (int i = n - window; i < n; i++)
+    {
+        for (int ch = 0; ch < 2; ch++)
+        {
+            int v = lr[i * 2 + ch];
+            if (v < 0)
+                v = -v;
+            if (v > pk[ch])
+                pk[ch] = v;
+        }
+    }
+    for (int ch = 0; ch < 2; ch++)
+    {
+        float lvl = 0.0f;
+        if (pk[ch] > 0)
+        {
+            const float db = 20.0f * (float)log10(pk[ch] / 32768.0);
+            lvl = (db + 48.0f) / 48.0f;
+            if (lvl < 0.0f)
+                lvl = 0.0f;
+            if (lvl > 1.0f)
+                lvl = 1.0f;
+        }
+        float &m = meter[src][ch];
+        m = (lvl > m) ? lvl : m * meter_decay;
+        if (lvl >= meter_peak[src][ch] || now_ms - meter_peak_ms[src][ch] > 1000)
+        {
+            meter_peak[src][ch] = lvl;
+            meter_peak_ms[src][ch] = now_ms;
+        }
+        level[ch] = m;
+        peak[ch] = meter_peak[src][ch];
+    }
+}
+
+} // namespace audiowave

--- a/common/audio/audio_waveform.hpp
+++ b/common/audio/audio_waveform.hpp
@@ -1,0 +1,211 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <string>
+#include <vector>
+
+/* Everything the Sound > Show Audio Waveform viewer needs that is not a
+ * window, shared by the Qt and GTK ports: the track list, the channel masks
+ * with the viewer's mute/solo overlay, the zoom modes, the level meters, the
+ * per-track WAV recorder and the diagnostic labels. The windows only draw
+ * what this hands them and route clicks back. win32 keeps its own copy of
+ * this logic in wsnes9x.cpp, which this mirrors. */
+namespace audiowave
+{
+
+/* Viewer sources, numbered as the win32 viewer numbers them. */
+enum Source
+{
+    kSPC = 0,        // SPC pre-mix; a group row that expands to the voices
+    kGB = 1,         // GB APU pre-mix; a group row that expands to the channels
+    kMix = 2,        // final host mix, always the bottom row
+    kGBChannel1 = 3, // GB CH1-CH4 are 3..6
+    kSPCVoice1 = 7,  // SPC V1-V8 are 7..14
+    kSourceCount = 15
+};
+
+constexpr int kSnapshotFrames = 4800; // frames of history each lane shows
+constexpr int kHeaderWidth = 144;     // the track header strip, in pixels
+
+struct Color
+{
+    uint8_t r, g, b;
+};
+
+struct TrackInfo
+{
+    const char *name;
+    Color color;
+};
+extern const TrackInfo kTracks[kSourceCount];
+
+Color shade(Color c, int pct); // scale toward black
+Color tint(Color c, int pct);  // blend toward white
+
+bool is_group(int src);
+
+/* ---- Channel audibility --------------------------------------------------
+ * The user's channel masks (Sound > Channels and the viewer's [M] buttons)
+ * plus the viewer's solo overlay. SPC voices ride the 8-bit mask the menu
+ * shows; the GB APU's CH1-CH4 have their own 4-bit mask so muting CH2 in the
+ * viewer does not silence SPC voice 2. The menu is the blunt tool and
+ * re-syncs the GB mask to its low bits. The MIX row is the master mute,
+ * which lives in the port's config, so the port supplies hooks for it. */
+uint8_t spc_mask();
+uint8_t gb_mask();
+void set_channel_mask(uint8_t mask); // Sound > Channels: SPC, GB = low bits
+void toggle_channel(int channel);    // hotkey: 0-7 toggles one, 8 enables all
+void enable_all_channels();          // all on, and drops any engaged solo
+void set_master_mute_hooks(std::function<bool()> get, std::function<void(bool)> set);
+
+/* Masks the cores actually get: the user masks composed with the solo set.
+ * While any solo is engaged only soloed tracks stay audible; mute still wins
+ * over solo on the same track. */
+void effective_masks(uint8_t *spc, uint8_t *gb);
+void apply(); // push the effective masks to the SPC DSP and the GB APU
+
+bool is_muted(int src);   // the user's own mute on this track
+bool is_soloed(int src);
+bool is_audible(int src); // reaches the output right now (mute + solo)
+void toggle_mute(int src);
+void toggle_solo(int src);
+void clear_solo();
+
+/* ---- Vertical zoom -------------------------------------------------------
+ * Chip output is often a small fraction of full scale, so linear rendering
+ * leaves near-flat traces; these modes trade amplitude truth for visibility
+ * in different ways. */
+enum Scale
+{
+    kScaleLinear = 0, // true amplitude
+    kScaleX2,         // fixed gains, clipped at the lane edge
+    kScaleX4,
+    kScaleX8,
+    kScaleX16,
+    kScaleAuto, // normalize each lane to its own visible peak
+    kScaleLog,  // dB mapping with a -60 dB floor (Audacity-style)
+    kScaleSqrt, // gentler perceptual boost than log
+    kScaleCount
+};
+extern const char *const kScaleLabels[kScaleCount];
+constexpr int kDefaultScale = kScaleSqrt;
+
+struct RefreshOption
+{
+    int ms;
+    int hz;
+    const char *label;
+};
+constexpr int kRefreshCount = 6;
+extern const RefreshOption kRefreshOptions[kRefreshCount];
+constexpr int kDefaultRefresh = 3; // 20 Hz
+
+/* Level meter color bands, as fractions of the -48..0 dB meter width. */
+struct MeterSegment
+{
+    float to;
+    Color color;
+};
+extern const MeterSegment kMeterSegments[3];
+
+/* ---- One-track recorder --------------------------------------------------
+ * Raw PCM streams to a temporary file while armed; stopping hands the
+ * caller the track so it can prompt for a .wav destination. */
+class Recorder
+{
+  public:
+    ~Recorder();
+    bool start(int src);
+    void pump();  // drain what the ring gained since the last call
+    void abort(); // drop everything, e.g. on close
+    /* Stops recording and returns the track that was armed, or -1 if none.
+     * The data is kept until write_wav or discard. */
+    int stop();
+    bool write_wav(const std::string &path);
+    void discard();
+    int source() const { return src; }     // armed track, -1 while idle
+    int elapsed_seconds() const;
+    static int sample_rate(int src);
+    static int channels(int src);
+
+  private:
+    int src = -1;
+    int stopped_src = -1;
+    FILE *file = nullptr;
+    uint32_t frames = 0;
+    int cursor = -1;
+    int64_t start_ms = 0;
+};
+
+/* ---- The viewer ---------------------------------------------------------- */
+class Viewer
+{
+  public:
+    Viewer();
+    ~Viewer();
+    void open();  // start capturing; call when the window opens
+    void close(); // stop capturing and honor reset_on_close
+
+    /* Top-to-bottom row list for the running core and the expansion state.
+     * Dead cores are dropped (no SPC group in BIOS-less GB, no GB group for
+     * SNES-only games); MIX always sits at the bottom. Solos on tracks that
+     * just left the layout are dropped so they cannot silence the rest. */
+    int build_order(int order[kSourceCount]);
+
+    /* Newest frames of a source as interleaved stereo, oldest first; the
+     * mono GB channels are expanded in place. */
+    int fetch(int src, int16_t *lr, int max_frames);
+    int sample_rate(int src) const;
+
+    /* Call around each paint: refreshes the diagnostic rates on a 500 ms
+     * cadence and sets up the meter decay for this frame. */
+    void begin_paint();
+    void end_paint();
+
+    /* Info label at the top-left of a lane: rates, or the counters and
+     * fills when nerd_stats is on. Empty for rows with nothing to say. */
+    std::string info_text(int src) const;
+    /* "%.0f ms" label for x-axis division 1..6 of 7. */
+    static std::string axis_label(int division, int frames, int sample_rate);
+
+    /* One vertical min/max segment per pixel column under the current zoom,
+     * bridged to the previous column so steep slopes read as a continuous
+     * trace. Both vectors hold lane-relative y (0 = lane top). */
+    void build_envelope(const int16_t *lr, int frames, int width, int lane_height,
+                        std::vector<int> &y_min, std::vector<int> &y_max) const;
+
+    /* Logic-style L/R meters: smoothed level and a 1 s peak hold per side,
+     * both 0..1 over -48..0 dB. */
+    void meter_levels(int src, const int16_t *lr, int frames, float level[2], float peak[2]);
+
+    int scale = kDefaultScale;
+    int refresh = kDefaultRefresh;
+    bool spc_open = false;
+    bool gb_open = false;
+    /* By default closing restores the all-on channel defaults (mutes and
+     * solos are listening experiments). Unchecked, the audible state is kept
+     * and engaged solos are baked into the channel masks. */
+    bool reset_on_close = true;
+    bool nerd_stats = false;
+    Recorder recorder;
+
+  private:
+    struct Stats;
+    Stats *stats;
+    float meter[kSourceCount][2] = {};
+    float meter_peak[kSourceCount][2] = {};
+    int64_t meter_peak_ms[kSourceCount][2] = {};
+    int64_t meter_ms = 0;
+    float meter_decay = 1.0f;
+    int64_t now_ms = 0;
+    bool opened = false;
+};
+
+} // namespace audiowave

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -307,10 +307,14 @@ list(APPEND SOURCES
     src/gtk_control.h
     src/gtk_movie.cpp
     src/gtk_movie.h
+    src/gtk_audio_waveform.cpp
+    src/gtk_audio_waveform.h
     ../common/recording/avi_writer.cpp
     ../common/recording/avi_writer.hpp
     ../common/recording/avi_recorder.cpp
     ../common/recording/avi_recorder.hpp
+    ../common/audio/audio_waveform.cpp
+    ../common/audio/audio_waveform.hpp
     src/gtk_display.cpp
     src/gtk_display_driver_gtk.cpp
     src/gtk_display_driver_gtk.h

--- a/gtk/src/gtk_audio_waveform.cpp
+++ b/gtk/src/gtk_audio_waveform.cpp
@@ -1,0 +1,506 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "gtk_audio_waveform.h"
+#include "gtk_compat.h"
+#include "gtk_s9x.h"
+#include "gtk_sound.h"
+
+#include "common/audio/audio_waveform.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace aw = audiowave;
+
+namespace
+{
+
+struct Rect
+{
+    int x, y, w, h;
+    bool contains(int px, int py) const
+    {
+        return px >= x && px < x + w && py >= y && py < y + h;
+    }
+};
+
+/* [R]ecord, [M]ute and [S]olo button rects inside a row: the right side of
+ * the header, vertically centered. Shared by the painter and the hit test. */
+Rect rec_rect(const Rect &row)
+{
+    return { row.x + aw::kHeaderWidth - 84, row.y + row.h / 2 - 9, 22, 18 };
+}
+
+Rect mute_rect(const Rect &row)
+{
+    return { row.x + aw::kHeaderWidth - 58, row.y + row.h / 2 - 9, 22, 18 };
+}
+
+Rect solo_rect(const Rect &row)
+{
+    return { row.x + aw::kHeaderWidth - 32, row.y + row.h / 2 - 9, 22, 18 };
+}
+
+void set_color(const Cairo::RefPtr<Cairo::Context> &cr, aw::Color c)
+{
+    cr->set_source_rgb(c.r / 255.0, c.g / 255.0, c.b / 255.0);
+}
+
+void fill_rect(const Cairo::RefPtr<Cairo::Context> &cr, const Rect &r, aw::Color c)
+{
+    set_color(cr, c);
+    cr->rectangle(r.x, r.y, r.w, r.h);
+    cr->fill();
+}
+
+void frame_rect(const Cairo::RefPtr<Cairo::Context> &cr, const Rect &r, aw::Color c)
+{
+    set_color(cr, c);
+    cr->set_line_width(1.0);
+    cr->rectangle(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+    cr->stroke();
+}
+
+enum Align
+{
+    kAlignLeft,
+    kAlignCenter
+};
+
+/* Text vertically centered in r, clipped to it. */
+void draw_text(const Cairo::RefPtr<Cairo::Context> &cr, const Glib::RefPtr<Pango::Layout> &layout,
+               const Rect &r, const std::string &text, aw::Color c, Align align = kAlignLeft)
+{
+    if (text.empty())
+        return;
+    layout->set_text(text);
+    int tw, th;
+    layout->get_pixel_size(tw, th);
+    const int x = (align == kAlignCenter) ? r.x + (r.w - tw) / 2 : r.x;
+    cr->save();
+    cr->rectangle(r.x, r.y, r.w, r.h);
+    cr->clip();
+    set_color(cr, c);
+    cr->move_to(x, r.y + (r.h - th) / 2);
+    layout->show_in_cairo_context(cr);
+    cr->restore();
+}
+
+} // namespace
+
+class Snes9xAudioWaveform : public Gtk::Window
+{
+  public:
+    Snes9xAudioWaveform();
+    ~Snes9xAudioWaveform() override;
+    /* Stops capturing and honors reset-on-close; safe to call twice. */
+    void shutdown();
+
+  private:
+    bool draw(const Cairo::RefPtr<Cairo::Context> &cr);
+    void draw_row(const Cairo::RefPtr<Cairo::Context> &cr, const Rect &r, int src,
+                  const int16_t *lr, int n, bool show_axis);
+    bool button_press(GdkEventButton *event);
+    bool tick();
+    void apply_refresh();
+    void toggle_recording(int src);
+    /* Rows split the height evenly; the last one takes the remainder. */
+    Rect row_rect(int index, int panels) const;
+
+    aw::Viewer viewer;
+    Gtk::Box vbox{ Gtk::ORIENTATION_VERTICAL };
+    Gtk::DrawingArea area;
+    Gtk::Box footer{ Gtk::ORIENTATION_HORIZONTAL, 8 };
+    Gtk::CheckButton reset_check;
+    Gtk::Label zoom_label;
+    Gtk::ComboBoxText zoom_combo;
+    Gtk::Label rate_label;
+    Gtk::ComboBoxText rate_combo;
+    Gtk::CheckButton nerd_check;
+    sigc::connection tick_connection;
+    Glib::RefPtr<Pango::Layout> layout;
+    std::vector<int16_t> buffer;
+    std::vector<int> y_min, y_max;
+};
+
+Snes9xAudioWaveform::Snes9xAudioWaveform()
+    : reset_check(_("reset channels on close")),
+      zoom_label(_("zoom")),
+      rate_label(_("rate")),
+      nerd_check(_("stats for nerds"))
+{
+    set_title(_("Audio Waveform  (click SPC/GB to expand channels)"));
+    set_default_size(800, 560);
+    if (top_level && top_level->window)
+        set_transient_for(*top_level->window.get());
+
+    // The MIX row's [M] is the preferences dialog's "Mute sound output".
+    aw::set_master_mute_hooks(
+        [] { return gui_config->mute_sound; },
+        [](bool muted) {
+            gui_config->mute_sound = muted;
+            S9xPortSoundReinit();
+        });
+
+    buffer.resize(aw::kSnapshotFrames * 2);
+
+    layout = area.create_pango_layout("");
+    auto font = area.get_pango_context()->get_font_description();
+    font.set_absolute_size(12 * PANGO_SCALE);
+    layout->set_font_description(font);
+
+    area.set_size_request(-1, 120);
+    area.add_events(Gdk::BUTTON_PRESS_MASK);
+    area.signal_draw().connect(sigc::mem_fun(*this, &Snes9xAudioWaveform::draw));
+    area.signal_button_press_event().connect(sigc::mem_fun(*this, &Snes9xAudioWaveform::button_press));
+
+    reset_check.set_active(viewer.reset_on_close);
+    reset_check.signal_toggled().connect([this] { viewer.reset_on_close = reset_check.get_active(); });
+
+    for (int i = 0; i < aw::kScaleCount; i++)
+        zoom_combo.append(aw::kScaleLabels[i]);
+    zoom_combo.set_active(viewer.scale);
+    zoom_combo.signal_changed().connect([this] {
+        const int index = zoom_combo.get_active_row_number();
+        if (index >= 0)
+            viewer.scale = index;
+        area.queue_draw();
+    });
+
+    for (int i = 0; i < aw::kRefreshCount; i++)
+        rate_combo.append(aw::kRefreshOptions[i].label);
+    rate_combo.set_active(viewer.refresh);
+    rate_combo.signal_changed().connect([this] {
+        const int index = rate_combo.get_active_row_number();
+        if (index >= 0)
+            viewer.refresh = index;
+        apply_refresh();
+    });
+
+    nerd_check.set_active(viewer.nerd_stats);
+    nerd_check.signal_toggled().connect([this] {
+        viewer.nerd_stats = nerd_check.get_active();
+        area.queue_draw();
+    });
+
+    footer.set_border_width(4);
+    footer.pack_start(reset_check, Gtk::PACK_SHRINK);
+    footer.pack_start(zoom_label, Gtk::PACK_SHRINK, 8);
+    footer.pack_start(zoom_combo, Gtk::PACK_SHRINK);
+    footer.pack_start(rate_label, Gtk::PACK_SHRINK, 8);
+    footer.pack_start(rate_combo, Gtk::PACK_SHRINK);
+    footer.pack_start(nerd_check, Gtk::PACK_SHRINK, 8);
+
+    vbox.pack_start(area, Gtk::PACK_EXPAND_WIDGET);
+    vbox.pack_start(footer, Gtk::PACK_SHRINK);
+    add(vbox);
+
+    signal_delete_event().connect([](GdkEventAny *) -> bool {
+        S9xCloseAudioWaveformWindow();
+        return true;
+    });
+
+    viewer.open();
+    apply_refresh();
+    show_all();
+}
+
+Snes9xAudioWaveform::~Snes9xAudioWaveform()
+{
+    shutdown();
+}
+
+void Snes9xAudioWaveform::shutdown()
+{
+    tick_connection.disconnect();
+    viewer.close();
+}
+
+void Snes9xAudioWaveform::apply_refresh()
+{
+    tick_connection.disconnect();
+    tick_connection = Glib::signal_timeout().connect(sigc::mem_fun(*this, &Snes9xAudioWaveform::tick),
+                                                     aw::kRefreshOptions[viewer.refresh].ms);
+}
+
+bool Snes9xAudioWaveform::tick()
+{
+    viewer.recorder.pump();
+    auto gdk_window = get_window();
+    if (!gdk_window || !(gdk_window->get_state() & Gdk::WINDOW_STATE_ICONIFIED))
+        area.queue_draw();
+    return true;
+}
+
+Rect Snes9xAudioWaveform::row_rect(int index, int panels) const
+{
+    const int width = area.get_allocated_width();
+    const int height = area.get_allocated_height();
+    const int h = height / panels;
+    return { 0, index * h, width, (index == panels - 1) ? height - index * h : h };
+}
+
+bool Snes9xAudioWaveform::draw(const Cairo::RefPtr<Cairo::Context> &cr)
+{
+    const int width = area.get_allocated_width();
+    const int height = area.get_allocated_height();
+    fill_rect(cr, { 0, 0, width, height }, { 18, 18, 20 });
+
+    int order[aw::kSourceCount];
+    const int panels = viewer.build_order(order);
+    if (height / panels <= 0)
+        return true;
+
+    viewer.begin_paint();
+    for (int i = 0; i < panels; i++)
+    {
+        const int src = order[i];
+        const int n = viewer.fetch(src, buffer.data(), aw::kSnapshotFrames);
+        draw_row(cr, row_rect(i, panels), src, buffer.data(), n, i == panels - 1);
+    }
+    viewer.end_paint();
+    return true;
+}
+
+void Snes9xAudioWaveform::draw_row(const Cairo::RefPtr<Cairo::Context> &cr, const Rect &r, int src,
+                                   const int16_t *lr, int n, bool show_axis)
+{
+    const aw::TrackInfo &track = aw::kTracks[src];
+    const bool group = aw::is_group(src);
+    const bool expanded = (src == aw::kSPC) ? viewer.spc_open : viewer.gb_open;
+    const bool user_muted = aw::is_muted(src);
+    const bool soloed = aw::is_soloed(src);
+    const bool audible = aw::is_audible(src);
+    const int cy = r.y + r.h / 2;
+
+    // Header strip: color tab, disclosure triangle on group rows, name.
+    const Rect header{ r.x, r.y, aw::kHeaderWidth, r.h };
+    fill_rect(cr, header, group ? aw::Color{ 56, 56, 60 } : aw::Color{ 40, 40, 44 });
+    fill_rect(cr, { header.x, header.y, 5, header.h }, track.color);
+
+    if (group)
+    {
+        const int ix = header.x + 10;
+        set_color(cr, aw::tint(track.color, 30));
+        if (expanded)
+        {
+            cr->move_to(ix, cy - 3);
+            cr->line_to(ix + 10, cy - 3);
+            cr->line_to(ix + 5, cy + 4);
+        }
+        else
+        {
+            cr->move_to(ix + 2, cy - 5);
+            cr->line_to(ix + 2, cy + 5);
+            cr->line_to(ix + 9, cy);
+        }
+        cr->close_path();
+        cr->fill();
+    }
+
+    draw_text(cr, layout, { header.x + (group ? 26 : 30), cy - 8, 40, 16 }, track.name,
+              audible ? aw::Color{ 225, 225, 228 } : aw::Color{ 130, 130, 135 });
+
+    auto button = [&](const Rect &b, const char *label, bool on, aw::Color fill_on,
+                      aw::Color frame_on, aw::Color text_on) {
+        fill_rect(cr, b, on ? fill_on : aw::Color{ 52, 52, 56 });
+        frame_rect(cr, b, on ? frame_on : aw::Color{ 80, 80, 86 });
+        draw_text(cr, layout, b, label, on ? text_on : aw::Color{ 150, 150, 156 }, kAlignCenter);
+    };
+    const bool rec_this = viewer.recorder.source() == src;
+    button(rec_rect(r), "R", rec_this, { 200, 40, 40 }, { 240, 90, 90 }, { 255, 255, 255 });
+    button(mute_rect(r), "M", user_muted, { 96, 150, 250 }, { 140, 180, 255 }, { 20, 30, 60 });
+    // The MIX row is the master bus, so it has no solo.
+    if (src != aw::kMix)
+        button(solo_rect(r), "S", soloed, { 230, 192, 62 }, { 250, 220, 120 }, { 60, 45, 10 });
+
+    // Waveform lane, dimmed when the track doesn't reach the output, whether
+    // by its own mute or by someone else's solo.
+    const int axis_h = show_axis ? 16 : 0;
+    const Rect lane{ r.x + aw::kHeaderWidth, r.y, r.w - aw::kHeaderWidth, r.h };
+    const Rect body{ lane.x, lane.y, lane.w, lane.h - axis_h };
+    fill_rect(cr, body, aw::shade(track.color, audible ? 28 : 14));
+    const int mid_y = body.y + body.h / 2;
+    set_color(cr, aw::shade(track.color, audible ? 44 : 24));
+    cr->set_line_width(1.0);
+    cr->move_to(body.x, mid_y + 0.5);
+    cr->line_to(body.x + body.w, mid_y + 0.5);
+    cr->stroke();
+
+    viewer.build_envelope(lr, n, body.w, body.h, y_min, y_max);
+    if (!y_min.empty())
+    {
+        set_color(cr, audible ? aw::tint(track.color, 55) : aw::shade(track.color, 52));
+        for (size_t i = 0; i < y_min.size(); i++)
+        {
+            const double x = body.x + (int)i + 0.5;
+            cr->move_to(x, body.y + y_min[i]);
+            cr->line_to(x, body.y + y_max[i] + 1);
+        }
+        cr->stroke();
+    }
+
+    // L/R meters under the buttons: -48..0 dB with 1 s peak-hold ticks.
+    if (r.h >= 46)
+    {
+        float level[2], peak[2];
+        viewer.meter_levels(src, lr, n, level, peak);
+        const int mx0 = header.x + 8;
+        const int mw = header.w - 16;
+        for (int ch = 0; ch < 2; ch++)
+        {
+            const int y0 = cy + 13 + ch * 4;
+            fill_rect(cr, { mx0, y0, mw, 3 }, { 30, 30, 32 });
+            float from = 0.0f;
+            for (int s = 0; s < 3 && from < level[ch]; s++)
+            {
+                const float to = std::min(level[ch], aw::kMeterSegments[s].to);
+                if (to > from)
+                {
+                    const int x0 = mx0 + (int)(from * mw);
+                    const int x1 = mx0 + (int)(to * mw);
+                    fill_rect(cr, { x0, y0, x1 - x0, 3 }, aw::kMeterSegments[s].color);
+                }
+                from = aw::kMeterSegments[s].to;
+            }
+            if (peak[ch] > 0.01f)
+                fill_rect(cr, { mx0 + (int)(peak[ch] * (mw - 2)), y0, 2, 3 }, { 220, 220, 224 });
+        }
+    }
+
+    // Clip-label style info at the top-left of the lane, status at the right.
+    draw_text(cr, layout, { lane.x + 6, lane.y + 2, lane.w - 12, 16 }, viewer.info_text(src),
+              aw::tint(track.color, audible ? 70 : 25));
+    if (user_muted)
+        draw_text(cr, layout, { lane.x + lane.w - 52, lane.y + 2, 50, 16 }, _("muted"),
+                  aw::tint(track.color, 40));
+    if (rec_this)
+    {
+        const int seconds = viewer.recorder.elapsed_seconds();
+        char text[32];
+        snprintf(text, sizeof(text), "REC %d:%02d", seconds / 60, seconds % 60);
+        draw_text(cr, layout, { lane.x + lane.w - 140, lane.y + 2, 86, 16 }, text, { 235, 80, 80 });
+    }
+
+    if (show_axis)
+    {
+        const Rect axis{ lane.x, body.y + body.h, lane.w, axis_h };
+        fill_rect(cr, axis, { 18, 18, 20 });
+        const int rate = viewer.sample_rate(src);
+        for (int i = 1; i < 7; i++)
+        {
+            const int x = lane.x + (lane.w * i) / 7;
+            draw_text(cr, layout, { x - 22, axis.y + 1, 44, 14 }, aw::Viewer::axis_label(i, n, rate),
+                      { 140, 140, 145 }, kAlignCenter);
+        }
+        draw_text(cr, layout, { lane.x + 2, axis.y + 1, 20, 14 }, "0", { 140, 140, 145 });
+    }
+
+    set_color(cr, { 20, 20, 22 });
+    cr->move_to(r.x, r.y + r.h - 0.5);
+    cr->line_to(r.x + r.w, r.y + r.h - 0.5);
+    cr->stroke();
+}
+
+bool Snes9xAudioWaveform::button_press(GdkEventButton *event)
+{
+    if (event->button != 1)
+        return false;
+    int order[aw::kSourceCount];
+    const int panels = viewer.build_order(order);
+    const int h = area.get_allocated_height() / panels;
+    if (h <= 0)
+        return true;
+    const int px = (int)event->x;
+    const int py = (int)event->y;
+    const int index = std::clamp(py / h, 0, panels - 1);
+    const int src = order[index];
+    const Rect row = row_rect(index, panels);
+
+    if (rec_rect(row).contains(px, py))
+        toggle_recording(src);
+    else if (mute_rect(row).contains(px, py))
+        aw::toggle_mute(src);
+    else if (src != aw::kMix && solo_rect(row).contains(px, py))
+        aw::toggle_solo(src);
+    // Anywhere else on a group row toggles its expansion.
+    else if (src == aw::kSPC)
+        viewer.spc_open = !viewer.spc_open;
+    else if (src == aw::kGB)
+        viewer.gb_open = !viewer.gb_open;
+    else
+        return true;
+    area.queue_draw();
+    return true;
+}
+
+void Snes9xAudioWaveform::toggle_recording(int src)
+{
+    auto &recorder = viewer.recorder;
+    // One track at a time; clicking the armed one stops and saves.
+    if (recorder.source() == src)
+    {
+        recorder.stop();
+        Gtk::FileChooserDialog dialog(*this, _("Save WAV file..."), Gtk::FILE_CHOOSER_ACTION_SAVE);
+        dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
+        dialog.add_button(_("_Save"), Gtk::RESPONSE_ACCEPT);
+        dialog.set_do_overwrite_confirmation(true);
+        dialog.set_current_name(std::string(aw::kTracks[src].name) + ".wav");
+        auto filter = Gtk::FileFilter::create();
+        filter->set_name(_("WAV audio"));
+        filter->add_pattern("*.wav");
+        filter->add_pattern("*.WAV");
+        dialog.add_filter(filter);
+
+        const int result = dialog.run();
+        dialog.hide();
+        if (result != Gtk::RESPONSE_ACCEPT)
+        {
+            recorder.discard();
+            return;
+        }
+        if (!recorder.write_wav(dialog.get_filename()))
+        {
+            std::string message = _("Couldn't save WAV file:");
+            message += " " + dialog.get_filename();
+            Gtk::MessageDialog(*this, message, false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE, true).run();
+        }
+    }
+    else if (recorder.source() < 0)
+    {
+        recorder.start(src);
+    }
+}
+
+static std::unique_ptr<Snes9xAudioWaveform> waveform_window;
+
+void S9xToggleAudioWaveformWindow()
+{
+    if (waveform_window)
+        S9xCloseAudioWaveformWindow();
+    else
+        waveform_window = std::make_unique<Snes9xAudioWaveform>();
+}
+
+bool S9xAudioWaveformWindowOpen()
+{
+    return waveform_window != nullptr;
+}
+
+void S9xCloseAudioWaveformWindow()
+{
+    if (!waveform_window)
+        return;
+    waveform_window->shutdown();
+    waveform_window->hide();
+    // This may run from the window's own delete-event handler, where
+    // destroying it is unsafe: let the main loop finish with it first.
+    auto *window = waveform_window.release();
+    Glib::signal_idle().connect_once([window] { delete window; });
+}

--- a/gtk/src/gtk_audio_waveform.h
+++ b/gtk/src/gtk_audio_waveform.h
@@ -1,0 +1,16 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+/* Sound > Show Audio Waveform, as on win32: Logic-style track rows for the
+ * SPC and GB pre-mixes (each expands to its voices / channels) and the final
+ * mix, with record/mute/solo buttons and L/R level meters in each header,
+ * and a footer for the reset-on-close, zoom, refresh rate and nerd stats
+ * choices. One window at a time; the menu item toggles it. */
+void S9xToggleAudioWaveformWindow();
+bool S9xAudioWaveformWindowOpen();
+void S9xCloseAudioWaveformWindow();

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -12,6 +12,7 @@
 #include "gtk_s9x.h"
 #include "gtk_control.h"
 #include "gtk_sound.h"
+#include "gtk_audio_waveform.h"
 #include "gtk_display.h"
 #include "gtk_netplay.h"
 #include "gtk_retroachievements.h"
@@ -684,6 +685,7 @@ static void check_pointer_timer()
 void S9xExit()
 {
     S9xAVIStop();
+    S9xCloseAudioWaveformWindow();
 
     gui_config->save_config_file();
 

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -29,6 +29,8 @@
 #include "gtk_cheat.h"
 #include "gtk_netplay.h"
 #include "gtk_movie.h"
+#include "gtk_audio_waveform.h"
+#include "common/audio/audio_waveform.hpp"
 #include "gtk_retroachievements.h"
 #include "retroachievements.h"
 #include "gtk_s9xwindow.h"
@@ -433,7 +435,16 @@ void Snes9xWindow::connect_signals()
     }
 
     get_object<Gtk::MenuItem>("enable_all_channels_item")->signal_activate().connect([] {
-        S9xSetSoundChannelMask(255);
+        // All on audibly: also drops any solo engaged in the waveform viewer.
+        audiowave::enable_all_channels();
+    });
+
+    // win32's Sound->Show Audio Waveform: the track viewer of the audio rings.
+    auto waveform_item = get_object<Gtk::CheckMenuItem>("audio_waveform_item");
+    waveform_item->signal_toggled().connect([waveform_item] {
+        // The menu-open sync also flips the item; only act on real changes.
+        if (waveform_item->get_active() != S9xAudioWaveformWindowOpen())
+            S9xToggleAudioWaveformWindow();
     });
 
     get_object<Gtk::MenuItem>("color_correction_item")->signal_activate().connect([this] {
@@ -465,20 +476,25 @@ void Snes9xWindow::connect_signals()
     });
 
     get_object<Gtk::MenuItem>("sound_menu_item")->signal_activate().connect([this] {
-        uint8_t mask = S9xGetSoundChannelMask();
+        // Checkmarks show the effective state — the user mask composed with
+        // any waveform-viewer solo — so soloing V3 leaves only Channel 3 checked.
+        uint8_t spc_mask, gb_mask;
+        audiowave::effective_masks(&spc_mask, &gb_mask);
         // Channels 1-4 drive both SPC voices 1-4 and the GB APU's CH1-CH4.
         // In BIOS-less GB mode the SPC isn't running, so 5-8 control
         // nothing — grey them there, as on win32.
         bool gb_only = Settings.SuperGameBoy && !Settings.SGB_BIOSModeActive;
+        const uint8_t low_bits = gb_only ? gb_mask : spc_mask;
         for (int i = 0; i < 8; i++)
         {
             std::string name = "sound_channel_" + std::to_string(i + 1) + "_item";
             auto item = get_object<Gtk::CheckMenuItem>(name.c_str());
-            item->set_active((mask & (1 << i)) != 0);
+            item->set_active(((i < 4 ? low_bits : spc_mask) & (1 << i)) != 0);
             if (i >= 4)
                 item->set_sensitive(!gb_only);
         }
         get_object<Gtk::CheckMenuItem>("mute_item")->set_active(gui_config->mute_sound);
+        get_object<Gtk::CheckMenuItem>("audio_waveform_item")->set_active(S9xAudioWaveformWindowOpen());
     });
 
 #ifdef RETROACHIEVEMENTS_SUPPORT
@@ -807,7 +823,10 @@ void Snes9xWindow::focus_notify(bool state)
 {
     focused = state;
 
-    if (!state && config->pause_emulation_on_switch && !paused_from_focus_loss)
+    // Focus moving to the audio waveform viewer is not leaving the emulator,
+    // so the focus-loss pause is suspended for as long as the viewer is open.
+    if (!state && config->pause_emulation_on_switch && !paused_from_focus_loss &&
+        !S9xAudioWaveformWindowOpen())
     {
         sys_pause++;
         propagate_pause_state();

--- a/gtk/src/gtk_sound.cpp
+++ b/gtk/src/gtk_sound.cpp
@@ -12,6 +12,7 @@
 #include "snes9x.h"
 #include "apu/apu.h"
 #include "sgb/sgb.h"
+#include "common/audio/audio_waveform.hpp"
 #include "common/recording/avi_recorder.hpp"
 
 #ifdef USE_PORTAUDIO
@@ -297,34 +298,19 @@ bool8 S9xOpenSoundDevice()
     return driver->open_device(Settings.SoundPlaybackRate, gui_config->sound_buffer_size);
 }
 
-/* This really shouldn't be in the port layer */
-static uint8_t sound_channel_mask = 255;
-
-static void apply_sound_channel_mask()
-{
-    S9xSetSoundControl(sound_channel_mask);
-    // Channels 1-4 double as the GB APU's CH1-CH4 (pulse A, pulse B, wave,
-    // noise) so the mask also works for GB/SGB games, as on win32.
-    S9xSGBSetSoundChannelMask(sound_channel_mask & 0x0f);
-}
-
+/* Sound > Channels. The masks live in the shared audio waveform module so
+ * the viewer's mute/solo overlay composes with them, as on win32. */
 uint8_t S9xGetSoundChannelMask()
 {
-    return sound_channel_mask;
+    return audiowave::spc_mask();
 }
 
 void S9xSetSoundChannelMask(uint8_t mask)
 {
-    sound_channel_mask = mask;
-    apply_sound_channel_mask();
+    audiowave::set_channel_mask(mask);
 }
 
 void S9xToggleSoundChannel(int c)
 {
-    if (c == 8)
-        sound_channel_mask = 255;
-    else
-        sound_channel_mask ^= 1 << c;
-
-    apply_sound_channel_mask();
+    audiowave::toggle_channel(c);
 }

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -2146,6 +2146,20 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkSeparatorMenuItem" id="audio_waveform_separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="audio_waveform_item">
+                        <property name="label" translatable="yes">Show Audio _Waveform</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem" id="sound_settings_separator">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -311,10 +311,14 @@ list(APPEND QT_GUI_SOURCES
     src/ColorCorrectionDialog.hpp
     src/MovieDialogs.cpp
     src/MovieDialogs.hpp
+    src/AudioWaveformWindow.cpp
+    src/AudioWaveformWindow.hpp
     ../common/recording/avi_writer.cpp
     ../common/recording/avi_writer.hpp
     ../common/recording/avi_recorder.cpp
     ../common/recording/avi_recorder.hpp
+    ../common/audio/audio_waveform.cpp
+    ../common/audio/audio_waveform.hpp
     src/SoftwareScalers.cpp
     src/SoftwareFilters.cpp
     src/SoftwareFilters.hpp

--- a/qt/src/AudioWaveformWindow.cpp
+++ b/qt/src/AudioWaveformWindow.cpp
@@ -1,0 +1,410 @@
+#include "AudioWaveformWindow.hpp"
+#include "EmuApplication.hpp"
+#include "EmuConfig.hpp"
+#include "EmuMainWindow.hpp"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPainter>
+#include <QVBoxLayout>
+#include <QtEvents>
+#include <algorithm>
+
+namespace aw = audiowave;
+
+namespace
+{
+
+QColor toQColor(aw::Color c)
+{
+    return QColor(c.r, c.g, c.b);
+}
+
+/* [R]ecord, [M]ute and [S]olo button rects inside a row: the right side of
+ * the header, vertically centered. Shared by the painter and the hit test. */
+QRect recRect(const QRect &row)
+{
+    return QRect(row.left() + aw::kHeaderWidth - 84, row.top() + row.height() / 2 - 9, 22, 18);
+}
+
+QRect muteRect(const QRect &row)
+{
+    return QRect(row.left() + aw::kHeaderWidth - 58, row.top() + row.height() / 2 - 9, 22, 18);
+}
+
+QRect soloRect(const QRect &row)
+{
+    return QRect(row.left() + aw::kHeaderWidth - 32, row.top() + row.height() / 2 - 9, 22, 18);
+}
+
+} // namespace
+
+class AudioWaveformWindow::TrackArea : public QWidget
+{
+  public:
+    explicit TrackArea(AudioWaveformWindow *owner)
+        : QWidget(owner), owner(owner)
+    {
+        setMinimumHeight(120);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        buffer.resize(aw::kSnapshotFrames * 2);
+    }
+
+  protected:
+    void paintEvent(QPaintEvent *) override;
+    void mousePressEvent(QMouseEvent *event) override;
+
+  private:
+    /* Rows split the height evenly; the last one takes the remainder. */
+    QRect rowRect(int index, int panels) const
+    {
+        const int h = height() / panels;
+        return QRect(0, index * h, width(), (index == panels - 1) ? height() - index * h : h);
+    }
+    void drawRow(QPainter &p, const QRect &r, int src, const int16_t *lr, int n, bool show_axis);
+
+    AudioWaveformWindow *owner;
+    std::vector<int16_t> buffer;
+    std::vector<int> y_min, y_max;
+    std::vector<QLine> lines;
+};
+
+void AudioWaveformWindow::TrackArea::paintEvent(QPaintEvent *)
+{
+    QPainter p(this);
+    p.fillRect(rect(), QColor(18, 18, 20));
+    QFont f = font();
+    f.setPixelSize(12);
+    p.setFont(f);
+
+    auto &viewer = owner->viewer;
+    int order[aw::kSourceCount];
+    const int panels = viewer.build_order(order);
+    if (height() / panels <= 0)
+        return;
+
+    viewer.begin_paint();
+    for (int i = 0; i < panels; i++)
+    {
+        const int src = order[i];
+        const int n = viewer.fetch(src, buffer.data(), aw::kSnapshotFrames);
+        drawRow(p, rowRect(i, panels), src, buffer.data(), n, i == panels - 1);
+    }
+    viewer.end_paint();
+}
+
+void AudioWaveformWindow::TrackArea::drawRow(QPainter &p, const QRect &r, int src,
+                                             const int16_t *lr, int n, bool show_axis)
+{
+    auto &viewer = owner->viewer;
+    const aw::TrackInfo &track = aw::kTracks[src];
+    const QColor color = toQColor(track.color);
+    const bool group = aw::is_group(src);
+    const bool expanded = (src == aw::kSPC) ? viewer.spc_open : viewer.gb_open;
+    const bool user_muted = aw::is_muted(src);
+    const bool soloed = aw::is_soloed(src);
+    const bool audible = aw::is_audible(src);
+    const int cy = r.top() + r.height() / 2;
+
+    // Header strip: color tab, disclosure triangle on group rows, name.
+    const QRect header(r.left(), r.top(), aw::kHeaderWidth, r.height());
+    p.fillRect(header, group ? QColor(56, 56, 60) : QColor(40, 40, 44));
+    p.fillRect(QRect(header.left(), header.top(), 5, header.height()), color);
+
+    if (group)
+    {
+        const int ix = header.left() + 10;
+        QPolygon triangle;
+        if (expanded)
+            triangle << QPoint(ix, cy - 3) << QPoint(ix + 10, cy - 3) << QPoint(ix + 5, cy + 4);
+        else
+            triangle << QPoint(ix + 2, cy - 5) << QPoint(ix + 2, cy + 5) << QPoint(ix + 9, cy);
+        const QColor tc = toQColor(aw::tint(track.color, 30));
+        p.setPen(tc);
+        p.setBrush(tc);
+        p.drawPolygon(triangle);
+        p.setBrush(Qt::NoBrush);
+    }
+
+    p.setPen(audible ? QColor(225, 225, 228) : QColor(130, 130, 135));
+    p.drawText(QRect(header.left() + (group ? 26 : 30), cy - 8, 40, 16),
+               Qt::AlignLeft | Qt::AlignVCenter, track.name);
+
+    auto button = [&p](const QRect &b, const char *label, bool on,
+                       QColor fill_on, QColor frame_on, QColor text_on) {
+        p.fillRect(b, on ? fill_on : QColor(52, 52, 56));
+        p.setPen(on ? frame_on : QColor(80, 80, 86));
+        p.drawRect(b.adjusted(0, 0, -1, -1));
+        p.setPen(on ? text_on : QColor(150, 150, 156));
+        p.drawText(b, Qt::AlignCenter, label);
+    };
+    const bool rec_this = viewer.recorder.source() == src;
+    button(recRect(r), "R", rec_this, QColor(200, 40, 40), QColor(240, 90, 90), Qt::white);
+    button(muteRect(r), "M", user_muted, QColor(96, 150, 250), QColor(140, 180, 255), QColor(20, 30, 60));
+    // The MIX row is the master bus, so it has no solo.
+    if (src != aw::kMix)
+        button(soloRect(r), "S", soloed, QColor(230, 192, 62), QColor(250, 220, 120), QColor(60, 45, 10));
+
+    // Waveform lane, dimmed when the track doesn't reach the output, whether
+    // by its own mute or by someone else's solo.
+    const int axis_h = show_axis ? 16 : 0;
+    const QRect lane(r.left() + aw::kHeaderWidth, r.top(), r.width() - aw::kHeaderWidth, r.height());
+    const QRect body(lane.left(), lane.top(), lane.width(), lane.height() - axis_h);
+    p.fillRect(body, toQColor(aw::shade(track.color, audible ? 28 : 14)));
+    const int mid_y = body.top() + body.height() / 2;
+    p.setPen(toQColor(aw::shade(track.color, audible ? 44 : 24)));
+    p.drawLine(body.left(), mid_y, body.right(), mid_y);
+
+    viewer.build_envelope(lr, n, body.width(), body.height(), y_min, y_max);
+    if (!y_min.empty())
+    {
+        lines.resize(y_min.size());
+        for (size_t i = 0; i < y_min.size(); i++)
+        {
+            const int x = body.left() + (int)i;
+            lines[i] = QLine(x, body.top() + y_min[i], x, body.top() + y_max[i]);
+        }
+        p.setPen(toQColor(audible ? aw::tint(track.color, 55) : aw::shade(track.color, 52)));
+        p.drawLines(lines.data(), (int)lines.size());
+    }
+
+    // L/R meters under the buttons: -48..0 dB with 1 s peak-hold ticks.
+    if (r.height() >= 46)
+    {
+        float level[2], peak[2];
+        viewer.meter_levels(src, lr, n, level, peak);
+        const int mx0 = header.left() + 8;
+        const int mw = header.width() - 16;
+        for (int ch = 0; ch < 2; ch++)
+        {
+            const int y0 = cy + 13 + ch * 4;
+            p.fillRect(QRect(mx0, y0, mw, 3), QColor(30, 30, 32));
+            float from = 0.0f;
+            for (int s = 0; s < 3 && from < level[ch]; s++)
+            {
+                const float to = std::min(level[ch], aw::kMeterSegments[s].to);
+                if (to > from)
+                {
+                    const int x0 = mx0 + (int)(from * mw);
+                    const int x1 = mx0 + (int)(to * mw);
+                    p.fillRect(QRect(x0, y0, x1 - x0, 3), toQColor(aw::kMeterSegments[s].color));
+                }
+                from = aw::kMeterSegments[s].to;
+            }
+            if (peak[ch] > 0.01f)
+                p.fillRect(QRect(mx0 + (int)(peak[ch] * (mw - 2)), y0, 2, 3), QColor(220, 220, 224));
+        }
+    }
+
+    // Clip-label style info at the top-left of the lane, status at the right.
+    const std::string info = viewer.info_text(src);
+    if (!info.empty())
+    {
+        p.setPen(toQColor(aw::tint(track.color, audible ? 70 : 25)));
+        p.drawText(QRect(lane.left() + 6, lane.top() + 2, lane.width() - 12, 16),
+                   Qt::AlignLeft | Qt::AlignVCenter, QString::fromStdString(info));
+    }
+    if (user_muted)
+    {
+        p.setPen(toQColor(aw::tint(track.color, 40)));
+        p.drawText(QRect(lane.right() - 52, lane.top() + 2, 50, 16),
+                   Qt::AlignLeft | Qt::AlignVCenter, tr("muted"));
+    }
+    if (rec_this)
+    {
+        const int seconds = viewer.recorder.elapsed_seconds();
+        p.setPen(QColor(235, 80, 80));
+        p.drawText(QRect(lane.right() - 140, lane.top() + 2, 86, 16), Qt::AlignLeft | Qt::AlignVCenter,
+                   QString("REC %1:%2").arg(seconds / 60).arg(seconds % 60, 2, 10, QChar('0')));
+    }
+
+    if (show_axis)
+    {
+        const QRect axis(lane.left(), body.top() + body.height(), lane.width(), axis_h);
+        p.fillRect(axis, QColor(18, 18, 20));
+        p.setPen(QColor(140, 140, 145));
+        const int rate = viewer.sample_rate(src);
+        for (int i = 1; i < 7; i++)
+        {
+            const int x = lane.left() + (lane.width() * i) / 7;
+            p.drawText(QRect(x - 22, axis.top() + 1, 44, 14), Qt::AlignCenter,
+                       QString::fromStdString(aw::Viewer::axis_label(i, n, rate)));
+        }
+        p.drawText(QRect(lane.left() + 2, axis.top() + 1, 20, 14), Qt::AlignLeft | Qt::AlignVCenter, "0");
+    }
+
+    p.setPen(QColor(20, 20, 22));
+    p.drawLine(r.left(), r.bottom(), r.right(), r.bottom());
+}
+
+void AudioWaveformWindow::TrackArea::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() != Qt::LeftButton)
+        return;
+    auto &viewer = owner->viewer;
+    int order[aw::kSourceCount];
+    const int panels = viewer.build_order(order);
+    const int h = height() / panels;
+    if (h <= 0)
+        return;
+    const QPoint pos = event->position().toPoint();
+    const int index = std::clamp(pos.y() / h, 0, panels - 1);
+    const int src = order[index];
+    const QRect row = rowRect(index, panels);
+
+    if (recRect(row).contains(pos))
+        owner->toggleRecording(src);
+    else if (muteRect(row).contains(pos))
+        aw::toggle_mute(src);
+    else if (src != aw::kMix && soloRect(row).contains(pos))
+        aw::toggle_solo(src);
+    // Anywhere else on a group row toggles its expansion.
+    else if (src == aw::kSPC)
+        viewer.spc_open = !viewer.spc_open;
+    else if (src == aw::kGB)
+        viewer.gb_open = !viewer.gb_open;
+    else
+        return;
+    update();
+}
+
+AudioWaveformWindow::AudioWaveformWindow(EmuMainWindow *parent, EmuApplication *app_)
+    : QWidget(parent, Qt::Window), main_window(parent), app(app_)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowTitle(tr("Audio Waveform  (click SPC/GB to expand channels)"));
+    resize(800, 560);
+
+    // The MIX row's [M] is the Sound panel's "Mute all sound".
+    aw::set_master_mute_hooks(
+        [app_] { return app_->config->mute_audio; },
+        [app_](bool muted) {
+            app_->config->mute_audio = muted;
+            app_->updateSettings();
+        });
+
+    auto layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    tracks = new TrackArea(this);
+    layout->addWidget(tracks, 1);
+
+    auto footer = new QHBoxLayout;
+    footer->setContentsMargins(8, 4, 8, 4);
+    footer->setSpacing(8);
+
+    auto reset_box = new QCheckBox(tr("reset channels on close"));
+    reset_box->setChecked(viewer.reset_on_close);
+    connect(reset_box, &QCheckBox::toggled, [this](bool on) { viewer.reset_on_close = on; });
+    footer->addWidget(reset_box);
+
+    footer->addSpacing(12);
+    footer->addWidget(new QLabel(tr("zoom")));
+    auto zoom = new QComboBox;
+    for (int i = 0; i < aw::kScaleCount; i++)
+        zoom->addItem(aw::kScaleLabels[i]);
+    zoom->setCurrentIndex(viewer.scale);
+    connect(zoom, &QComboBox::currentIndexChanged, [this](int index) {
+        viewer.scale = index;
+        tracks->update();
+    });
+    footer->addWidget(zoom);
+
+    footer->addSpacing(12);
+    footer->addWidget(new QLabel(tr("rate")));
+    auto rate = new QComboBox;
+    for (int i = 0; i < aw::kRefreshCount; i++)
+        rate->addItem(aw::kRefreshOptions[i].label);
+    rate->setCurrentIndex(viewer.refresh);
+    connect(rate, &QComboBox::currentIndexChanged, [this](int index) {
+        viewer.refresh = index;
+        applyRefresh();
+    });
+    footer->addWidget(rate);
+
+    footer->addSpacing(12);
+    auto nerd_box = new QCheckBox(tr("stats for nerds"));
+    nerd_box->setChecked(viewer.nerd_stats);
+    connect(nerd_box, &QCheckBox::toggled, [this](bool on) {
+        viewer.nerd_stats = on;
+        tracks->update();
+    });
+    footer->addWidget(nerd_box);
+    footer->addStretch(1);
+    layout->addLayout(footer);
+
+    connect(&timer, &QTimer::timeout, [this] {
+        viewer.recorder.pump();
+        if (!isMinimized())
+            tracks->update();
+    });
+
+    viewer.open();
+    applyRefresh();
+}
+
+AudioWaveformWindow::~AudioWaveformWindow()
+{
+    timer.stop();
+    viewer.close();
+}
+
+void AudioWaveformWindow::closeEvent(QCloseEvent *event)
+{
+    timer.stop();
+    viewer.close();
+    event->accept();
+}
+
+bool AudioWaveformWindow::event(QEvent *event)
+{
+    // For "pause emulation when unfocused" this window is part of the main
+    // window: moving between the two doesn't pause, leaving from here does.
+    switch (event->type())
+    {
+    case QEvent::WindowActivate:
+        main_window->handleFocusChange(true);
+        break;
+    case QEvent::WindowDeactivate:
+        // Not while closing: focus then goes back to the main window anyway.
+        if (isVisible() && QApplication::activeWindow() != main_window)
+            main_window->handleFocusChange(false);
+        break;
+    default:
+        break;
+    }
+    return QWidget::event(event);
+}
+
+void AudioWaveformWindow::applyRefresh()
+{
+    timer.start(aw::kRefreshOptions[viewer.refresh].ms);
+}
+
+void AudioWaveformWindow::toggleRecording(int src)
+{
+    auto &recorder = viewer.recorder;
+    // One track at a time; clicking the armed one stops and saves.
+    if (recorder.source() == src)
+    {
+        recorder.stop();
+        auto filename = QFileDialog::getSaveFileName(
+            this, tr("Save Recording"), QString("%1.wav").arg(aw::kTracks[src].name),
+            tr("WAV audio (*.wav)"));
+        if (filename.isEmpty())
+            recorder.discard();
+        else if (!recorder.write_wav(filename.toStdString()))
+            QMessageBox::warning(this, tr("Save Recording"),
+                                 tr("Couldn't write %1").arg(filename));
+    }
+    else if (recorder.source() < 0)
+    {
+        recorder.start(src);
+    }
+}

--- a/qt/src/AudioWaveformWindow.hpp
+++ b/qt/src/AudioWaveformWindow.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <QTimer>
+#include <QWidget>
+#include <functional>
+#include <vector>
+
+#include "common/audio/audio_waveform.hpp"
+
+class EmuApplication;
+class EmuMainWindow;
+
+/* Sound > Show Audio Waveform, as on win32: Logic-style track rows for the
+ * SPC and GB pre-mixes (each expands to its voices / channels) and the final
+ * mix, with record/mute/solo buttons and L/R level meters in each header,
+ * and a footer for the reset-on-close, zoom, refresh rate and nerd stats
+ * choices. */
+class AudioWaveformWindow : public QWidget
+{
+  public:
+    AudioWaveformWindow(EmuMainWindow *parent, EmuApplication *app);
+    ~AudioWaveformWindow() override;
+
+  protected:
+    void closeEvent(QCloseEvent *event) override;
+    bool event(QEvent *event) override;
+
+  private:
+    class TrackArea;
+    friend class TrackArea;
+
+    void applyRefresh();
+    void toggleRecording(int src);
+
+    EmuMainWindow *main_window;
+    EmuApplication *app;
+    audiowave::Viewer viewer;
+    TrackArea *tracks = nullptr;
+    QTimer timer;
+};

--- a/qt/src/EmuApplication.cpp
+++ b/qt/src/EmuApplication.cpp
@@ -5,6 +5,7 @@
 #include "common/audio/s9x_sound_driver_sdl3.hpp"
 #include "common/audio/s9x_sound_driver_cubeb.hpp"
 #include "apu/apu.h"
+#include "common/audio/audio_waveform.hpp"
 #ifdef USE_PULSEAUDIO
 #include "common/audio/s9x_sound_driver_pulse.hpp"
 #endif
@@ -1095,6 +1096,14 @@ void EmuApplication::setSoundChannelMask(uint8_t mask)
 {
     emu_thread->runOnThread([mask] {
         S9xSetSoundChannelMask(mask);
+    });
+}
+
+void EmuApplication::enableAllSoundChannels()
+{
+    // All on audibly: also drops any solo engaged in the waveform viewer.
+    emu_thread->runOnThread([] {
+        audiowave::enable_all_channels();
     });
 }
 

--- a/qt/src/EmuApplication.hpp
+++ b/qt/src/EmuApplication.hpp
@@ -115,6 +115,7 @@ struct EmuApplication
     bool isAVIRecording();
     uint8_t getSoundChannelMask();
     void setSoundChannelMask(uint8_t mask);
+    void enableAllSoundChannels();
     void startGame();
     void startThread();
     void stopThread();

--- a/qt/src/EmuMainWindow.cpp
+++ b/qt/src/EmuMainWindow.cpp
@@ -7,12 +7,14 @@
 #include <QMessageBox>
 #include <QtEvents>
 #include <QGuiApplication>
+#include <QApplication>
 #include <QActionGroup>
 
 #ifdef Q_OS_WIN
 #include <dwmapi.h>
 #endif
 
+#include "AudioWaveformWindow.hpp"
 #include "CheatsDialog.hpp"
 #include "ColorCorrectionDialog.hpp"
 #include "MovieDialogs.hpp"
@@ -707,7 +709,7 @@ void EmuMainWindow::createWidgets()
     channels_menu->addSeparator();
     auto enable_all_channels_item = channels_menu->addAction(tr("Enable All"));
     connect(enable_all_channels_item, &QAction::triggered, [&] {
-        app->setSoundChannelMask(255);
+        app->enableAllSoundChannels();
     });
     core_actions.push_back(sound_menu->addMenu(channels_menu));
 
@@ -723,6 +725,15 @@ void EmuMainWindow::createWidgets()
 
     sound_menu->addSeparator();
 
+    // win32's Show Audio Waveform: the track viewer of the audio rings.
+    auto waveform_item = sound_menu->addAction(tr("Show Audio &Waveform"));
+    waveform_item->setCheckable(true);
+    connect(waveform_item, &QAction::triggered, [&] {
+        toggleAudioWaveform();
+    });
+
+    sound_menu->addSeparator();
+
     auto sound_settings_item = sound_menu->addAction(QIcon(iconset + "sound.svg"), tr("&Settings..."));
     connect(sound_settings_item, &QAction::triggered, [&] {
         if (!g_emu_settings_window)
@@ -730,19 +741,24 @@ void EmuMainWindow::createWidgets()
         g_emu_settings_window->show(2); // the Sound panel
     });
 
-    connect(sound_menu, &QMenu::aboutToShow, this, [this, channel_actions, mute_item] {
-        const uint8_t mask = app->getSoundChannelMask();
+    connect(sound_menu, &QMenu::aboutToShow, this, [this, channel_actions, mute_item, waveform_item] {
+        // Checkmarks show the effective state — the user mask composed with
+        // any waveform-viewer solo — so soloing V3 leaves only Channel 3 checked.
+        uint8_t spc_mask, gb_mask;
+        audiowave::effective_masks(&spc_mask, &gb_mask);
         // Channels 1-4 drive both SPC voices 1-4 and the GB APU's CH1-CH4.
         // In BIOS-less GB mode the SPC isn't running, so 5-8 control
         // nothing — grey them there, as on win32.
         const bool gb_only = Settings.SuperGameBoy && !Settings.SGB_BIOSModeActive;
+        const uint8_t low_bits = gb_only ? gb_mask : spc_mask;
         for (int i = 0; i < 8; i++)
         {
-            channel_actions[i]->setChecked(mask & (1 << i));
+            channel_actions[i]->setChecked((i < 4 ? low_bits : spc_mask) & (1 << i));
             if (i >= 4)
                 channel_actions[i]->setEnabled(!gb_only);
         }
         mute_item->setChecked(app->config->mute_audio);
+        waveform_item->setChecked(audio_waveform_window != nullptr);
     });
 
     menuBar()->addMenu(sound_menu);
@@ -1274,24 +1290,15 @@ bool EmuMainWindow::event(QEvent *event)
         }
         break;
     case QEvent::WindowActivate:
-        if (focus_pause)
-        {
-            focus_pause = false;
-            app->unpause();
-        }
+        handleFocusChange(true);
         break;
     case QEvent::WindowDeactivate:
         if (mouse_grabbed)
             toggleMouseGrab();
-        if (app->config->pause_emulation_when_unfocused && !focus_pause
-#ifdef KAILLERA_SUPPORT
-            && !KailleraClientIsPlaying()
-#endif
-        )
-        {
-            focus_pause = true;
-            app->pause();
-        }
+        // Focus moving to the audio waveform viewer stays within the
+        // emulator. Qt has already made it the active window at this point.
+        if (!(audio_waveform_window && QApplication::activeWindow() == audio_waveform_window.data()))
+            handleFocusChange(false);
         break;
     case QEvent::WindowStateChange:
     {
@@ -1515,6 +1522,40 @@ void EmuMainWindow::gameChanging()
 {
     if (cheats_dialog)
         cheats_dialog->close();
+}
+
+void EmuMainWindow::toggleAudioWaveform()
+{
+    if (audio_waveform_window)
+    {
+        audio_waveform_window->close();
+        return;
+    }
+    audio_waveform_window = new AudioWaveformWindow(this, app);
+    audio_waveform_window->show();
+}
+
+void EmuMainWindow::handleFocusChange(bool active)
+{
+    if (active)
+    {
+        if (focus_pause)
+        {
+            focus_pause = false;
+            app->unpause();
+        }
+        return;
+    }
+
+    if (app->config->pause_emulation_when_unfocused && !focus_pause
+#ifdef KAILLERA_SUPPORT
+        && !KailleraClientIsPlaying()
+#endif
+    )
+    {
+        focus_pause = true;
+        app->pause();
+    }
 }
 
 bool EmuMainWindow::gunAimsAtPointer()

--- a/qt/src/EmuMainWindow.hpp
+++ b/qt/src/EmuMainWindow.hpp
@@ -3,11 +3,13 @@
 
 #include <QAction>
 #include <QMainWindow>
+#include <QPointer>
 #include <QTimer>
 #include "EmuCanvas.hpp"
 
 class EmuApplication;
 class CheatsDialog;
+class AudioWaveformWindow;
 
 class EmuMainWindow : public QMainWindow
 {
@@ -43,6 +45,11 @@ class EmuMainWindow : public QMainWindow
     void shaderChanged();
     void updateShaderSettingsItem();
     void gameChanging();
+    void toggleAudioWaveform();
+    /* "Pause emulation when unfocused". The audio waveform viewer counts as
+     * part of this window: moving between the two doesn't pause, leaving
+     * from either does, so the viewer reports its focus changes here too. */
+    void handleFocusChange(bool active);
     void toggleMouseGrab();
     void updatePortConfigurationMenu();
     std::vector<std::string> getDisplayDeviceList();
@@ -57,6 +64,8 @@ class EmuMainWindow : public QMainWindow
     static const size_t recent_menu_size = 10;
 
     std::unique_ptr<CheatsDialog> cheats_dialog;
+    // Sound->Show Audio Waveform; deletes itself on close, so this goes null.
+    QPointer<AudioWaveformWindow> audio_waveform_window;
 
     bool manual_pause = false;
     bool focus_pause = false;

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -12,6 +12,7 @@ namespace fs = std::filesystem;
 #include "memmap.h"
 #include "apu/apu.h"
 #include "sgb/sgb.h"
+#include "common/audio/audio_waveform.hpp"
 #include "gfx.h"
 #include "ppu.h"
 #include "snapshot.h"
@@ -698,35 +699,21 @@ bool S9xPollButton(unsigned int, bool *)
     return false;
 }
 
-static uint8_t sound_channel_mask = 255;
-
-static void applySoundChannelMask()
-{
-    S9xSetSoundControl(sound_channel_mask);
-    // Channels 1-4 double as the GB APU's CH1-CH4 (pulse A, pulse B, wave,
-    // noise) so the mask also works for GB/SGB games, as on win32.
-    S9xSGBSetSoundChannelMask(sound_channel_mask & 0x0f);
-}
-
+/* Sound > Channels. The masks live in the shared audio waveform module so
+ * the viewer's mute/solo overlay composes with them, as on win32. */
 uint8_t S9xGetSoundChannelMask()
 {
-    return sound_channel_mask;
+    return audiowave::spc_mask();
 }
 
 void S9xSetSoundChannelMask(uint8_t mask)
 {
-    sound_channel_mask = mask;
-    applySoundChannelMask();
+    audiowave::set_channel_mask(mask);
 }
 
 void S9xToggleSoundChannel(int c)
 {
-    if (c == 8)
-        sound_channel_mask = 255;
-    else
-        sound_channel_mask ^= 1 << c;
-
-    applySoundChannelMask();
+    audiowave::toggle_channel(c);
 }
 
 std::string S9xGetFilenameInc(std::string e, enum s9x_getdirtype dirtype)


### PR DESCRIPTION
## Summary

Brings win32's **Sound → Show Audio Waveform** to the Qt and GTK ports (#225, part of #227).

- **Track rows** for the SPC and GB pre-mixes and the final MIX, in the win32 layout: a header strip with the track color tab, name, `[R]` record, `[M]` mute and `[S]` solo buttons and Logic-style L/R level meters with 1 s peak hold, then the waveform lane with an info label and a time axis on the bottom row.
- **Groups expand on click**: SPC to V1–V8 (fed per voice from the DSP), GB to CH1–CH4 (pulse A, pulse B, wave, noise). Cores that aren't running are dropped from the layout, so a BIOS-less GB game shows only the GB group and MIX.
- **Mute / solo** with DAW semantics: while any solo is engaged only soloed tracks stay audible, mute wins over solo on the same track, and a track that doesn't reach the output is drawn dimmed with a "muted" tag. The GB APU gets its own 4-bit mask so muting CH2 in the viewer no longer silences SPC voice 2; Sound → Channels stays the blunt tool that re-syncs it. Menu checkmarks show the effective state, and Enable All also drops any engaged solo, as on win32.
- **Footer**: "reset channels on close" (default on; unchecked, engaged solos are baked into the channel masks on close), zoom (linear, 2x–16x, auto-fit, log dB, sqrt), refresh rate (2–60 Hz) and "stats for nerds" (ring I/O rates, emulation fps, cycle meters, splice counters and fills).
- **Recorder**: `[R]` streams one track's raw PCM to a temp file; clicking it again stops and prompts for a `.wav` destination. Rates and channel counts follow the source (host rate stereo for SPC/GB/MIX, 32 kHz stereo per SPC voice, GB APU rate mono per GB channel).

## Implementation

- `common/audio/audio_waveform.{hpp,cpp}` holds everything that isn't a window: the track table, the channel masks with the solo overlay, zoom modes, meters, the recorder and the label text. Both ports' `S9xGet/SetSoundChannelMask` and `S9xToggleSoundChannel` now wrap it.
- `qt/src/AudioWaveformWindow` paints with QPainter; `gtk/src/gtk_audio_waveform` with Cairo and Pango. Both use native widgets for the footer.
- `apu/apu.cpp`: the SPC ring was only fed from the SGB BIOS mix path (`S9xPullSpcOutput`), so the SPC lane sat flat for plain SNES games on every port including win32. `S9xMixSamples` now pushes it on the plain path too, and flat-lines it while muted.
- **Focus pausing**: opening the viewer no longer trips "pause emulation when unfocused". Qt treats the viewer as part of the main window (moving between the two never pauses, leaving from either to another app still does). GTK suspends its focus-loss pause while the viewer is open.

## Deviations from win32

- The footer uses native checkboxes and combo boxes instead of win32's hand-drawn controls.
- The Sound menu item is checkable and reflects whether the viewer is open.
- Master mute on the MIX row goes through each port's own mute setting (Qt's "Mute all sound", GTK's "Mute sound output").

## Testing

- Both ports build (`ninja snes9x-qt` in `qt/build`, `ninja snes9x-gtk` in `gtk/build`), no warnings from the new files.
- GTK launched with a SNES ROM: the viewer opens from the menu, the SPC group expands to its voices with live traces, meters, the time axis and the footer render. The Qt window and the record/mute/solo buttons were not exercised interactively here; a manual pass on each port is recommended, including the WAV save and the focus-pause behaviour with the option enabled.
- GTK `.po` files were not regenerated for the new strings.
