### PR TITLE
qt/gtk: add the win32 SNES Image and Game Boy Image display settings

### DIFF
--- a/common/video/gb_camera_v4l2.cpp
+++ b/common/video/gb_camera_v4l2.cpp
@@ -1,0 +1,461 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#include "gb_camera_v4l2.hpp"
+#include "snes9x.h"
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <thread>
+
+#ifdef __linux__
+#include <cerrno>
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <linux/videodev2.h>
+#endif
+
+void S9xGBSetCameraCallback(bool (*cb)(unsigned char *dst, int width, int height));
+
+namespace {
+
+/* Latest frame as 8-bit luma, native camera size. The capture thread writes
+ * it, the core's capture callback reads it. */
+std::mutex                 g_lock;
+std::vector<unsigned char> g_frame;
+int                        g_frame_width = 0;
+int                        g_frame_height = 0;
+bool                       g_frame_valid = false;
+
+std::thread                g_thread;
+std::atomic<bool>          g_stop{false};
+bool                       g_running = false;
+int                        g_running_index = -1;
+
+bool CameraGetImageCB(unsigned char *dst, int out_width, int out_height)
+{
+    std::lock_guard<std::mutex> lock(g_lock);
+    if (!g_frame_valid || g_frame_width <= 0 || g_frame_height <= 0 || g_frame.empty())
+        return false;
+
+    /* Nearest-neighbour resample of the whole frame onto the sensor, mirrored
+     * horizontally, exactly as the win32 bridge hands it to the core. */
+    const unsigned char *src = g_frame.data();
+    const int sw = g_frame_width, sh = g_frame_height;
+    for (int y = 0; y < out_height; y++)
+    {
+        int sy = y * sh / out_height;
+        if (sy < 0) sy = 0; else if (sy >= sh) sy = sh - 1;
+        for (int x = 0; x < out_width; x++)
+        {
+            int sx = sw - 1 - (x * sw / out_width);
+            if (sx < 0) sx = 0; else if (sx >= sw) sx = sw - 1;
+            dst[y * out_width + x] = src[(size_t)sy * sw + sx];
+        }
+    }
+    return true;
+}
+
+#ifdef __linux__
+
+struct Device
+{
+    std::string node;
+    std::string name;
+};
+
+int xioctl(int fd, unsigned long request, void *arg)
+{
+    int r;
+    do
+        r = ioctl(fd, request, arg);
+    while (r == -1 && errno == EINTR);
+    return r;
+}
+
+/* Video capture nodes under /dev, in node order. A UVC camera usually exposes
+ * a second, metadata-only node right after its capture node; that one has no
+ * capture capability (or no capture format) and is skipped. */
+std::vector<Device> EnumDevices()
+{
+    std::vector<Device> devices;
+
+    for (int i = 0; i < 64; i++)
+    {
+        char node[32];
+        snprintf(node, sizeof(node), "/dev/video%d", i);
+
+        int fd = open(node, O_RDWR | O_NONBLOCK | O_CLOEXEC);
+        if (fd < 0)
+            continue;
+
+        v4l2_capability cap{};
+        bool usable = xioctl(fd, VIDIOC_QUERYCAP, &cap) == 0;
+        if (usable)
+        {
+            uint32_t caps = (cap.capabilities & V4L2_CAP_DEVICE_CAPS) ? cap.device_caps
+                                                                      : cap.capabilities;
+            usable = (caps & V4L2_CAP_VIDEO_CAPTURE) && (caps & V4L2_CAP_STREAMING);
+        }
+        if (usable)
+        {
+            v4l2_fmtdesc desc{};
+            desc.index = 0;
+            desc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+            usable = xioctl(fd, VIDIOC_ENUM_FMT, &desc) == 0;
+        }
+        if (usable)
+        {
+            std::string name((const char *)cap.card, strnlen((const char *)cap.card, sizeof(cap.card)));
+            if (name.empty())
+                name = "Camera";
+            devices.push_back({ node, name });
+        }
+        close(fd);
+    }
+
+    /* Two identical cameras get told apart by their node. */
+    for (size_t i = 0; i < devices.size(); i++)
+    {
+        bool duplicate = false;
+        for (size_t j = 0; j < devices.size(); j++)
+            if (j != i && devices[j].name == devices[i].name)
+                duplicate = true;
+        if (duplicate)
+            devices[i].name += " (" + devices[i].node.substr(5) + ")";
+    }
+
+    return devices;
+}
+
+/* Raw formats we can turn into luma, most preferred first. Luma-first
+ * layouts are cheapest; RGB needs a weighted sum per pixel. */
+const uint32_t kPreferredFormats[] = {
+    V4L2_PIX_FMT_YUYV,   V4L2_PIX_FMT_UYVY,   V4L2_PIX_FMT_YVYU,   V4L2_PIX_FMT_VYUY,
+    V4L2_PIX_FMT_GREY,   V4L2_PIX_FMT_NV12,   V4L2_PIX_FMT_NV21,   V4L2_PIX_FMT_YUV420,
+    V4L2_PIX_FMT_YVU420, V4L2_PIX_FMT_RGB24,  V4L2_PIX_FMT_BGR24,  V4L2_PIX_FMT_RGB32,
+    V4L2_PIX_FMT_BGR32,  V4L2_PIX_FMT_XRGB32, V4L2_PIX_FMT_XBGR32, V4L2_PIX_FMT_RGB565
+};
+
+inline unsigned char Luma(int r, int g, int b)
+{
+    return (unsigned char)((r * 54 + g * 183 + b * 19) >> 8);
+}
+
+/* Converts one captured buffer to 8-bit luma. Returns false for a buffer too
+ * short for the format it claims. */
+bool ToLuma(const unsigned char *src, size_t length, const v4l2_pix_format &pix, std::vector<unsigned char> &luma)
+{
+    const int w = (int)pix.width, h = (int)pix.height;
+    if (w <= 0 || h <= 0)
+        return false;
+    size_t bpl = pix.bytesperline;
+
+    auto need = [&](size_t bytes_per_pixel, size_t rows) {
+        if (bpl == 0) bpl = (size_t)w * bytes_per_pixel;
+        return length >= bpl * (rows - 1) + (size_t)w * bytes_per_pixel;
+    };
+
+    luma.resize((size_t)w * h);
+
+    switch (pix.pixelformat)
+    {
+    case V4L2_PIX_FMT_YUYV:
+    case V4L2_PIX_FMT_YVYU:
+        if (!need(2, h)) return false;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+                luma[(size_t)y * w + x] = src[y * bpl + x * 2];
+        return true;
+
+    case V4L2_PIX_FMT_UYVY:
+    case V4L2_PIX_FMT_VYUY:
+        if (!need(2, h)) return false;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+                luma[(size_t)y * w + x] = src[y * bpl + x * 2 + 1];
+        return true;
+
+    case V4L2_PIX_FMT_GREY:
+    case V4L2_PIX_FMT_NV12:
+    case V4L2_PIX_FMT_NV21:
+    case V4L2_PIX_FMT_YUV420:
+    case V4L2_PIX_FMT_YVU420:
+        /* The Y plane comes first in all of these. */
+        if (!need(1, h)) return false;
+        for (int y = 0; y < h; y++)
+            memcpy(&luma[(size_t)y * w], src + y * bpl, w);
+        return true;
+
+    case V4L2_PIX_FMT_RGB24:
+    case V4L2_PIX_FMT_BGR24:
+    {
+        if (!need(3, h)) return false;
+        const bool bgr = pix.pixelformat == V4L2_PIX_FMT_BGR24;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                const unsigned char *p = src + y * bpl + x * 3;
+                luma[(size_t)y * w + x] = bgr ? Luma(p[2], p[1], p[0]) : Luma(p[0], p[1], p[2]);
+            }
+        return true;
+    }
+
+    case V4L2_PIX_FMT_RGB32:
+    case V4L2_PIX_FMT_XRGB32:
+        /* x r g b */
+        if (!need(4, h)) return false;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                const unsigned char *p = src + y * bpl + x * 4;
+                luma[(size_t)y * w + x] = Luma(p[1], p[2], p[3]);
+            }
+        return true;
+
+    case V4L2_PIX_FMT_BGR32:
+    case V4L2_PIX_FMT_XBGR32:
+        /* b g r x */
+        if (!need(4, h)) return false;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                const unsigned char *p = src + y * bpl + x * 4;
+                luma[(size_t)y * w + x] = Luma(p[2], p[1], p[0]);
+            }
+        return true;
+
+    case V4L2_PIX_FMT_RGB565:
+        if (!need(2, h)) return false;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                const unsigned char *p = src + y * bpl + x * 2;
+                const unsigned v = p[0] | (p[1] << 8);
+                const int r = ((v >> 11) & 0x1f) * 255 / 31;
+                const int g = ((v >> 5) & 0x3f) * 255 / 63;
+                const int b = (v & 0x1f) * 255 / 31;
+                luma[(size_t)y * w + x] = Luma(r, g, b);
+            }
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+struct MappedBuffer
+{
+    void *start = nullptr;
+    size_t length = 0;
+};
+
+void PublishInvalid()
+{
+    std::lock_guard<std::mutex> lock(g_lock);
+    g_frame_valid = false;
+}
+
+/* Streams frames from one node until asked to stop. Any failure just ends the
+ * thread: like the win32 bridge, the game then sees a blank viewfinder until
+ * the camera is re-applied from the settings. */
+void CaptureThread(std::string node)
+{
+    int fd = open(node.c_str(), O_RDWR | O_NONBLOCK | O_CLOEXEC);
+    if (fd < 0)
+    {
+        PublishInvalid();
+        return;
+    }
+
+    /* The sensor is 128x112, so a small mode keeps USB bandwidth and the
+     * conversion cheap; the driver rounds to what the camera can do. */
+    v4l2_format format{};
+    bool have_format = false;
+    for (uint32_t fourcc : kPreferredFormats)
+    {
+        format = {};
+        format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        format.fmt.pix.width = 320;
+        format.fmt.pix.height = 240;
+        format.fmt.pix.pixelformat = fourcc;
+        format.fmt.pix.field = V4L2_FIELD_ANY;
+        if (xioctl(fd, VIDIOC_S_FMT, &format) == 0 && format.fmt.pix.pixelformat == fourcc)
+        {
+            have_format = true;
+            break;
+        }
+    }
+
+    std::vector<MappedBuffer> buffers;
+    bool streaming = false;
+
+    if (have_format)
+    {
+        v4l2_requestbuffers request{};
+        request.count = 4;
+        request.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        request.memory = V4L2_MEMORY_MMAP;
+        if (xioctl(fd, VIDIOC_REQBUFS, &request) == 0 && request.count >= 2)
+        {
+            bool mapped = true;
+            for (uint32_t i = 0; i < request.count && mapped; i++)
+            {
+                v4l2_buffer buffer{};
+                buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+                buffer.memory = V4L2_MEMORY_MMAP;
+                buffer.index = i;
+                if (xioctl(fd, VIDIOC_QUERYBUF, &buffer) != 0)
+                {
+                    mapped = false;
+                    break;
+                }
+                void *start = mmap(nullptr, buffer.length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, buffer.m.offset);
+                if (start == MAP_FAILED)
+                {
+                    mapped = false;
+                    break;
+                }
+                buffers.push_back({ start, buffer.length });
+                if (xioctl(fd, VIDIOC_QBUF, &buffer) != 0)
+                    mapped = false;
+            }
+
+            if (mapped)
+            {
+                v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+                streaming = xioctl(fd, VIDIOC_STREAMON, &type) == 0;
+            }
+        }
+    }
+
+    std::vector<unsigned char> luma;
+    while (streaming && !g_stop.load())
+    {
+        pollfd pfd{ fd, POLLIN, 0 };
+        int ready = poll(&pfd, 1, 100);
+        if (ready < 0)
+        {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        if (ready == 0)
+            continue;
+        if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))
+            break;
+
+        v4l2_buffer buffer{};
+        buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        buffer.memory = V4L2_MEMORY_MMAP;
+        if (xioctl(fd, VIDIOC_DQBUF, &buffer) != 0)
+        {
+            if (errno == EAGAIN)
+                continue;
+            break;
+        }
+
+        if (buffer.index < buffers.size() && !(buffer.flags & V4L2_BUF_FLAG_ERROR) &&
+            ToLuma((const unsigned char *)buffers[buffer.index].start, buffer.bytesused, format.fmt.pix, luma))
+        {
+            std::lock_guard<std::mutex> lock(g_lock);
+            g_frame.swap(luma);
+            g_frame_width = (int)format.fmt.pix.width;
+            g_frame_height = (int)format.fmt.pix.height;
+            g_frame_valid = true;
+        }
+
+        if (xioctl(fd, VIDIOC_QBUF, &buffer) != 0)
+            break;
+    }
+
+    if (streaming)
+    {
+        v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        xioctl(fd, VIDIOC_STREAMOFF, &type);
+    }
+    for (auto &b : buffers)
+        munmap(b.start, b.length);
+    close(fd);
+
+    PublishInvalid();
+}
+
+#endif /* __linux__ */
+
+} // namespace
+
+void S9xGBCameraRegister()
+{
+    S9xGBSetCameraCallback(&CameraGetImageCB);
+}
+
+void S9xGBCameraEnumerate(std::vector<std::string> &names)
+{
+    names.clear();
+#ifdef __linux__
+    for (auto &device : EnumDevices())
+        names.push_back(device.name);
+#endif
+}
+
+bool S9xGBCameraStart(int device_index)
+{
+    S9xGBCameraStop();
+#ifdef __linux__
+    auto devices = EnumDevices();
+    if (device_index < 0 || device_index >= (int)devices.size())
+        return false;
+
+    g_stop.store(false);
+    g_thread = std::thread(CaptureThread, devices[device_index].node);
+    g_running = true;
+    g_running_index = device_index;
+    return true;
+#else
+    (void)device_index;
+    return false;
+#endif
+}
+
+void S9xGBCameraStop()
+{
+    if (g_running)
+    {
+        g_stop.store(true);
+        if (g_thread.joinable())
+            g_thread.join();
+        g_running = false;
+        g_running_index = -1;
+    }
+    std::lock_guard<std::mutex> lock(g_lock);
+    g_frame_valid = false;
+}
+
+bool S9xGBCameraIsRunning()
+{
+    return g_running;
+}
+
+void S9xGBCameraApply()
+{
+    if (!Settings.GBVideoCamera)
+    {
+        S9xGBCameraStop();
+        return;
+    }
+
+    const int index = Settings.GBVideoCameraIndex;
+    if (g_running && g_running_index == index)
+        return;
+
+    S9xGBCameraStart(index);
+}

