### PR TITLE
qt: fix black menubar text on KDE dark colour schemes in the AppImage

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -137,6 +137,12 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 endif()
 find_package(Qt6 REQUIRED COMPONENTS Widgets Gui)
 list(APPEND LIBS Qt6::Widgets Qt6::Gui)
+# main.cpp reads the platform theme's palette back on Qt 6.2/6.3 (the
+# QTBUG-98762 workaround), and QPlatformTheme is QPA API: private headers,
+# which Ubuntu 22.04's qt6-base-private-dev provides.
+if(NOT WIN32 AND NOT APPLE AND Qt6_VERSION VERSION_LESS 6.3.2)
+    list(APPEND LIBS Qt6::GuiPrivate)
+endif()
 
 # Must come before the first pkg_check_modules() call below. It used to sit
 # after the libcurl lookup and only worked because something else in the

--- a/qt/src/main.cpp
+++ b/qt/src/main.cpp
@@ -15,8 +15,54 @@
 #include <QStyle>
 #include <QStyleHints>
 
+// Qt 6.2.3 through 6.3.1 drop QPalette::setBrush()'s resolve bit when the
+// brush is unchanged (qtbase 56bd1b76d2, undone by 9334e06bdf for 6.3.2 and
+// 6.4: QTBUG-98762). The built-in KDE platform theme fills a default
+// black-and-white QPalette from kdeglobals, so any colour that is exactly
+// black or white stays "unset" and QApplication takes it from Fusion's light
+// palette instead: dark colour schemes with pure white text (Nobara's, for
+// one) come up with black menubar text on a black bar. The Ubuntu 22.04
+// AppImage ships Qt 6.2.4. Reading the theme palette back is QPA API.
+#if !defined(_WIN32) && !defined(__APPLE__) && QT_VERSION < QT_VERSION_CHECK(6, 3, 2)
+#define REAPPLY_THEME_PALETTE
+#include <qpa/qplatformtheme.h>
+#include <private/qguiapplication_p.h>
+#endif
+
 #ifndef _WIN32
 #include <csignal>
+#endif
+
+#ifdef REAPPLY_THEME_PALETTE
+// Copy the theme's colours over the resolved application palette. setBrush()
+// only flags the roles that differ, so the roles the theme got through stay
+// as they were and a healthy palette is left alone.
+static void reapplyPlatformThemePalette()
+{
+    const QPlatformTheme *theme = QGuiApplicationPrivate::platformTheme();
+    const QPalette *themePalette = theme ? theme->palette() : nullptr;
+    if (!themePalette)
+        return;
+
+    // The roles QKdeTheme fills in from kdeglobals.
+    static const QPalette::ColorRole roles[] = {
+        QPalette::Window, QPalette::WindowText, QPalette::Base, QPalette::AlternateBase,
+        QPalette::Text, QPalette::Button, QPalette::ButtonText, QPalette::Highlight,
+        QPalette::HighlightedText, QPalette::Link, QPalette::LinkVisited,
+        QPalette::ToolTipBase, QPalette::ToolTipText
+    };
+    static const QPalette::ColorGroup groups[] = {
+        QPalette::Active, QPalette::Inactive, QPalette::Disabled
+    };
+
+    QPalette palette = QApplication::palette();
+    for (auto role : roles)
+        for (auto group : groups)
+            palette.setBrush(group, role, themePalette->brush(group, role));
+
+    if (palette != QApplication::palette())
+        QApplication::setPalette(palette);
+}
 #endif
 
 #ifdef _WIN32
@@ -88,6 +134,9 @@ int main(int argc, char *argv[])
             QApplication::setStyle("windowsvista");
         }
     }
+#ifdef REAPPLY_THEME_PALETTE
+    reapplyPlatformThemePalette();
+#endif
 
 #ifndef _WIN32
     auto quit_handler = [](int) { QApplication::quit(); };


### PR DESCRIPTION
Fixes #262.

## Cause

The nightly x86_64 AppImage is built on Ubuntu 22.04 and bundles **Qt 6.2.4**; the 1.63.29 release AppImage was built on a Qt 6.4.2 host, which is why it was fine.

Qt 6.2.3 through 6.3.1 have `QPalette::setBrush()` skip the resolve bit when the brush is unchanged (qtbase `56bd1b76d2`, QTBUG-98762, undone in `9334e06bdf` for 6.3.2/6.4). Qt's built-in KDE platform theme fills a default black-and-white `QPalette` from `kdeglobals`, so any scheme colour that is exactly black or white is left "unset", and `QApplication` then takes that role from Fusion's light palette.

Nobara's colour scheme has `[Colors:Button] ForegroundNormal=255,255,255` on an `18,18,18` window, so the menubar text (drawn with `ButtonText`) resolved to Fusion's black on an almost black bar. Breeze Dark with pure white text loses `WindowText`, `Text` and `ButtonText` the same way.

## Fix

On Qt older than 6.3.2 (Linux only), copy the platform theme's colours for the roles the KDE theme reads back over the resolved application palette. `setBrush()` only flags the roles that differ, so a palette that resolved correctly is left untouched. Reading the theme palette is QPA API, so those builds link `Qt6::GuiPrivate` (Ubuntu 22.04's `qt6-base-private-dev`, already installed in the container). The i386 (Debian 12, Qt 6.4.2) and macOS builds don't compile the block at all.

## Testing

- Reproduced with the nightly AppImage under a faked Plasma session (`XDG_CURRENT_DESKTOP=KDE`, `KDE_SESSION_VERSION=6`, Nobara's `.colors` as `kdeglobals`): black menubar text on a black bar. The 1.63.29 AppImage was fine with the same config.
- A standalone test with the exact function from `main.cpp`, compiled against Ubuntu 22.04's Qt 6.2.4 headers and run on the nightly's bundled Qt libs, with Nobara's scheme:
  - before: `Window #121212 ButtonText #000000`
  - after: `Window #121212 ButtonText #ffffff`
  - Breeze Dark with `255,255,255` text: `WindowText/Text/ButtonText #000000` before, `#ffffff` after.
- Host build (Qt 6.4.2) with the version gate temporarily widened so the code path is active: Nobara, Breeze Dark and a plain GNOME session all render as before. Restored gate builds clean.

The nightly x86_64 AppImage from this branch is the real end-to-end check on the reporter's setup.