--- a/common/video/gb_camera_v4l2.hpp
+++ b/common/video/gb_camera_v4l2.hpp
@@ -1,0 +1,32 @@
+/*****************************************************************************\
+     Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+                This file is licensed under the Snes9x License.
+   For further information, consult the LICENSE file in the root directory.
+\*****************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+/* Host webcam feed for the Game Boy Camera (Pocket Camera) cartridge's image
+ * sensor, the Linux counterpart of win32/win32_webcam.{h,cpp}. The core asks
+ * for a 128x112 greyscale frame through the callback registered with
+ * S9xGBSetCameraCallback() whenever the game triggers a capture; a background
+ * thread keeps the latest frame from a Video4Linux2 device ready for it.
+ *
+ * Device indexes are positions in the list S9xGBCameraEnumerate() returns,
+ * which is what Settings.GBVideoCameraIndex stores (as on win32). Cameras that
+ * only offer compressed (MJPEG/H.264) streams are listed but produce no image.
+ * On non-Linux builds every call is a stub and the list is always empty. */
+
+void S9xGBCameraRegister();
+void S9xGBCameraEnumerate(std::vector<std::string> &names);
+bool S9xGBCameraStart(int device_index);
+void S9xGBCameraStop();
+bool S9xGBCameraIsRunning();
+
+/* Start or stop the capture to match Settings.GBVideoCamera and
+ * Settings.GBVideoCameraIndex; a no-op when the running device already
+ * matches. Mirrors win32's ApplyGBVideoCamera(). */
+void S9xGBCameraApply();

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -313,6 +313,8 @@ list(APPEND SOURCES
     ../common/recording/avi_writer.hpp
     ../common/recording/avi_recorder.cpp
     ../common/recording/avi_recorder.hpp
+    ../common/video/gb_camera_v4l2.cpp
+    ../common/video/gb_camera_v4l2.hpp
     ../common/audio/audio_waveform.cpp
     ../common/audio/audio_waveform.hpp
     src/gtk_display.cpp

--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -85,6 +85,7 @@ int Snes9xConfig::load_defaults()
     scale_method = 0;
     hires_scale_method = 0;
     overscan = false;
+    blend_hires = true;
     save_sram_after_secs = 0;
     rom_loaded = false;
     multithreading = false;
@@ -149,6 +150,10 @@ int Snes9xConfig::load_defaults()
     Settings.GBFrameBlend = 0;
     Settings.GBFrameBlendLayer = 0;
     Settings.GBFrameBlendAuto = true;
+    // Game Boy Camera webcam feed (Display Settings > Game Boy Image), stored in
+    // Settings like on win32. Off by default; index into the enumerated list.
+    Settings.GBVideoCamera = false;
+    Settings.GBVideoCameraIndex = 0;
     Settings.ColorCorrection = false;
     Settings.AdjustmentsEnabled = false;
     Settings.Gamma = 0;
@@ -199,6 +204,9 @@ int Snes9xConfig::load_defaults()
     Settings.AutoSaveDelay = 0;
     Settings.SkipFrames = THROTTLE_TIMER_FRAMESKIP;
     Settings.Transparency = true;
+    // Draw messages into the SNES image (pixel font) instead of the on-screen
+    // overlay, so they also land in screenshots, AVIs and the XV/Cairo drivers.
+    Settings.AutoDisplayMessages = false;
     Settings.DisplayTime = false;
     Settings.DisplayFrameRate = false;
     Settings.DisplayIndicators = false;
@@ -279,6 +287,8 @@ int Snes9xConfig::save_config_file()
     outbool("ChangeDisplayResolution", change_display_resolution, "Set the resolution in fullscreen mode");
     outbool("ScaleToFit", scale_to_fit, "Scale the image to fit the window size");
     outbool("ShowOverscanArea", overscan, "Show the overscan area at the top and bottom that most games hide");
+    outbool("BlendHiRes", blend_hires, "Horizontally blend hi-res (512-wide) frames so games that alternate columns for a transparency effect look as intended with filters that do not account for this");
+    outbool("MessagesInImage", Settings.AutoDisplayMessages, "Draw messages inside the SNES image (they get into AVIs, screenshots and filters) instead of the on-screen overlay");
     outbool("MaintainAspectRatio", maintain_aspect_ratio, "Resize the screen to the proportions set by aspect ratio option");
     outbool("Multithreading", multithreading, "Apply filters using multiple threads");
     outbool("BilinearFilter", Settings.BilinearFilter, "Smoothes scaled image");
@@ -299,6 +309,8 @@ int Snes9xConfig::save_config_file()
     outint("BlendGBFrames", Settings.GBFrameBlend, "Game Boy frame-blend mode (Super Game Boy only): 0=off, 1=Simple Blend (mix each frame 50/50 with the previous, fixes flicker-based fake transparency e.g. ZAS), 2=LCD Blend (slow-decay LCD-style ghosting)");
     outint("BlendGBFramesLayer", Settings.GBFrameBlendLayer, "Which Game Boy layer the frame-blend applies to: 0=all, 1=background (keeps moving sprites crisp), 2=window, 3=sprites");
     outbool("BlendGBFramesAuto", Settings.GBFrameBlendAuto, "Auto-pick the GB frame-blend per game from a built-in known-flicker-game table at load (off for unlisted games); when false the manual mode/layer apply to every GB game");
+    outbool("GBVideoCamera", Settings.GBVideoCamera, "Feed a connected webcam into the Game Boy Camera (Pocket Camera) cartridge's image sensor");
+    outint("GBVideoCameraIndex", Settings.GBVideoCameraIndex, "Index of the selected webcam in the device list (set via Display Settings > Game Boy Image)");
     outbool("ColorCorrection", Settings.ColorCorrection, "Enable accurate SNES color correction (simulates SNES CRT output)");
     outbool("AdjustmentsEnabled", Settings.AdjustmentsEnabled, "Apply the Gamma/Contrast/Saturation adjustments below");
     outint("Gamma", Settings.Gamma, "Gamma adjustment (-100..+100, 0 = no change)");
@@ -532,6 +544,8 @@ int Snes9xConfig::load_config_file()
     inint("SoftwareScaleFilterHires", hires_scale_method);
     inint("ScanlineFilterIntensity", scanline_filter_intensity);
     inbool("ShowOverscanArea", overscan);
+    inbool("BlendHiRes", blend_hires);
+    inbool("MessagesInImage", Settings.AutoDisplayMessages);
     inint("HiresEffect", hires_effect);
     inbool("ForceInvertedByteOrder", force_inverted_byte_order);
     inbool("Multithreading", multithreading);
@@ -545,6 +559,8 @@ int Snes9xConfig::load_config_file()
     inint("BlendGBFrames", Settings.GBFrameBlend);
     inint("BlendGBFramesLayer", Settings.GBFrameBlendLayer);
     inbool("BlendGBFramesAuto", Settings.GBFrameBlendAuto);
+    inbool("GBVideoCamera", Settings.GBVideoCamera);
+    inint("GBVideoCameraIndex", Settings.GBVideoCameraIndex);
     inbool("ColorCorrection", Settings.ColorCorrection);
     inbool("AdjustmentsEnabled", Settings.AdjustmentsEnabled);
     inint("Gamma", Settings.Gamma);

--- a/gtk/src/gtk_config.h
+++ b/gtk/src/gtk_config.h
@@ -65,6 +65,9 @@ class Snes9xConfig
     int scale_method;
     int hires_scale_method;
     bool overscan;
+    /* win32's "Blend Hi-Res Images": horizontally blend 512-wide hi-res frames
+       before the software filter. */
+    bool blend_hires;
     bool multithreading;
     int hires_effect;
     bool force_inverted_byte_order;

--- a/gtk/src/gtk_display.cpp
+++ b/gtk/src/gtk_display.cpp
@@ -363,6 +363,28 @@ static void S9xMergeHires(void *buffer, int pitch, int &width, int &height)
     width >>= 1;
 }
 
+/* In-place horizontal blend of a 512-wide frame that keeps its width: each
+   pixel becomes the average of itself and its left neighbour (win32's
+   RenderMergeHires behind "Blend Hi-Res Images"). */
+static void S9xBlendHires(void *buffer, int pitch, int width, int height)
+{
+    if (width < 512)
+        return;
+
+    for (int y = 0; y < height; y++)
+    {
+        uint16 *line = (uint16 *)((uint8 *)buffer + y * pitch);
+        uint16 left = 0;
+
+        for (int x = 0; x < width; x++)
+        {
+            uint16 right = line[x];
+            line[x] = average_565(left, right);
+            left = right;
+        }
+    }
+}
+
 void filter_2x(uint8 *src,
                int src_pitch,
                uint8 *dst,
@@ -882,6 +904,7 @@ bool8 S9xDeinitUpdate(int width, int height)
     if (!Settings.Paused && !NetPlay.Paused)
         S9xAVICaptureFrame(screen_view, GFX.Pitch, width, height);
 
+    const bool native_hires = (width == 512);
     if (!Settings.Paused && !NetPlay.Paused)
 
     {
@@ -901,6 +924,15 @@ bool8 S9xDeinitUpdate(int width, int height)
        second "Hi Res" box under Output Image Processing. */
     bool hires_frame = (width == 512 || height > SNES_HEIGHT_EXTENDED);
     active_filter = hires_frame ? gui_config->hires_scale_method : gui_config->scale_method;
+
+    /* "Blend Hi-Res Images": average each pixel of a 512-wide frame with its
+       left neighbour, keeping the width, so games that alternate columns for a
+       transparency effect blend them. Frames the game drew in low-res and
+       merged frames are left alone; so is Blargg's NTSC filter, which merges
+       the hi-res columns itself (win32's GetFilterBlendSupport). */
+    if (!Settings.Paused && !NetPlay.Paused && gui_config->blend_hires &&
+        native_hires && width == 512 && active_filter != FILTER_NTSC)
+        S9xBlendHires(screen_view, GFX.Pitch, width, height);
 
     if (active_filter > 0)
     {

--- a/gtk/src/gtk_display_driver_opengl.cpp
+++ b/gtk/src/gtk_display_driver_opengl.cpp
@@ -437,7 +437,7 @@ int S9xOpenGLDisplayDriver::init()
 
     context->swap_interval(config->sync_to_vblank);
 
-    if (version >= 33)
+    if (version >= 33 && !Settings.AutoDisplayMessages)
     {
         auto defaults = S9xImGuiGetDefaults();
         defaults.font_size = gui_config->osd_size;

--- a/gtk/src/gtk_display_driver_vulkan.cpp
+++ b/gtk/src/gtk_display_driver_vulkan.cpp
@@ -147,7 +147,8 @@ int S9xVulkanDisplayDriver::init()
     }
 
     device = context->device;
-    init_imgui();
+    if (!Settings.AutoDisplayMessages)
+        init_imgui();
 
     if (!gui_config->shader_filename.empty() && gui_config->use_shaders)
     {

--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -6,6 +6,7 @@
 
 #include "gtk_compat.h"
 #include "gtk_preferences.h"
+#include "common/video/gb_camera_v4l2.hpp"
 #include "gtk_config.h"
 #include "gtk_control.h"
 #include "gtk_sound.h"
@@ -175,6 +176,9 @@ void Snes9xPreferences::connect_signals()
     });
     get_object<Gtk::ComboBox>("gb_frame_blend")->signal_changed().connect([&] {
         update_gb_blend_enable_state();
+    });
+    get_object<Gtk::CheckButton>("gb_video_camera")->signal_toggled().connect([&] {
+        update_gb_camera_enable_state();
     });
     // Handle plurals on GtkLabel “threads_for_filtering_and_scaling_label”
     get_object<Gtk::SpinButton>("num_threads")->signal_value_changed().connect([&] {
@@ -382,16 +386,46 @@ void Snes9xPreferences::update_gb_blend_enable_state()
     // titles (or when nothing is loaded). With "Auto Layer Transparency" on, the two
     // dropdowns are list-driven so they are greyed too; the layer dropdown also needs
     // blending to be on (mode != Off). Mirrors the win32 and Qt frontends.
+    // The webcam controls further down the frame are not tied to the loaded
+    // game, so only the frame's title and the blend widgets are greyed.
     bool gb_active = Settings.SuperGameBoy || Settings.SGB_BIOSModeActive;
     bool manual = gb_active && !get_check("gb_frame_blend_auto");
     bool layer = manual && get_combo("gb_frame_blend") != 0;
 
-    enable_widget("gb_image_frame",             gb_active);
+    enable_widget("gb_image_label",             gb_active);
     enable_widget("gb_frame_blend_auto",        gb_active);
     enable_widget("gb_frame_blend",             manual);
     enable_widget("gb_frame_blend_label",       manual);
     enable_widget("gb_frame_blend_layer",       layer);
     enable_widget("gb_frame_blend_layer_label", layer);
+}
+
+void Snes9xPreferences::populate_gb_cameras()
+{
+    std::vector<std::string> names;
+    S9xGBCameraEnumerate(names);
+
+    auto combo = get_object<Gtk::ComboBox>("gb_camera_combo");
+    Glib::RefPtr<Gtk::ListStore>::cast_dynamic(combo->get_model())->clear();
+    for (auto &name : names)
+        combo_box_append(combo.get(), name.c_str());
+
+    // A remembered index past the end of the list falls back to the first
+    // camera, as on win32.
+    if (!names.empty())
+    {
+        int index = Settings.GBVideoCameraIndex;
+        if (index < 0 || index >= (int)names.size())
+            index = 0;
+        set_combo("gb_camera_combo", index);
+    }
+}
+
+void Snes9xPreferences::update_gb_camera_enable_state()
+{
+    auto combo = get_object<Gtk::ComboBox>("gb_camera_combo");
+    bool have_cameras = combo->get_model()->children().size() > 0;
+    enable_widget("gb_camera_combo", get_check("gb_video_camera") && have_cameras);
 }
 
 void Snes9xPreferences::about_dialog()
@@ -569,10 +603,16 @@ void Snes9xPreferences::move_settings_to_dialog()
     set_spin("osd_size",                   config->osd_size);
     set_check("change_display_resolution", config->change_display_resolution);
     set_check("scale_to_fit",              config->scale_to_fit);
+    set_check("transparency_effects",      Settings.Transparency);
+    set_check("blend_hires",               config->blend_hires);
     set_check("overscan",                  config->overscan);
+    set_check("messages_in_image",         Settings.AutoDisplayMessages);
     set_combo("gb_frame_blend",            Settings.GBFrameBlend);
     set_combo("gb_frame_blend_layer",      Settings.GBFrameBlendLayer);
     set_check("gb_frame_blend_auto",       Settings.GBFrameBlendAuto);
+    populate_gb_cameras();
+    set_check("gb_video_camera",           Settings.GBVideoCamera);
+    update_gb_camera_enable_state();
     set_check("multithreading",            config->multithreading);
     enable_widget("num_threads", get_check("multithreading"));
     set_label("threads_for_filtering_and_scaling_label",
@@ -775,6 +815,9 @@ void Snes9xPreferences::get_settings_from_dialog()
     if (config->osd_size != get_spin("osd_size"))
         gfx_needs_restart = true;
 
+    if ((bool)Settings.AutoDisplayMessages != get_check("messages_in_image"))
+        gfx_needs_restart = true;
+
 
     config->enable_icons = get_check("force_enable_icons");
     auto settings = Gtk::Settings::get_default();
@@ -788,7 +831,10 @@ void Snes9xPreferences::get_settings_from_dialog()
     Settings.DisplayIndicators        = get_check("show_indicators");
     config->osd_size                  = get_spin("osd_size");
     config->scale_to_fit              = get_check("scale_to_fit");
+    Settings.Transparency             = get_check("transparency_effects");
+    config->blend_hires               = get_check("blend_hires");
     config->overscan                  = get_check("overscan");
+    Settings.AutoDisplayMessages      = get_check("messages_in_image");
     // Game Boy frame-blend. Settings.GBFrameBlend* is the single stored value (saved
     // straight to the config file), exactly like win32. When "Auto Layer Transparency"
     // is on, the per-title table in sgb.cpp picks the mode/layer and overwrites it in
@@ -802,6 +848,11 @@ void Snes9xPreferences::get_settings_from_dialog()
         set_combo("gb_frame_blend",       Settings.GBFrameBlend);
         set_combo("gb_frame_blend_layer", Settings.GBFrameBlendLayer);
     }
+    // Game Boy Camera webcam feed: (re)start or stop the capture to match.
+    Settings.GBVideoCamera            = get_check("gb_video_camera");
+    if (get_combo("gb_camera_combo") >= 0)
+        Settings.GBVideoCameraIndex   = get_combo("gb_camera_combo");
+    S9xGBCameraApply();
     config->maintain_aspect_ratio     = get_check("maintain_aspect_ratio");
     config->aspect_ratio              = get_combo("aspect_ratio");
     config->scale_method              = get_combo("scale_method_combo");

--- a/gtk/src/gtk_preferences.h
+++ b/gtk/src/gtk_preferences.h
@@ -32,6 +32,8 @@ class Snes9xPreferences final : public GtkBuilderWindow
     void input_rate_changed();
     void update_sgb_volume_enable_state();
     void update_gb_blend_enable_state();
+    void populate_gb_cameras();
+    void update_gb_camera_enable_state();
     bool key_pressed(GdkEventKey *event);
     void shader_select();
     void game_data_browse(const std::string &folder);

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -16,6 +16,7 @@
 #include "gtk_display.h"
 #include "gtk_netplay.h"
 #include "gtk_retroachievements.h"
+#include "common/video/gb_camera_v4l2.hpp"
 #include "retroachievements.h"
 #include "statemanager.h"
 #include "background_particles.h"
@@ -99,6 +100,11 @@ int main(int argc, char *argv[])
     S9xInitDisplay(argc, argv);
 
     S9xPortSoundInit();
+
+    // Game Boy Camera webcam feed, started here when the config says so and
+    // re-applied from the preferences dialog.
+    S9xGBCameraRegister();
+    S9xGBCameraApply();
 
     S9xApplyControllerOption();
     S9xReportControllers();
@@ -685,6 +691,7 @@ static void check_pointer_timer()
 void S9xExit()
 {
     S9xAVIStop();
+    S9xGBCameraStop();
     S9xCloseAudioWaveformWindow();
 
     gui_config->save_config_file();

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1048,6 +1048,12 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="liststore_gb_camera">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkListStore" id="liststore_gb_blend_layer">
     <columns>
       <!-- column-name item -->
@@ -3300,14 +3306,142 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkCheckButton" id="overscan">
-                                <property name="label" translatable="yes">Use overscanned height</property>
+                              <object class="GtkFrame" id="snes_image_frame">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Use SNES extended height. Will probably cause letterboxing</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0</property>
+                                <property name="shadow_type">none</property>
+                                <child>
+                                  <object class="GtkAlignment" id="snes_image_alignment">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
+                                    <child>
+                                      <object class="GtkVBox" id="snes_image_vbox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="border_width">5</property>
+                                        <property name="spacing">5</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="transparency_effects">
+                                            <property name="label" translatable="yes">Transparency Effects</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Render the SNES colour‑math and transparency effects. Turn off only for troubleshooting.</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="blend_hires">
+                                            <property name="label" translatable="yes">Blend Hi‑Res Images</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Horizontally blend hi‑res (512‑wide) images, so games that alternate columns for a transparency effect look as intended with filters that do not account for this.</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="overscan">
+                                            <property name="label" translatable="yes">Extend Height of SNES Image</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Display an extra 15 pixels at the bottom, which few games use. Also increases AVI output size from 256x224 to 256x240.</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="messages_in_image">
+                                            <property name="label" translatable="yes">Display messages inside SNES image</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Draw text inside the SNES image with a pixel font instead of the on‑screen overlay (it will get into AVIs, screenshots, and filters). The only way to see messages with the XVideo and software drivers.</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkHBox" id="osd_box">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="spacing">12</property>
+                                            <child>
+                                              <object class="GtkLabel" id="osdlabel">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">On‑screen display size:</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="osd_size">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="tooltip_text" translatable="yes">The size of on‑screen display messages in pixels</property>
+                                                <property name="primary_icon_activatable">False</property>
+                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="primary_icon_sensitive">True</property>
+                                                <property name="secondary_icon_sensitive">True</property>
+                                                <property name="adjustment">osd_size_adjustment</property>
+                                                <property name="snap_to_ticks">True</property>
+                                                <property name="width_chars">6</property>
+                                                <property name="numeric">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">4</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="snes_image_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">&lt;b&gt;SNES Image&lt;/b&gt;</property>
+                                    <property name="use_markup">True</property>
+                                  </object>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -3435,6 +3569,53 @@
                                             <property name="position">2</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="gb_video_camera">
+                                            <property name="label" translatable="yes">Enable Video Camera</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Feed a connected USB webcam into the Game Boy Camera (Pocket Camera) cartridge's image sensor. With this off (or no camera connected) the in‑game viewfinder is blank.</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkHBox" id="gb_camera_box">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="spacing">12</property>
+                                            <child>
+                                              <object class="GtkComboBox" id="gb_camera_combo">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="model">liststore_gb_camera</property>
+                                                <property name="tooltip_text" translatable="yes">The webcam to feed into the Game Boy Camera. Cameras that only offer compressed (MJPEG) video produce a blank image.</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="gb_camera_renderer"/>
+                                                  <attributes>
+                                                    <attribute name="text">0</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">4</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -3454,51 +3635,6 @@
                                 <property name="position">6</property>
                               </packing>
                             </child>
-
-                            <child>
-                              <object class="GtkHBox" id="osd_box">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="spacing">12</property>
-
-                                <child>
-                                  <object class="GtkLabel" id="osdlabel">
-                                    <property name="visible">True</property>
-                                   <property name="can_focus">False</property>
-                                   <property name="label" translatable="yes">On‑screen display size:</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="osd_size">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">The size of on‑screen display messages in pixels</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
-                                    <property name="adjustment">osd_size_adjustment</property>
-                                    <property name="snap_to_ticks">True</property>
-                                    <property name="width_chars">6</property>
-                                    <property name="numeric">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">7</property>
-                              </packing>
-                            </child>
-
 
                             <child>
                               <object class="GtkHBox" id="resolution_box">
@@ -3543,7 +3679,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
 

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -323,6 +323,8 @@ list(APPEND QT_GUI_SOURCES
     ../common/recording/avi_writer.hpp
     ../common/recording/avi_recorder.cpp
     ../common/recording/avi_recorder.hpp
+    ../common/video/gb_camera_v4l2.cpp
+    ../common/video/gb_camera_v4l2.hpp
     ../common/audio/audio_waveform.cpp
     ../common/audio/audio_waveform.hpp
     src/SoftwareScalers.cpp

--- a/qt/src/DisplayPanel.cpp
+++ b/qt/src/DisplayPanel.cpp
@@ -2,6 +2,7 @@
 #include "EmuMainWindow.hpp"
 #include "EmuConfig.hpp"
 #include "SoftwareFilters.hpp"
+#include "common/video/gb_camera_v4l2.hpp"
 #include <QFileDialog>
 
 #include "snes9x.h"
@@ -72,6 +73,16 @@ DisplayPanel::DisplayPanel(EmuApplication *app_)
 
     connect(checkBox_overscan, &QCheckBox::clicked, [&](bool checked) {
         app->config->show_overscan = checked;
+        app->updateSettings();
+    });
+
+    connect(checkBox_transparency, &QCheckBox::clicked, [&](bool checked) {
+        app->config->transparency_effects = checked;
+        app->updateSettings();
+    });
+
+    connect(checkBox_blend_hires, &QCheckBox::clicked, [&](bool checked) {
+        app->config->blend_hires = checked;
         app->updateSettings();
     });
 
@@ -151,20 +162,66 @@ DisplayPanel::DisplayPanel(EmuApplication *app_)
         app->config->gb_frame_blend_layer = index;
         app->updateSettings();
     });
+
+    // Game Boy Camera webcam feed. Unlike the blend options this is not tied to
+    // the loaded game: applying the settings (re)starts or stops the capture.
+    comboBox_gb_camera->setPlaceholderText(tr("No video camera found"));
+
+    connect(checkBox_gb_video_camera, &QCheckBox::clicked, [&](bool checked) {
+        app->config->gb_video_camera = checked;
+        updateGBCameraEnabledState();
+        app->updateSettings();
+    });
+
+    connect(comboBox_gb_camera, &QComboBox::activated, [&](int index) {
+        app->config->gb_video_camera_index = index;
+        app->updateSettings();
+    });
+}
+
+void DisplayPanel::populateCameras()
+{
+    std::vector<std::string> names;
+    S9xGBCameraEnumerate(names);
+
+    comboBox_gb_camera->clear();
+    for (auto &name : names)
+        comboBox_gb_camera->addItem(QString::fromStdString(name));
+
+    // A remembered index past the end of the list falls back to the first
+    // camera, as on win32.
+    auto &index = app->config->gb_video_camera_index;
+    if (names.empty())
+        comboBox_gb_camera->setCurrentIndex(-1);
+    else
+    {
+        if (index < 0 || index >= (int)names.size())
+            index = 0;
+        comboBox_gb_camera->setCurrentIndex(index);
+    }
+}
+
+void DisplayPanel::updateGBCameraEnabledState()
+{
+    comboBox_gb_camera->setEnabled(checkBox_gb_video_camera->isChecked() &&
+                                   comboBox_gb_camera->count() > 0);
 }
 
 void DisplayPanel::updateGBBlendEnabledState()
 {
-    // The Game Boy Image options only apply to a Game Boy / GBC / SGB game — grey
+    // The frame-blend options only apply to a Game Boy / GBC / SGB game — grey
     // them out for SNES titles (or when nothing is loaded). With Auto on, the two
     // dropdowns are list-driven so they're greyed too; the layer one also needs
-    // blending to be on (mode != Off).
+    // blending to be on (mode != Off). The webcam controls further down the
+    // group stay available regardless, as on win32.
     bool gb_active = (Settings.SuperGameBoy || Settings.SGB_BIOSModeActive);
     bool manual = gb_active && !app->config->gb_frame_blend_auto;
-    groupBox_gb_image->setEnabled(gb_active);
+    bool layer = manual && app->config->gb_frame_blend != EmuConfig::eGBBlendOff;
     checkBox_gb_frame_blend_auto->setEnabled(gb_active);
+    label_gb_frame_blend->setEnabled(manual);
     comboBox_gb_frame_blend->setEnabled(manual);
-    comboBox_gb_frame_blend_layer->setEnabled(manual && app->config->gb_frame_blend != EmuConfig::eGBBlendOff);
+    label_gb_frame_blend_layer->setEnabled(layer);
+    comboBox_gb_frame_blend_layer->setEnabled(layer);
 }
 
 void DisplayPanel::selectShaderDialog()
@@ -233,6 +290,8 @@ void DisplayPanel::showEvent(QShowEvent *event)
     checkBox_maintain_aspect_ratio->setChecked(config->maintain_aspect_ratio);
     checkBox_integer_scaling->setChecked(config->use_integer_scaling);
     checkBox_overscan->setChecked(config->show_overscan);
+    checkBox_transparency->setChecked(config->transparency_effects);
+    checkBox_blend_hires->setChecked(config->blend_hires);
 
     if (config->aspect_ratio_numerator == 4)
         comboBox_aspect_ratio->setCurrentIndex(0);
@@ -263,6 +322,10 @@ void DisplayPanel::showEvent(QShowEvent *event)
     comboBox_gb_frame_blend->setCurrentIndex(config->gb_frame_blend);
     comboBox_gb_frame_blend_layer->setCurrentIndex(config->gb_frame_blend_layer);
     updateGBBlendEnabledState();
+
+    populateCameras();
+    checkBox_gb_video_camera->setChecked(config->gb_video_camera);
+    updateGBCameraEnabledState();
 
     QWidget::showEvent(event);
 }

--- a/qt/src/DisplayPanel.hpp
+++ b/qt/src/DisplayPanel.hpp
@@ -12,6 +12,8 @@ class DisplayPanel :
     void populateDevices();
     void selectShaderDialog();
     void updateGBBlendEnabledState();
+    void populateCameras();
+    void updateGBCameraEnabledState();
 
     std::vector<std::pair<int, std::string>> driver_list;
     bool updating = true;

--- a/qt/src/DisplayPanel.ui
+++ b/qt/src/DisplayPanel.ui
@@ -186,19 +186,6 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="checkBox_overscan">
-          <property name="toolTip">
-           <string>Show the areas on the top and bottom of the screen that are normally black and hidden by the TV. Some games will draw in these areas.</string>
-          </property>
-          <property name="whatsThis">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On classic CRT televisions, some areas of the screen were covered by the bezel, so weren't used often in games. This option allows you to show that area, but it will usually be just black bars.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Show overscan area</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <widget class="QCheckBox" name="checkBox_integer_scaling">
           <property name="toolTip">
@@ -373,11 +360,48 @@ Output directly will cause the screen to change between the two modes and look w
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_4">
+    <widget class="QGroupBox" name="groupBox_snes_image">
      <property name="title">
-      <string>Messages</string>
+      <string>SNES Image</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_snes_image">
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="checkBox_transparency">
+          <property name="toolTip">
+           <string>Render the SNES colour-math and transparency effects. Turn off only for troubleshooting.</string>
+          </property>
+          <property name="text">
+           <string>Transparency Effects</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="checkBox_blend_hires">
+          <property name="toolTip">
+           <string>Horizontally blend hi-res (512-wide) images, so games that alternate columns for a transparency effect look as intended with filters that do not account for this.</string>
+          </property>
+          <property name="text">
+           <string>Blend Hi-Res Images</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="checkBox_overscan">
+          <property name="toolTip">
+           <string>Display an extra 15 pixels at the bottom, which few games use. Also increases AVI output size from 256x224 to 256x240.</string>
+          </property>
+          <property name="whatsThis">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On classic CRT televisions, some areas of the screen were covered by the bezel, so weren't used often in games. This option allows you to show that area, but it will usually be just black bars.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Extend Height of SNES Image</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item>
        <layout class="QGridLayout" name="gridLayout_5">
         <item row="0" column="0">
@@ -566,6 +590,52 @@ Output directly will cause the screen to change between the two modes and look w
         </item>
         <item row="0" column="2">
          <spacer name="horizontalSpacer_gb_blend">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox_gb_video_camera">
+        <property name="toolTip">
+         <string>Feed a connected webcam into the Game Boy Camera (Pocket Camera) cartridge's image sensor. With this off (or no camera connected) the in-game viewfinder is blank.</string>
+        </property>
+        <property name="text">
+         <string>Enable Video Camera</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_gb_camera">
+        <item>
+         <widget class="QComboBox" name="comboBox_gb_camera">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>240</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>The webcam to feed into the Game Boy Camera. Cameras that only offer compressed (MJPEG) video produce a blank image.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_gb_camera">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>

--- a/qt/src/EmuConfig.cpp
+++ b/qt/src/EmuConfig.cpp
@@ -284,6 +284,8 @@ bool EmuConfig::setDefaults(int section)
         aspect_ratio_numerator = 4;
         aspect_ratio_denominator = 3;
         show_overscan = false;
+        transparency_effects = true;
+        blend_hires = true;
         high_resolution_effect = eLeaveAlone;
 
         software_filter = {};
@@ -295,6 +297,8 @@ bool EmuConfig::setDefaults(int section)
         gb_frame_blend = eGBBlendOff;
         gb_frame_blend_layer = eGBBlendLayerAll;
         gb_frame_blend_auto = true;
+        gb_video_camera = false;
+        gb_video_camera_index = 0;
 
         color_correction = false;
         color_adjustments_enabled = false;
@@ -558,6 +562,8 @@ void EmuConfig::config(const std::string &filename, bool write)
     Int("AspectRatioNumerator", aspect_ratio_numerator, "Aspect-ratio width term (e.g. 4 in 4:3)");
     Int("AspectRatioDenominator", aspect_ratio_denominator, "Aspect-ratio height term (e.g. 3 in 4:3)");
     Bool("ShowOverscan", show_overscan, "Show the overscan area at the top and bottom that most games hide");
+    Bool("Transparency", transparency_effects, "Render the SNES colour-math/transparency effects (turn off only for troubleshooting)");
+    Bool("BlendHiRes", blend_hires, "Horizontally blend hi-res (512-wide) frames so games that alternate columns for a transparency effect look as intended with filters that do not account for this");
     Enum("HighResolutionEffect", high_resolution_effect, { "LeaveAlone", "ScaleDown", "ScaleUp" }, "How to handle hi-res (512-wide) frames: LeaveAlone, ScaleDown, or ScaleUp");
 
     String("SoftwareFilter", software_filter, "Software scaling filter name, e.g. \"HQ2x\" or \"Blargg's NTSC (Composite)\"; empty means none");
@@ -571,6 +577,8 @@ void EmuConfig::config(const std::string &filename, bool write)
     Enum("BlendGBFrames", gb_frame_blend, { "Off", "SimpleBlend", "LCDBlend" }, "Game Boy frame-blend (Super Game Boy only): Off, SimpleBlend (fixes flicker fake-transparency), or LCDBlend (LCD-style ghosting)");
     Enum("BlendGBFramesLayer", gb_frame_blend_layer, { "All", "Background", "Window", "Sprites" }, "Which Game Boy layer the frame-blend applies to: All, Background, Window, or Sprites");
     Bool("BlendGBFramesAuto", gb_frame_blend_auto, "Auto-pick the GB frame-blend per game from a built-in known-flicker table");
+    Bool("GBVideoCamera", gb_video_camera, "Feed a connected webcam into the Game Boy Camera (Pocket Camera) cartridge's image sensor");
+    Int("GBVideoCameraIndex", gb_video_camera_index, "Index of the selected webcam in the device list under Display > Game Boy Image");
 
     Bool("ColorCorrection", color_correction, "Enable accurate SNES color correction (simulates SNES CRT output)");
     Bool("AdjustmentsEnabled", color_adjustments_enabled, "Apply the gamma/contrast/saturation adjustments below");

--- a/qt/src/EmuConfig.hpp
+++ b/qt/src/EmuConfig.hpp
@@ -76,6 +76,11 @@ struct EmuConfig
     int aspect_ratio_numerator;
     int aspect_ratio_denominator;
     bool show_overscan;
+    // The rest of win32's "SNES Image" box: the core's colour-math/transparency
+    // effects (Settings.Transparency) and a horizontal blend of 512-wide hi-res
+    // frames before the software filter ("Blend Hi-Res Images").
+    bool transparency_effects;
+    bool blend_hires;
     enum HighResolutionEffect
     {
         eLeaveAlone = 0,
@@ -118,6 +123,10 @@ struct EmuConfig
     };
     int gb_frame_blend_layer;
     bool gb_frame_blend_auto;
+    // Feed a webcam into the Game Boy Camera cartridge (win32 "Enable Video
+    // Camera"); the index is the device's position in the enumerated list.
+    bool gb_video_camera;
+    int gb_video_camera_index;
 
     bool color_correction;
     bool color_adjustments_enabled;

--- a/qt/src/Snes9xController.cpp
+++ b/qt/src/Snes9xController.cpp
@@ -22,6 +22,7 @@ namespace fs = std::filesystem;
 #include "cheats.h"
 #include "movie.h"
 #include "common/recording/avi_recorder.hpp"
+#include "common/video/gb_camera_v4l2.hpp"
 
 #ifdef KAILLERA_SUPPORT
 #include "kaillera_client.h"
@@ -119,11 +120,16 @@ void Snes9xController::init()
     S9xUnmapAllControls();
     S9xCheatsEnable();
 
+    // Game Boy Camera webcam feed; the capture itself is started by
+    // updateSettings() once the config says so.
+    S9xGBCameraRegister();
+
     active = false;
 }
 
 void Snes9xController::deinit()
 {
+    S9xGBCameraStop();
     if (active)
         S9xAutoSaveSRAM();
     S9xGraphicsDeinit();
@@ -258,6 +264,8 @@ void Snes9xController::updateSettings(EmuConfig *config)
     Settings.TwoClockCycles = overclock_cycles[config->overclock][0] * 2;
 
     Settings.ShowOverscan = config->show_overscan;
+    Settings.Transparency = config->transparency_effects;
+    blend_hires = config->blend_hires;
 
     // Game Boy frame-blend (Super Game Boy). Push the stored mode/layer first, then,
     // when "Auto Layer Transparency" is on, let the per-title table in sgb.cpp pick
@@ -274,6 +282,11 @@ void Snes9xController::updateSettings(EmuConfig *config)
         config->gb_frame_blend       = Settings.GBFrameBlend;
         config->gb_frame_blend_layer = Settings.GBFrameBlendLayer;
     }
+
+    // Game Boy Camera webcam feed: (re)start or stop the capture to match.
+    Settings.GBVideoCamera = config->gb_video_camera;
+    Settings.GBVideoCameraIndex = (uint8)std::clamp(config->gb_video_camera_index, 0, 255);
+    S9xGBCameraApply();
 
     high_resolution_effect = config->high_resolution_effect;
     software_filter = S9xSoftwareFilterFromName(config->software_filter);
@@ -538,7 +551,9 @@ bool8 S9xDeinitUpdate(int width, int height)
     if (!Settings.Paused)
         S9xAVICaptureFrame(screen_view, GFX.Pitch, width, height);
 
-    auto hires_effect = Snes9xController::get()->high_resolution_effect;
+    auto controller = Snes9xController::get();
+    auto hires_effect = controller->high_resolution_effect;
+    const bool native_hires = (width == 512);
     if (!Settings.Paused)
     {
         if (hires_effect == EmuConfig::eScaleUp)
@@ -556,8 +571,18 @@ bool8 S9xDeinitUpdate(int width, int height)
     // Hi-res frames get their own filter selection, like the win32 port's
     // second "Hi Res" box under Output Image Processing.
     bool hires_frame = (width == 512 || height > SNES_HEIGHT_EXTENDED);
-    int filter = hires_frame ? Snes9xController::get()->software_filter_hires
-                             : Snes9xController::get()->software_filter;
+    int filter = hires_frame ? controller->software_filter_hires
+                             : controller->software_filter;
+
+    // "Blend Hi-Res Images": average each pixel of a 512-wide frame with its
+    // left neighbour, keeping the width, so games that alternate columns for
+    // a transparency effect blend them (win32's BlendHiRes). Frames the game
+    // drew in low-res and merged frames are left alone, as is a filter that
+    // consumes the hi-res columns itself.
+    if (!Settings.Paused && controller->blend_hires && native_hires && width == 512 &&
+        !S9xSoftwareFilterBlendsHires(filter))
+        S9xBlendHires(screen_view, GFX.Pitch, width, height);
+
     if (filter != 0)
     {
         // The filters can only grow the image, so the scratch buffer sized for

--- a/qt/src/Snes9xController.hpp
+++ b/qt/src/Snes9xController.hpp
@@ -84,6 +84,7 @@ class Snes9xController
     std::string bios_folder;
     int16_t mouse_x, mouse_y;
     int high_resolution_effect;
+    bool blend_hires = true;
     int software_filter = 0;
     int software_filter_hires = 0;
     int rewind_buffer_size;

--- a/qt/src/SoftwareFilters.cpp
+++ b/qt/src/SoftwareFilters.cpp
@@ -237,3 +237,8 @@ void S9xApplySoftwareFilter(int filter,
     else
         filter_table[filter].func(src, src_pitch, dst, dst_pitch, width, height);
 }
+
+bool S9xSoftwareFilterBlendsHires(int filter)
+{
+    return filter >= FILTER_NTSC_COMPOSITE && filter <= FILTER_NTSC_MONOCHROME;
+}

--- a/qt/src/SoftwareFilters.hpp
+++ b/qt/src/SoftwareFilters.hpp
@@ -10,3 +10,7 @@ void S9xApplySoftwareFilter(int filter,
                             uint8_t *src, int src_pitch,
                             uint8_t *dst, int dst_pitch,
                             int width, int height);
+/* Whether the filter takes 512-wide hi-res lines as-is and merges the column
+ * pairs itself, so the "Blend Hi-Res Images" pass must stay out of its way
+ * (win32's GetFilterBlendSupport). */
+bool S9xSoftwareFilterBlendsHires(int filter);

--- a/qt/src/SoftwareScalers.cpp
+++ b/qt/src/SoftwareScalers.cpp
@@ -41,3 +41,22 @@ void S9xMergeHires(void *buffer, int pitch, int &width, int &height)
 
     width >>= 1;
 }
+
+void S9xBlendHires(void *buffer, int pitch, int width, int height)
+{
+    if (width < 512)
+        return;
+
+    for (int y = 0; y < height; y++)
+    {
+        uint16_t *line = (uint16_t *)((uint8_t *)buffer + y * pitch);
+        uint16_t left = 0;
+
+        for (int x = 0; x < width; x++)
+        {
+            uint16_t right = line[x];
+            line[x] = average_565(left, right);
+            left = right;
+        }
+    }
+}

--- a/qt/src/SoftwareScalers.hpp
+++ b/qt/src/SoftwareScalers.hpp
@@ -2,3 +2,7 @@
 
 void S9xForceHires(void *buffer, int pitch, int &width, int &height);
 void S9xMergeHires(void *buffer, int pitch, int &width, int &height);
+/* In-place horizontal blend of a 512-wide frame that keeps its width: each
+ * pixel becomes the average of itself and its left neighbour (win32's
+ * RenderMergeHires). */
+void S9xBlendHires(void *buffer, int pitch, int width, int height);


### PR DESCRIPTION
## Summary

Display Settings on Linux now carries the same two boxes as the win32 dialog.

**SNES Image**
- Transparency Effects (`Settings.Transparency`)
- Blend Hi-Res Images: averages each pixel of a 512-wide frame with its left neighbour before the hi-res software filter, bit-identical to win32's `RenderMergeHires`. Skipped for Blargg's NTSC filter (merges the columns itself) and for frames the game drew in low-res or that were already merged.
- Extend Height of SNES Image (the existing overscan toggle, moved in and relabeled)
- Messages and on-screen display size. GTK gains a "Display messages inside SNES image" box (`Settings.AutoDisplayMessages`) and, like win32, skips the ImGui overlay while messages are drawn into the image. Qt keeps its existing Onscreen / Inside the screen / None combo, which already covers it.

**Game Boy Image**
- The frame-blend controls stay, joined by "Enable Video Camera" and a camera list.
- New `common/video/gb_camera_v4l2.{hpp,cpp}` mirrors `win32/win32_webcam.{h,cpp}`: a Video4Linux2 capture thread streams a small raw mode (YUYV, UYVY, GREY, NV12/YUV420, RGB24/32, RGB565) and the core's 128x112 callback resamples and mirrors it the same way as win32. Cameras that only offer MJPEG show a blank viewfinder; non-Linux builds get stubs.
- Only the blend widgets are greyed for SNES titles now, so the camera controls stay usable as on win32.

Config keys match `wconfig.cpp`: `Transparency`, `BlendHiRes`, `GBVideoCamera`, `GBVideoCameraIndex`, and `MessagesInImage` on GTK.

## Testing

- Qt and GTK both build clean (`ninja` / `ninja snes9x-gtk`).
- Both binaries start, run and exit cleanly with a throwaway config directory and persist the new keys.
- Qt panel rendered offscreen and GTK page previewed in a nested X server; both match the win32 grouping.
- `S9xBlendHires` checked bit-for-bit against win32's `RenderMergeHires` on random 512x448 frames.
- Camera bridge covered by a harness over the pixel conversion, resampling, enumeration and start/stop paths.
- Not yet tested with a real webcam and a Game Boy Camera ROM (no camera on the dev machine).
